### PR TITLE
Use Dependabot to check for outdated action versions used in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"
+    assignees:
+      - per1234
+
+  # Configure check for outdated GitHub Actions actions in workflow templates.
+  - package-ecosystem: github-actions
+    # The workflows under the .github/workflows/ subfolder of this path will be checked.
+    directory: /workflow-templates/dependabot/workflow-template-copies/
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: (DO NOT MERGE)
+    labels:
+      - "topic: infrastructure"
+    assignees:
+      - per1234

--- a/.github/workflows/check-sync.yml
+++ b/.github/workflows/check-sync.yml
@@ -1,0 +1,31 @@
+# This repository contains intentionally duplicated copies of files:
+# - Workflow template copies under workflow-templates/dependabot/workflow-template-copies used for Dependabot checks.
+# - Workflow template copies in .github/workflows used for this repository's own CI system.
+# - Assets for the workflow templates used in this repository.
+#
+# This workflow checks that the copies are in sync.
+# If the workflow fails, run workflow-templates/etc/sync.sh and commit.
+
+name: Check File Duplicates Sync
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Check file duplicates sync
+        run: |
+          SYNC_SCRIPT_PATH="etc/sync.sh"
+          "${{ github.workspace }}/$SYNC_SCRIPT_PATH"
+          git add .
+          if ! git diff --color --exit-code HEAD; then
+            echo "::error::File duplicates are out of sync. Please run $SYNC_SCRIPT_PATH"
+            exit 1
+          fi

--- a/etc/sync.sh
+++ b/etc/sync.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Sync the repository's intentionally duplicated files.
+
+readonly REPOSITORY_ROOT_PATH="$(git rev-parse --show-toplevel)"
+readonly WORKFLOW_TEMPLATE_ASSETS_PATH="${REPOSITORY_ROOT_PATH}/workflow-templates/assets"
+readonly WORKFLOW_TEMPLATES_PATH="${REPOSITORY_ROOT_PATH}/workflow-templates"
+readonly WORKFLOWS_PATH="${REPOSITORY_ROOT_PATH}/.github/workflows"
+readonly WORKFLOW_TEMPLATE_COPIES_PATH="${REPOSITORY_ROOT_PATH}/workflow-templates/dependabot/workflow-template-copies/.github/workflows"
+
+# Sync workflow templates with the copies in the folder where Dependabot can check them for updates.
+mkdir --parents "$WORKFLOW_TEMPLATE_COPIES_PATH"
+rm --force "${WORKFLOW_TEMPLATE_COPIES_PATH}/"*
+find "$WORKFLOW_TEMPLATES_PATH" -maxdepth 1 -type f -and \( -name '*.yml' -or -name '*.yaml' \) -exec cp '{}' "$WORKFLOW_TEMPLATE_COPIES_PATH" \;

--- a/workflow-templates/assets/dependabot/README.md
+++ b/workflow-templates/assets/dependabot/README.md
@@ -1,0 +1,46 @@
+# Dependabot for GitHub Actions
+
+Dependabot can be used to check for outdated action versions used in the repository's GitHub Actions workflows:
+
+https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+
+## Instructions
+
+Just copy [this `dependabot.yml` file](dependabot.yml) to the `.github/` folder of the target repository (or add the entry if the repository already has a `/.github/dependabot.yml`) and everything else is handled automatically.
+
+### Note
+
+Dependabot's PRs will occasionally propose to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump.
+
+So even when the PRs from Dependabot are not exactly correct, they still have value in bringing the maintainer's attention to the fact that the action version in use is outdated. The effort needed to manually adjust the ref when this happens is trivial.
+
+Dependabot will automatically close its PR once the workflow has been updated.
+
+## Commit message
+
+```
+Configure Dependabot to check for outdated actions used in workflows
+
+Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to
+be outdated, it will submit a pull request to update them.
+
+NOTE: Dependabot's PRs will occasionally propose to pin to the patch version of the action (e.g., updating
+`uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has provided a major version ref, use that instead
+(e.g., `uses: foo/bar@v2`). Dependabot will automatically close its PR once the workflow has been updated.
+
+More information:
+https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+```
+
+## PR message
+
+```Markdown
+Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.
+
+NOTE: Dependabot's PRs will occasionally propose to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump.
+
+So even when the PRs from Dependabot are not exactly correct, they still have value in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.
+
+More information:
+https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+```

--- a/workflow-templates/assets/dependabot/dependabot.yml
+++ b/workflow-templates/assets/dependabot/dependabot.yml
@@ -1,0 +1,13 @@
+# See: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
+  # See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"


### PR DESCRIPTION
Dependabot will periodically check the GitHub Actions workflows and workflow templates of the repository and submit pull
requests to update any that are found to be using an outdated version of an action.

This check has previously been a manual process, and a frequently neglected one. Up to date action versions are
especially important in the workflow templates, since they are the source for the CI systems of many repositories.

Typically, the best approach is to only pin the major version of the action (e.g., `uses: foo/bar@v1`), so the workflow
will automatically use the latest version of the action except when there have been breaking changes. Many actions
provide major version refs for this purpose.

NOTE: Dependabot's PRs will occasionally try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1`
to `uses: foo/bar@v2.3.4`). When the action author has provided a major version ref, use that instead
(e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an
update PR again until the next major version bump. So even if the PRs from Dependabot are not always exactly correct,
their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated.
Dependabot will automatically close its PR once the workflow has been updated.

In the case of PRs from Dependabot for updates to the workflow template copies, these serve solely as update
notifications Dependabot has been configured to prefix the PR message with "(DO NOT MERGE)" to make this clear.

I have configured Dependabot to assign me to these pull requests and will take responsibility for reviewing and testing
them.

---
In addition to setting up Dependabot for this repository, I have also provided a template Dependabot configuration file
and documentation to make it easy to setting this up in other repositories where the maintainers have determined it would
be useful.