### PR TITLE
Add template workflow to check general file formatting

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,0 +1,3 @@
+{
+  "Exclude": ["LICENSE.txt"]
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,57 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/assets/shared/.editorconfig
+# See: https://editorconfig.org/
+# The formatting style defined in this file is the official standardized style to be used in all Arduino Tooling
+# projects and should not be modified.
+# Note: indent style for each file type is defined even when it matches the universal config in order to make it clear
+# that this type has an official style.
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{adoc,asc,asciidoc}]
+indent_size = 2
+indent_style = space
+
+[*.{bash,sh}]
+indent_size = 2
+indent_style = space
+
+[*.{c,cc,cp,cpp,cxx,h,hh,hpp,hxx,ii,inl,ino,ixx,pde,tpl,tpp,txx}]
+indent_size = 2
+indent_style = space
+
+[*.go]
+indent_style = tab
+
+[*.java]
+indent_size = 2
+indent_style = space
+
+[*.{js,jsx,json,jsonc,json5,ts,tsx}]
+indent_size = 2
+indent_style = space
+
+[*.{md,mdx,mkdn,mdown,markdown}]
+indent_size = unset
+indent_style = space
+
+[*.proto]
+indent_size = 2
+indent_style = space
+
+[*.py]
+indent_size = 4
+indent_style = space
+
+[*.svg]
+indent_size = 2
+indent_style = space
+
+[*.{yaml,yml}]
+indent_size = 2
+indent_style = space

--- a/.github/workflows/check-ci-sync.yml
+++ b/.github/workflows/check-ci-sync.yml
@@ -1,0 +1,47 @@
+# This repository contains intentionally duplicated copies of template workflows under .github/workflows used for this
+# repository's own CI system.
+#
+# This workflow checks that the copies are in sync.
+# If the workflow fails, run `task fix` and commit.
+
+name: Check CI Workflows Sync
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
+      - "workflow-templates/*.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
+      - "workflow-templates/*.ya?ml"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Sync files
+        run: task --silent ci:sync
+
+      - name: Check file duplicates sync
+        run: |
+          git add .
+          if ! git diff --color --exit-code HEAD; then
+            echo "::error::File duplicates are out of sync. Please run \"task fix\""
+            exit 1
+          fi

--- a/.github/workflows/check-config-sync.yml
+++ b/.github/workflows/check-config-sync.yml
@@ -1,0 +1,39 @@
+# This repository contains intentionally duplicated copies of template configuration files in use for this repository's
+# own purposes
+#
+# This workflow checks that the copies are in sync.
+# If the workflow fails, run `task fix` and commit.
+
+name: Check Configuration Files Sync
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Sync files
+        run: task --silent config:sync
+
+      - name: Check file duplicates sync
+        run: |
+          git add .
+          if ! git diff --color --exit-code HEAD; then
+            echo "::error::File duplicates are out of sync. Please run \"task fix\""
+            exit 1
+          fi

--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -1,0 +1,65 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-general-formatting-task.md
+name: Check General Formatting
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to tools.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Get data for latest editorconfig-checker release
+        id: get-release-data
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Pre-releases are ignored
+          route: GET /repos/:owner/:repo/releases/latest
+          # The following inputs result in "Unexpected input" warnings on the workflow run log and summary page,
+          # but they are correct
+          owner: editorconfig-checker
+          repo: editorconfig-checker
+
+      - name: Download release binary
+        id: download-release
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          # See: https://github.com/editorconfig-checker/editorconfig-checker/releases
+          file-url: https://github.com/editorconfig-checker/editorconfig-checker/releases/download/${{ fromJson(steps.get-release-data.outputs.data).tag_name }}/ec-linux-amd64.tar.gz
+          location: ${{ env.EC_INSTALL_PATH }}
+
+      - name: Install editorconfig-checker
+        run: |
+          cd "${{ env.EC_INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download-release.outputs.file-path }}"
+          # Give the binary a standard name
+          mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
+
+      - name: Check formatting
+        run: task --silent general:check-formatting

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Tooling Project Assets
 
 [![Check Configuration Files status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-configuration-files.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-configuration-files.yml)
+[![Check General Formatting status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-general-formatting-task.yml)
 [![Check License status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-license.yml)
 [![Check Workflow Duplicates Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot-sync.yml)
+[![Check CI Workflows Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-ci-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-ci-sync.yml)
+[![Check Configuration Files Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-config-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-config-sync.yml)
 
 The [Arduino](https://www.arduino.cc/) Tooling Team's collection of reusable project infrastructure assets.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,12 +4,47 @@ tasks:
   fix:
     desc: Make automated corrections to the project's files
     deps:
+      - task: ci:sync
+      - task: config:sync
       - task: dependabot:sync
 
   check:
     desc: Check for problems with the project
     deps:
+      - task: general:check-formatting
       - task: config:validate
+
+  general:check-formatting:
+    desc: Check basic formatting style of all files
+    cmds:
+      - |
+        if ! which ec &>/dev/null; then
+          echo "ec not found or not in PATH. Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
+          exit 1
+        fi
+      - ec
+
+  ci:sync:
+    desc: Sync CI workflows from templates
+    vars:
+      WORKFLOWS_PATH: "./.github/workflows"
+      WORKFLOW_TEMPLATES_PATH: "./workflow-templates"
+    cmds:
+      - |
+        cp \
+          "{{.WORKFLOW_TEMPLATES_PATH}}/check-general-formatting-task.yml" \
+          "{{.WORKFLOWS_PATH}}"
+
+  config:sync:
+    desc: Sync configuration files from templates
+    vars:
+      REPOSITORY_ROOT_PATH: "./"
+      WORKFLOW_TEMPLATE_ASSETS_PATH: "./workflow-templates/assets"
+    cmds:
+      - |
+        cp \
+          "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/shared/.editorconfig" \
+          "{{.REPOSITORY_ROOT_PATH}}"
 
   dependabot:sync:
     desc: Sync workflow duplicates for dependabot checks

--- a/workflow-templates/assets/check-general-formatting-task/.ecrc
+++ b/workflow-templates/assets/check-general-formatting-task/.ecrc
@@ -1,0 +1,3 @@
+{
+  "Exclude": ["LICENSE.txt"]
+}

--- a/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
+++ b/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
@@ -1,0 +1,14 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  general:check-formatting:
+    desc: Check basic formatting style of all files
+    cmds:
+      - |
+        if ! which ec &>/dev/null; then
+          echo "ec not found or not in PATH. Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
+          exit 1
+        fi
+      - ec

--- a/workflow-templates/assets/shared/.editorconfig
+++ b/workflow-templates/assets/shared/.editorconfig
@@ -1,0 +1,57 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/assets/shared/.editorconfig
+# See: https://editorconfig.org/
+# The formatting style defined in this file is the official standardized style to be used in all Arduino Tooling
+# projects and should not be modified.
+# Note: indent style for each file type is defined even when it matches the universal config in order to make it clear
+# that this type has an official style.
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{adoc,asc,asciidoc}]
+indent_size = 2
+indent_style = space
+
+[*.{bash,sh}]
+indent_size = 2
+indent_style = space
+
+[*.{c,cc,cp,cpp,cxx,h,hh,hpp,hxx,ii,inl,ino,ixx,pde,tpl,tpp,txx}]
+indent_size = 2
+indent_style = space
+
+[*.go]
+indent_style = tab
+
+[*.java]
+indent_size = 2
+indent_style = space
+
+[*.{js,jsx,json,jsonc,json5,ts,tsx}]
+indent_size = 2
+indent_style = space
+
+[*.{md,mdx,mkdn,mdown,markdown}]
+indent_size = unset
+indent_style = space
+
+[*.proto]
+indent_size = 2
+indent_style = space
+
+[*.py]
+indent_size = 4
+indent_style = space
+
+[*.svg]
+indent_size = 2
+indent_style = space
+
+[*.{yaml,yml}]
+indent_size = 2
+indent_style = space

--- a/workflow-templates/check-general-formatting-task.md
+++ b/workflow-templates/check-general-formatting-task.md
@@ -1,0 +1,57 @@
+# "Check General Formatting" workflow (task)
+
+Workflow file: [check-general-formatting-task.yml](check-general-formatting-task.yml)
+
+Use [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) to check if the formatting of the repository's files match the [`.editorconfig`](https://editorconfig.org/).
+
+## Assets
+
+- [`.editorconfig`](assets/shared/.editorconfig)
+  - Install to: repository root
+- [`Taskfile.yml`](assets/check-general-formatting-task/Taskfile.yml] - formatting check [task](https://taskfile.dev/).
+  - Install to: repository root (or add the `general:check-formatting` task into the existing `Taskfile.yml`)
+- [`.ecrc`](assets/check-general-formatting-task/.ecrc) - editorconfig-checker configuration file.
+
+The formatting style defined in `.editorconfig` is the official standardized style to be used in all Arduino tooling projects and should not be modified.
+
+## Configuration
+
+General formatting settings are configured in the [`.editorconfig` file](https://editorconfig.org/). [The standardized `.editorconfig`](assets/shared/.editorconfig) should be used in all Arduino Tooling repositories.
+
+editorconfig-checker can be configured via an `.ecrc` file:
+https://github.com/editorconfig-checker/editorconfig-checker#configuration
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Check General Formatting status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-general-formatting-task.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-general-formatting-task.yml/badge.svg["Check General Formatting status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-general-formatting-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to check general file formatting
+
+On every push, pull request, and periodically, check whether the repository's files are formatted according to
+.editorconfig.
+```
+
+## PR message
+
+```markdown
+On every push, pull request, and periodically, use [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) check whether the repository's files are formatted according to [`.editorconfig`](https://editorconfig.org/).
+```

--- a/workflow-templates/check-general-formatting-task.yml
+++ b/workflow-templates/check-general-formatting-task.yml
@@ -1,0 +1,65 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-general-formatting-task.md
+name: Check General Formatting
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to tools.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Get data for latest editorconfig-checker release
+        id: get-release-data
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Pre-releases are ignored
+          route: GET /repos/:owner/:repo/releases/latest
+          # The following inputs result in "Unexpected input" warnings on the workflow run log and summary page,
+          # but they are correct
+          owner: editorconfig-checker
+          repo: editorconfig-checker
+
+      - name: Download release binary
+        id: download-release
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          # See: https://github.com/editorconfig-checker/editorconfig-checker/releases
+          file-url: https://github.com/editorconfig-checker/editorconfig-checker/releases/download/${{ fromJson(steps.get-release-data.outputs.data).tag_name }}/ec-linux-amd64.tar.gz
+          location: ${{ env.EC_INSTALL_PATH }}
+
+      - name: Install editorconfig-checker
+        run: |
+          cd "${{ env.EC_INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download-release.outputs.file-path }}"
+          # Give the binary a standard name
+          mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
+
+      - name: Check formatting
+        run: task --silent general:check-formatting

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-general-formatting-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-general-formatting-task.yml
@@ -1,0 +1,65 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-general-formatting-task.md
+name: Check General Formatting
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to tools.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Get data for latest editorconfig-checker release
+        id: get-release-data
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Pre-releases are ignored
+          route: GET /repos/:owner/:repo/releases/latest
+          # The following inputs result in "Unexpected input" warnings on the workflow run log and summary page,
+          # but they are correct
+          owner: editorconfig-checker
+          repo: editorconfig-checker
+
+      - name: Download release binary
+        id: download-release
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          # See: https://github.com/editorconfig-checker/editorconfig-checker/releases
+          file-url: https://github.com/editorconfig-checker/editorconfig-checker/releases/download/${{ fromJson(steps.get-release-data.outputs.data).tag_name }}/ec-linux-amd64.tar.gz
+          location: ${{ env.EC_INSTALL_PATH }}
+
+      - name: Install editorconfig-checker
+        run: |
+          cd "${{ env.EC_INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download-release.outputs.file-path }}"
+          # Give the binary a standard name
+          mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
+
+      - name: Check formatting
+        run: task --silent general:check-formatting


### PR DESCRIPTION
On every push, pull request, and periodically, use [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) check whether the repository's files are formatted according to [`.editorconfig`](https://editorconfig.org/).

The workflow is also put into service in this repository, and the utility workflows put in place to keep the repository's workflows and configuration files in sync with their templates.