### PR TITLE
Add template workflow to check Markdown files for problems

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -1,0 +1,66 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-markdown-task.md
+name: Check Markdown
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-markdown-task.ya?ml"
+      - ".markdown-link-check.json"
+      - "Taskfile.ya?ml"
+      - "**/.markdownlint*"
+      - "**.mdx?"
+      - "**.mkdn"
+      - "**.mdown"
+      - "**.markdown"
+  pull_request:
+    paths:
+      - ".github/workflows/check-markdown-task.ya?ml"
+      - ".markdown-link-check.json"
+      - "Taskfile.ya?ml"
+      - "**/.markdownlint*"
+      - "**.mdx?"
+      - "**.mkdn"
+      - "**.mdown"
+      - "**.markdown"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by external changes.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Initialize markdownlint-cli problem matcher
+        uses: xt0rted/markdownlint-problem-matcher@v1
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Lint
+        run: task markdown:lint
+
+  links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check links
+        run: task --silent markdown:check-links

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,5 @@
+{
+  "retryOn429": true,
+  "retryCount": 3,
+  "aliveStatusCodes": [200, 206]
+}

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,62 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown/.markdownlint.yml
+# See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+# The code style defined in this file is the official standardized style to be used in all Arduino projects and should
+# not be modified.
+# Note: Rules disabled solely because they are redundant to Prettier are marked with a "Prettier" comment.
+
+default: false
+MD001: false
+MD002: false
+MD003: false # Prettier
+MD004: false # Prettier
+MD005: false # Prettier
+MD006: false # Prettier
+MD007: false # Prettier
+MD008: false # Prettier
+MD009:
+  br_spaces: 0
+  strict: true
+  list_item_empty_lines: false # Prettier
+MD010: false # Prettier
+MD011: true
+MD012: false # Prettier
+MD013: false
+MD014: false
+MD018: true
+MD019: false # Prettier
+MD020: true
+MD021: false # Prettier
+MD022: false # Prettier
+MD023: false # Prettier
+MD024: false
+MD025:
+  level: 1
+  front_matter_title: '^\s*"?title"?\s*[:=]'
+MD026: false
+MD027: false # Prettier
+MD028: false
+MD029:
+  style: one
+MD030:
+  ul_single: 1
+  ol_single: 1
+  ul_multi: 1
+  ol_multi: 1
+MD031: false # Prettier
+MD032: false # Prettier
+MD033: false
+MD034: false
+MD035: false # Prettier
+MD036: false
+MD037: true
+MD038: true
+MD039: true
+MD040: false
+MD041: false
+MD042: true
+MD043: false
+MD044: false
+MD045: true
+MD046:
+  style: fenced
+MD047: false # Prettier

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Check Workflow Duplicates Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot-sync.yml)
 [![Check CI Workflows Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-ci-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-ci-sync.yml)
 [![Check Configuration Files Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-config-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-config-sync.yml)
+[![Check Markdown status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdown-task.yml)
 
 The [Arduino](https://www.arduino.cc/) Tooling Team's collection of reusable project infrastructure assets.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,12 +7,15 @@ tasks:
       - task: ci:sync
       - task: config:sync
       - task: dependabot:sync
+      - task: markdown:fix
 
   check:
     desc: Check for problems with the project
     deps:
       - task: general:check-formatting
       - task: config:validate
+      - task: markdown:lint
+      - task: markdown:check-links
 
   general:check-formatting:
     desc: Check basic formatting style of all files
@@ -33,6 +36,7 @@ tasks:
       - |
         cp \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-general-formatting-task.yml" \
+          "{{.WORKFLOW_TEMPLATES_PATH}}/check-markdown-task.yml" \
           "{{.WORKFLOWS_PATH}}"
 
   config:sync:
@@ -44,6 +48,8 @@ tasks:
       - |
         cp \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/shared/.editorconfig" \
+          "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-markdown/.markdown-link-check.json" \
+          "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-markdown/.markdownlint.yml" \
           "{{.REPOSITORY_ROOT_PATH}}"
 
   dependabot:sync:
@@ -75,3 +81,50 @@ tasks:
     cmds:
       - wget --quiet --output-document="{{.DEPENDABOT_SCHEMA_PATH}}" {{.DEPENDABOT_SCHEMA_URL}}
       - npx ajv-cli@{{.AJV_CLI_VERSION}} validate -s "{{.DEPENDABOT_SCHEMA_PATH}}" -d "{{.DEPENDABOT_DATA_PATH}}"
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
+  markdown:lint:
+    desc: Check for problems in Markdown files
+    cmds:
+      - npx markdownlint-cli "**/*.md"
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
+  markdown:fix:
+    desc: Automatically correct linting violations in Markdown files where possible
+    cmds:
+      - npx markdownlint-cli --fix "**/*.md"
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
+  markdown:check-links:
+    desc: Check for broken links
+    cmds:
+      - |
+        if [[ "{{.OS}}" == "Windows_NT" ]]; then
+          # npx --call uses the native shell, which makes it too difficult to use npx for this application on Windows,
+          # so the Windows user is required to have markdown-link-check installed and in PATH.
+          if ! which markdown-link-check &>/dev/null; then
+            echo "markdown-link-check not found or not in PATH. Please install: https://github.com/tcort/markdown-link-check#readme"
+            exit 1
+          fi
+          STATUS=0
+          for file in $(find -name "*.md"); do
+            markdown-link-check \
+              --quiet \
+              --config "./.markdown-link-check.json" \
+              "$file"
+            STATUS=$(( $STATUS + $? ))
+          done
+          exit $STATUS
+        else
+          npx --package=markdown-link-check --call='
+            STATUS=0
+            for file in $(find -name "*.md"); do
+              markdown-link-check \
+                --quiet \
+                --config "./.markdown-link-check.json" \
+                "$file"
+              STATUS=$(( $STATUS + $? ))
+            done
+            exit $STATUS
+          '
+        fi

--- a/workflow-templates/assets/check-markdown-task/Taskfile.yml
+++ b/workflow-templates/assets/check-markdown-task/Taskfile.yml
@@ -1,0 +1,50 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
+  markdown:lint:
+    desc: Check for problems in Markdown files
+    cmds:
+      - npx markdownlint-cli "**/*.md"
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
+  markdown:fix:
+    desc: Automatically correct linting violations in Markdown files where possible
+    cmds:
+      - npx markdownlint-cli --fix "**/*.md"
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
+  markdown:check-links:
+    desc: Check for broken links
+    cmds:
+      - |
+        if [[ "{{.OS}}" == "Windows_NT" ]]; then
+          # npx --call uses the native shell, which makes it too difficult to use npx for this application on Windows,
+          # so the Windows user is required to have markdown-link-check installed and in PATH.
+          if ! which markdown-link-check &>/dev/null; then
+            echo "markdown-link-check not found or not in PATH. Please install: https://github.com/tcort/markdown-link-check#readme"
+            exit 1
+          fi
+          STATUS=0
+          for file in $(find -name "*.md"); do
+            markdown-link-check \
+              --quiet \
+              --config "./.markdown-link-check.json" \
+              "$file"
+            STATUS=$(( $STATUS + $? ))
+          done
+          exit $STATUS
+        else
+          npx --package=markdown-link-check --call='
+            STATUS=0
+            for file in $(find -name "*.md"); do
+              markdown-link-check \
+                --quiet \
+                --config "./.markdown-link-check.json" \
+                "$file"
+              STATUS=$(( $STATUS + $? ))
+            done
+            exit $STATUS
+          '
+        fi

--- a/workflow-templates/assets/check-markdown/.markdown-link-check.json
+++ b/workflow-templates/assets/check-markdown/.markdown-link-check.json
@@ -1,0 +1,5 @@
+{
+  "retryOn429": true,
+  "retryCount": 3,
+  "aliveStatusCodes": [200, 206]
+}

--- a/workflow-templates/assets/check-markdown/.markdownlint.yml
+++ b/workflow-templates/assets/check-markdown/.markdownlint.yml
@@ -1,0 +1,62 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown/.markdownlint.yml
+# See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+# The code style defined in this file is the official standardized style to be used in all Arduino projects and should
+# not be modified.
+# Note: Rules disabled solely because they are redundant to Prettier are marked with a "Prettier" comment.
+
+default: false
+MD001: false
+MD002: false
+MD003: false # Prettier
+MD004: false # Prettier
+MD005: false # Prettier
+MD006: false # Prettier
+MD007: false # Prettier
+MD008: false # Prettier
+MD009:
+  br_spaces: 0
+  strict: true
+  list_item_empty_lines: false # Prettier
+MD010: false # Prettier
+MD011: true
+MD012: false # Prettier
+MD013: false
+MD014: false
+MD018: true
+MD019: false # Prettier
+MD020: true
+MD021: false # Prettier
+MD022: false # Prettier
+MD023: false # Prettier
+MD024: false
+MD025:
+  level: 1
+  front_matter_title: '^\s*"?title"?\s*[:=]'
+MD026: false
+MD027: false # Prettier
+MD028: false
+MD029:
+  style: one
+MD030:
+  ul_single: 1
+  ol_single: 1
+  ul_multi: 1
+  ol_multi: 1
+MD031: false # Prettier
+MD032: false # Prettier
+MD033: false
+MD034: false
+MD035: false # Prettier
+MD036: false
+MD037: true
+MD038: true
+MD039: true
+MD040: false
+MD041: false
+MD042: true
+MD043: false
+MD044: false
+MD045: true
+MD046:
+  style: fenced
+MD047: false # Prettier

--- a/workflow-templates/check-markdown-task.md
+++ b/workflow-templates/check-markdown-task.md
@@ -1,0 +1,94 @@
+# "Check Markdown" workflow (Task)
+
+Workflow file: [check-markdown-task.yml](check-markdown-task.yml)
+
+Check the repository's Markdown files for problems:
+
+- Use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) to check for common problems and formatting.
+- Use [markdown-link-check](https://github.com/tcort/markdown-link-check) to check for broken links.
+
+NOTE: This workflow is focused on linting. Formatting checks for Markdown are provided by the ["Check Prettier Formatting" workflow](check-prettier-formatting-task.md), so both should be used.
+
+This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
+
+## Assets
+
+- [`.markdown-link-check.json`](assets/check-markdown/.markdown-link-check.json) - markdown-link-check configuration file.
+  - Install to: repository root
+- [`.markdownlint.yml`](assets/check-markdown/.markdownlint.yml) - markdownlint configuration file.
+  - Install to: repository root
+- [`Taskfile.yml`](assets/check-markdown-task/Taskfile.yml] - Markdown tasks.
+  - Install to: repository root (or add the `markdown:fix`, `markdown:lint`, and `markdown:check-links` tasks into the existing `Taskfile.yml`)
+
+The code style defined in `.markdownlint.yml` is the official standardized style to be used in all Arduino tooling projects and should not be modified.
+
+## Configuration
+
+### markdownlint
+
+In the event the repository contains externally maintained Markdown files, `markdownlint` can be configured to ignore them via a `.markdownlintignore` file:
+https://github.com/igorshubovych/markdownlint-cli#ignoring-files
+
+### markdown-link-check
+
+Advanced configuration of `markdown-link-check` can be done via the [`.markdown-link-check.json`](assets/check-markdown/.markdown-link-check.json) configuration file:
+https://github.com/gaurav-nelson/github-action-markdown-link-check#user-content-custom-variables:~:text=Specify%20a%20custom%20configuration%20file
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Check Markdown status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-markdown-task.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-markdown-task.yml/badge.svg["Check Markdown status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-markdown-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to check Markdown files for problems
+
+On every push and pull request that affects relevant files, and periodically, check the repository's Markdown files for
+problems:
+
+- Use markdownlint to check for common problems and formatting.
+- Use markdown-link-check to check for broken links.
+
+The Arduino tooling Markdown style is defined by the `.markdownlint.yml` file.
+
+In the event the repository contains externally maintained Markdown files, markdownlint can be configured to ignore them
+via a `.markdownlintignore` file:
+https://github.com/igorshubovych/markdownlint-cli#ignoring-files
+
+markdown-link-check is configured via the `.markdown-link-check.json` file:
+https://github.com/tcort/markdown-link-check#config-file-format
+```
+
+## PR message
+
+```markdown
+On every push and pull request that affects relevant files, and periodically, check the repository's Markdown files for
+problems:
+
+- Use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) to check for common problems and formatting.
+- Use [markdown-link-check](https://github.com/tcort/markdown-link-check) to check for broken links.
+
+The Arduino tooling Markdown style is defined by the `.markdownlint.yml` file.
+
+In the event the repository contains externally maintained Markdown files, markdownlint can be configured to ignore them via a `.markdownlintignore` file:
+https://github.com/igorshubovych/markdownlint-cli#ignoring-files
+
+markdown-link-check is configured via the `.markdown-link-check.json` file:
+https://github.com/tcort/markdown-link-check#config-file-format
+```

--- a/workflow-templates/check-markdown-task.yml
+++ b/workflow-templates/check-markdown-task.yml
@@ -1,0 +1,66 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-markdown-task.md
+name: Check Markdown
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-markdown-task.ya?ml"
+      - ".markdown-link-check.json"
+      - "Taskfile.ya?ml"
+      - "**/.markdownlint*"
+      - "**.mdx?"
+      - "**.mkdn"
+      - "**.mdown"
+      - "**.markdown"
+  pull_request:
+    paths:
+      - ".github/workflows/check-markdown-task.ya?ml"
+      - ".markdown-link-check.json"
+      - "Taskfile.ya?ml"
+      - "**/.markdownlint*"
+      - "**.mdx?"
+      - "**.mkdn"
+      - "**.mdown"
+      - "**.markdown"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by external changes.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Initialize markdownlint-cli problem matcher
+        uses: xt0rted/markdownlint-problem-matcher@v1
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Lint
+        run: task markdown:lint
+
+  links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check links
+        run: task --silent markdown:check-links

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-markdown-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-markdown-task.yml
@@ -1,0 +1,66 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-markdown-task.md
+name: Check Markdown
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-markdown-task.ya?ml"
+      - ".markdown-link-check.json"
+      - "Taskfile.ya?ml"
+      - "**/.markdownlint*"
+      - "**.mdx?"
+      - "**.mkdn"
+      - "**.mdown"
+      - "**.markdown"
+  pull_request:
+    paths:
+      - ".github/workflows/check-markdown-task.ya?ml"
+      - ".markdown-link-check.json"
+      - "Taskfile.ya?ml"
+      - "**/.markdownlint*"
+      - "**.mdx?"
+      - "**.mkdn"
+      - "**.mdown"
+      - "**.markdown"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by external changes.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Initialize markdownlint-cli problem matcher
+        uses: xt0rted/markdownlint-problem-matcher@v1
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Lint
+        run: task markdown:lint
+
+  links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check links
+        run: task --silent markdown:check-links


### PR DESCRIPTION
On every push and pull request that affects relevant files, and periodically, check the repository's Markdown files for
problems:

- Use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) to check for common problems and formatting.
- Use [markdown-link-check](https://github.com/tcort/markdown-link-check) to check for broken links.

The Arduino tooling Markdown style is defined by the `.markdownlint.yml` file.

In the event the repository contains externally maintained Markdown files, markdownlint can be configured to ignore them via a `.markdownlintignore` file:
https://github.com/igorshubovych/markdownlint-cli#ignoring-files

markdown-link-check is configured via the `.markdown-link-check.json` file:
https://github.com/tcort/markdown-link-check#config-file-format

The workflow is also used for this repository's own CI.

---
### Notes

Failure of the link check CI is expected currently due to:

- Links based on the final repository location under the `arduino` organization.
- Link to a readme for a template workflow that has not yet been added to the repository.

---
I have always been bothered by the lack of compatibility of our link check task with Windows.

The code used to iterate over the repository's Markdown files is in Bash. Normally this works perfectly well on Windows due to Task using a built-in shell interpreter independent from whatever is in use natively on the machine running the task. However, this particular Bash code is run by `npx --call`, which uses the native shell of the operating system. This means the Bash code is run in `cmd` on Windows machines, which doesn't work. I have spent a ton of time trying to find a way to get this working with `npx --call` on Windows:

- Attempting to write an equivalent in batch, which would be easy enough in a batch file, but is not at all once you are faced with the odd restrictions imposed by passing the code as an argument to npx in combination with some mangling done by YAML and Task.
- Looking for a way to configure npx to use another shell, which seems to be impossible.

The solution I settled on is to simply abandon the use of npx on Windows, instead requiring Windows users to have markdown-link-check pre-installed and in `PATH`. This allows the use of the Bash code directly in the task. Other operating systems continue to use the traditional npx approach. Even though this isn't an ideal solution, it's a great improvement over the previous one where it was impossible for Windows contributors to run the task.