### PR TITLE
Correct branch name in template source URLs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/assets/shared/.editorconfig
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/shared/.editorconfig
 # See: https://editorconfig.org/
 # The formatting style defined in this file is the official standardized style to be used in all Arduino Tooling
 # projects and should not be modified.

--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-general-formatting-task.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-general-formatting-task.md
 name: Check General Formatting
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows

--- a/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
+++ b/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
 # See: https://taskfile.dev/#/usage
 version: "3"
 

--- a/workflow-templates/assets/shared/.editorconfig
+++ b/workflow-templates/assets/shared/.editorconfig
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/assets/shared/.editorconfig
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/shared/.editorconfig
 # See: https://editorconfig.org/
 # The formatting style defined in this file is the official standardized style to be used in all Arduino Tooling
 # projects and should not be modified.

--- a/workflow-templates/check-general-formatting-task.yml
+++ b/workflow-templates/check-general-formatting-task.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-general-formatting-task.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-general-formatting-task.md
 name: Check General Formatting
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-general-formatting-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-general-formatting-task.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-general-formatting-task.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-general-formatting-task.md
 name: Check General Formatting
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows


### PR DESCRIPTION
The template files contain comments documenting their source to facilitate syncs in both directions. The repository these
files were originally planned to be added to used `master` as the default branch name, but this repository uses `main`.
The name change was missed when adding the files to the repository.