### PR TITLE
Add template workflow to check for Prettier formatting compliance

### DIFF
--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -1,0 +1,219 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-prettier-formatting-task.md
+name: Check Prettier Formatting
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.prettierignore"
+      - "**/.prettierrc*"
+      # CSS
+      - "**.css"
+      - "**.wxss"
+      # PostCSS
+      - "**.pcss"
+      - "**.postcss"
+      # Less
+      - "**.less"
+      # SCSS
+      - "**.scss"
+      # GraphQL
+      - "**.graphqls?"
+      - "**.gql"
+      # handlebars
+      - "**.handlebars"
+      - "**.hbs"
+      # HTML
+      - "**.mjml"
+      - "**.html?"
+      - "**.html.hl"
+      - "**.st"
+      - "**.xht"
+      - "**.xhtml"
+      # Vue
+      - "**.vue"
+      # JavaScript
+      - "**.flow"
+      - "**._?jsb?"
+      - "**.bones"
+      - "**.cjs"
+      - "**.es6?"
+      - "**.frag"
+      - "**.gs"
+      - "**.jake"
+      - "**.jscad"
+      - "**.jsfl"
+      - "**.js[ms]"
+      - "**.[mn]js"
+      - "**.pac"
+      - "**.wxs"
+      - "**.[xs]s?js"
+      - "**.xsjslib"
+      # JSX
+      - "**.jsx"
+      # TypeScript
+      - "**.ts"
+      # TSX
+      - "**.tsx"
+      # JSON
+      - "**/.eslintrc"
+      - "**.json"
+      - "**.avsc"
+      - "**.geojson"
+      - "**.gltf"
+      - "**.har"
+      - "**.ice"
+      - "**.JSON-tmLanguage"
+      - "**.mcmeta"
+      - "**.tfstate"
+      - "**.topojson"
+      - "**.webapp"
+      - "**.webmanifest"
+      - "**.yyp?"
+      # JSONC
+      - "**/.babelrc"
+      - "**/.jscsrc"
+      - "**/.js[hl]intrc"
+      - "**.jsonc"
+      - "**.sublime-*"
+      # JSON5
+      - "**.json5"
+      # Markdown
+      - "**.mdx?"
+      - "**.markdown"
+      - "**.mk?down"
+      - "**.mdwn"
+      - "**.mkdn?"
+      - "**.ronn"
+      - "**.workbook"
+      # YAML
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  pull_request:
+    paths:
+      - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.prettierignore"
+      - "**/.prettierrc*"
+      # CSS
+      - "**.css"
+      - "**.wxss"
+      # PostCSS
+      - "**.pcss"
+      - "**.postcss"
+      # Less
+      - "**.less"
+      # SCSS
+      - "**.scss"
+      # GraphQL
+      - "**.graphqls?"
+      - "**.gql"
+      # handlebars
+      - "**.handlebars"
+      - "**.hbs"
+      # HTML
+      - "**.mjml"
+      - "**.html?"
+      - "**.html.hl"
+      - "**.st"
+      - "**.xht"
+      - "**.xhtml"
+      # Vue
+      - "**.vue"
+      # JavaScript
+      - "**.flow"
+      - "**._?jsb?"
+      - "**.bones"
+      - "**.cjs"
+      - "**.es6?"
+      - "**.frag"
+      - "**.gs"
+      - "**.jake"
+      - "**.jscad"
+      - "**.jsfl"
+      - "**.js[ms]"
+      - "**.[mn]js"
+      - "**.pac"
+      - "**.wxs"
+      - "**.[xs]s?js"
+      - "**.xsjslib"
+      # JSX
+      - "**.jsx"
+      # TypeScript
+      - "**.ts"
+      # TSX
+      - "**.tsx"
+      # JSON
+      - "**/.eslintrc"
+      - "**.json"
+      - "**.avsc"
+      - "**.geojson"
+      - "**.gltf"
+      - "**.har"
+      - "**.ice"
+      - "**.JSON-tmLanguage"
+      - "**.mcmeta"
+      - "**.tfstate"
+      - "**.topojson"
+      - "**.webapp"
+      - "**.webmanifest"
+      - "**.yyp?"
+      # JSONC
+      - "**/.babelrc"
+      - "**/.jscsrc"
+      - "**/.js[hl]intrc"
+      - "**.jsonc"
+      - "**.sublime-*"
+      # JSON5
+      - "**.json5"
+      # Markdown
+      - "**.mdx?"
+      - "**.markdown"
+      - "**.mk?down"
+      - "**.mdwn"
+      - "**.mkdn?"
+      - "**.ronn"
+      - "**.workbook"
+      # YAML
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Format with Prettier
+        run: task general:format-prettier
+
+      - name: Check formatting
+        run: git diff --color --exit-code

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Check CI Workflows Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-ci-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-ci-sync.yml)
 [![Check Configuration Files Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-config-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-config-sync.yml)
 [![Check Markdown status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdown-task.yml)
+[![Check Prettier Formatting status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-prettier-formatting-task.yml)
 
 The [Arduino](https://www.arduino.cc/) Tooling Team's collection of reusable project infrastructure assets.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,7 @@ tasks:
       - task: config:sync
       - task: dependabot:sync
       - task: markdown:fix
+      - task: general:format-prettier
 
   check:
     desc: Check for problems with the project
@@ -16,6 +17,12 @@ tasks:
       - task: config:validate
       - task: markdown:lint
       - task: markdown:check-links
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
+  general:format-prettier:
+    desc: Format all supported files with Prettier
+    cmds:
+      - npx prettier --write .
 
   general:check-formatting:
     desc: Check basic formatting style of all files
@@ -37,6 +44,7 @@ tasks:
         cp \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-general-formatting-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-markdown-task.yml" \
+          "{{.WORKFLOW_TEMPLATES_PATH}}/check-prettier-formatting-task.yml" \
           "{{.WORKFLOWS_PATH}}"
 
   config:sync:

--- a/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
+++ b/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
@@ -1,0 +1,9 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
+  general:format-prettier:
+    desc: Format all supported files with Prettier
+    cmds:
+      - npx prettier --write .

--- a/workflow-templates/check-prettier-formatting-task.md
+++ b/workflow-templates/check-prettier-formatting-task.md
@@ -1,0 +1,68 @@
+# "Check Prettier Formatting" workflow (Task)
+
+Workflow file: [check-prettier-formatting-task.yml](check-prettier-formatting-task.yml)
+
+Use [Prettier](https://prettier.io/docs/en/index.html) to check formatting. Supported languages include:
+
+- JavaScript
+- TypeScript
+- CSS
+- HTML
+- JSON
+- Markdown
+- YAML
+
+This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
+
+## Assets
+
+- [`Taskfile.yml`](assets/check-prettier-formatting-task/Taskfile.yml] - Formatting task.
+  - Install to: repository root (or add the `general:format-prettier` task into the existing `Taskfile.yml`)
+
+## Configuration
+
+Prettier should be configured via a `.prettierignore` file to ignore any externally maintained files contained in the repository:
+https://prettier.io/docs/en/ignore.html
+
+Support for additional languages can be added to Prettier via plugins:
+https://prettier.io/docs/en/plugins.html
+
+Prettier automatically determines the language based on file name. In cases where it is not able to recognize a file, the parser can be specified in a `.prettierrc.yml` configuration file:
+https://prettier.io/docs/en/configuration.html#setting-the-parserdocsenoptionshtmlparser-option
+
+The default Prettier code style is the official standardized style to be used in all Arduino tooling projects and should not be modified.
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Check Prettier Formatting status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-prettier-formatting-task.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-prettier-formatting-task.yml/badge.svg["Check Prettier Formatting status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-prettier-formatting-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to check for Prettier formatting compliance
+
+On every push and pull request that affects relevant files, and periodically, check whether the formatting of supported
+files is compliant with the Prettier style.
+```
+
+## PR message
+
+```markdown
+On every push and pull request that affects relevant files, and periodically, check whether the formatting of supported files is compliant with the [Prettier](https://prettier.io/docs/en/index.html) style.
+```

--- a/workflow-templates/check-prettier-formatting-task.yml
+++ b/workflow-templates/check-prettier-formatting-task.yml
@@ -1,0 +1,219 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-prettier-formatting-task.md
+name: Check Prettier Formatting
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.prettierignore"
+      - "**/.prettierrc*"
+      # CSS
+      - "**.css"
+      - "**.wxss"
+      # PostCSS
+      - "**.pcss"
+      - "**.postcss"
+      # Less
+      - "**.less"
+      # SCSS
+      - "**.scss"
+      # GraphQL
+      - "**.graphqls?"
+      - "**.gql"
+      # handlebars
+      - "**.handlebars"
+      - "**.hbs"
+      # HTML
+      - "**.mjml"
+      - "**.html?"
+      - "**.html.hl"
+      - "**.st"
+      - "**.xht"
+      - "**.xhtml"
+      # Vue
+      - "**.vue"
+      # JavaScript
+      - "**.flow"
+      - "**._?jsb?"
+      - "**.bones"
+      - "**.cjs"
+      - "**.es6?"
+      - "**.frag"
+      - "**.gs"
+      - "**.jake"
+      - "**.jscad"
+      - "**.jsfl"
+      - "**.js[ms]"
+      - "**.[mn]js"
+      - "**.pac"
+      - "**.wxs"
+      - "**.[xs]s?js"
+      - "**.xsjslib"
+      # JSX
+      - "**.jsx"
+      # TypeScript
+      - "**.ts"
+      # TSX
+      - "**.tsx"
+      # JSON
+      - "**/.eslintrc"
+      - "**.json"
+      - "**.avsc"
+      - "**.geojson"
+      - "**.gltf"
+      - "**.har"
+      - "**.ice"
+      - "**.JSON-tmLanguage"
+      - "**.mcmeta"
+      - "**.tfstate"
+      - "**.topojson"
+      - "**.webapp"
+      - "**.webmanifest"
+      - "**.yyp?"
+      # JSONC
+      - "**/.babelrc"
+      - "**/.jscsrc"
+      - "**/.js[hl]intrc"
+      - "**.jsonc"
+      - "**.sublime-*"
+      # JSON5
+      - "**.json5"
+      # Markdown
+      - "**.mdx?"
+      - "**.markdown"
+      - "**.mk?down"
+      - "**.mdwn"
+      - "**.mkdn?"
+      - "**.ronn"
+      - "**.workbook"
+      # YAML
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  pull_request:
+    paths:
+      - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.prettierignore"
+      - "**/.prettierrc*"
+      # CSS
+      - "**.css"
+      - "**.wxss"
+      # PostCSS
+      - "**.pcss"
+      - "**.postcss"
+      # Less
+      - "**.less"
+      # SCSS
+      - "**.scss"
+      # GraphQL
+      - "**.graphqls?"
+      - "**.gql"
+      # handlebars
+      - "**.handlebars"
+      - "**.hbs"
+      # HTML
+      - "**.mjml"
+      - "**.html?"
+      - "**.html.hl"
+      - "**.st"
+      - "**.xht"
+      - "**.xhtml"
+      # Vue
+      - "**.vue"
+      # JavaScript
+      - "**.flow"
+      - "**._?jsb?"
+      - "**.bones"
+      - "**.cjs"
+      - "**.es6?"
+      - "**.frag"
+      - "**.gs"
+      - "**.jake"
+      - "**.jscad"
+      - "**.jsfl"
+      - "**.js[ms]"
+      - "**.[mn]js"
+      - "**.pac"
+      - "**.wxs"
+      - "**.[xs]s?js"
+      - "**.xsjslib"
+      # JSX
+      - "**.jsx"
+      # TypeScript
+      - "**.ts"
+      # TSX
+      - "**.tsx"
+      # JSON
+      - "**/.eslintrc"
+      - "**.json"
+      - "**.avsc"
+      - "**.geojson"
+      - "**.gltf"
+      - "**.har"
+      - "**.ice"
+      - "**.JSON-tmLanguage"
+      - "**.mcmeta"
+      - "**.tfstate"
+      - "**.topojson"
+      - "**.webapp"
+      - "**.webmanifest"
+      - "**.yyp?"
+      # JSONC
+      - "**/.babelrc"
+      - "**/.jscsrc"
+      - "**/.js[hl]intrc"
+      - "**.jsonc"
+      - "**.sublime-*"
+      # JSON5
+      - "**.json5"
+      # Markdown
+      - "**.mdx?"
+      - "**.markdown"
+      - "**.mk?down"
+      - "**.mdwn"
+      - "**.mkdn?"
+      - "**.ronn"
+      - "**.workbook"
+      # YAML
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Format with Prettier
+        run: task general:format-prettier
+
+      - name: Check formatting
+        run: git diff --color --exit-code

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-prettier-formatting-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-prettier-formatting-task.yml
@@ -1,0 +1,219 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-prettier-formatting-task.md
+name: Check Prettier Formatting
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.prettierignore"
+      - "**/.prettierrc*"
+      # CSS
+      - "**.css"
+      - "**.wxss"
+      # PostCSS
+      - "**.pcss"
+      - "**.postcss"
+      # Less
+      - "**.less"
+      # SCSS
+      - "**.scss"
+      # GraphQL
+      - "**.graphqls?"
+      - "**.gql"
+      # handlebars
+      - "**.handlebars"
+      - "**.hbs"
+      # HTML
+      - "**.mjml"
+      - "**.html?"
+      - "**.html.hl"
+      - "**.st"
+      - "**.xht"
+      - "**.xhtml"
+      # Vue
+      - "**.vue"
+      # JavaScript
+      - "**.flow"
+      - "**._?jsb?"
+      - "**.bones"
+      - "**.cjs"
+      - "**.es6?"
+      - "**.frag"
+      - "**.gs"
+      - "**.jake"
+      - "**.jscad"
+      - "**.jsfl"
+      - "**.js[ms]"
+      - "**.[mn]js"
+      - "**.pac"
+      - "**.wxs"
+      - "**.[xs]s?js"
+      - "**.xsjslib"
+      # JSX
+      - "**.jsx"
+      # TypeScript
+      - "**.ts"
+      # TSX
+      - "**.tsx"
+      # JSON
+      - "**/.eslintrc"
+      - "**.json"
+      - "**.avsc"
+      - "**.geojson"
+      - "**.gltf"
+      - "**.har"
+      - "**.ice"
+      - "**.JSON-tmLanguage"
+      - "**.mcmeta"
+      - "**.tfstate"
+      - "**.topojson"
+      - "**.webapp"
+      - "**.webmanifest"
+      - "**.yyp?"
+      # JSONC
+      - "**/.babelrc"
+      - "**/.jscsrc"
+      - "**/.js[hl]intrc"
+      - "**.jsonc"
+      - "**.sublime-*"
+      # JSON5
+      - "**.json5"
+      # Markdown
+      - "**.mdx?"
+      - "**.markdown"
+      - "**.mk?down"
+      - "**.mdwn"
+      - "**.mkdn?"
+      - "**.ronn"
+      - "**.workbook"
+      # YAML
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  pull_request:
+    paths:
+      - ".github/workflows/check-prettier-formatting-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.prettierignore"
+      - "**/.prettierrc*"
+      # CSS
+      - "**.css"
+      - "**.wxss"
+      # PostCSS
+      - "**.pcss"
+      - "**.postcss"
+      # Less
+      - "**.less"
+      # SCSS
+      - "**.scss"
+      # GraphQL
+      - "**.graphqls?"
+      - "**.gql"
+      # handlebars
+      - "**.handlebars"
+      - "**.hbs"
+      # HTML
+      - "**.mjml"
+      - "**.html?"
+      - "**.html.hl"
+      - "**.st"
+      - "**.xht"
+      - "**.xhtml"
+      # Vue
+      - "**.vue"
+      # JavaScript
+      - "**.flow"
+      - "**._?jsb?"
+      - "**.bones"
+      - "**.cjs"
+      - "**.es6?"
+      - "**.frag"
+      - "**.gs"
+      - "**.jake"
+      - "**.jscad"
+      - "**.jsfl"
+      - "**.js[ms]"
+      - "**.[mn]js"
+      - "**.pac"
+      - "**.wxs"
+      - "**.[xs]s?js"
+      - "**.xsjslib"
+      # JSX
+      - "**.jsx"
+      # TypeScript
+      - "**.ts"
+      # TSX
+      - "**.tsx"
+      # JSON
+      - "**/.eslintrc"
+      - "**.json"
+      - "**.avsc"
+      - "**.geojson"
+      - "**.gltf"
+      - "**.har"
+      - "**.ice"
+      - "**.JSON-tmLanguage"
+      - "**.mcmeta"
+      - "**.tfstate"
+      - "**.topojson"
+      - "**.webapp"
+      - "**.webmanifest"
+      - "**.yyp?"
+      # JSONC
+      - "**/.babelrc"
+      - "**/.jscsrc"
+      - "**/.js[hl]intrc"
+      - "**.jsonc"
+      - "**.sublime-*"
+      # JSON5
+      - "**.json5"
+      # Markdown
+      - "**.mdx?"
+      - "**.markdown"
+      - "**.mk?down"
+      - "**.mdwn"
+      - "**.mkdn?"
+      - "**.ronn"
+      - "**.workbook"
+      # YAML
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Format with Prettier
+        run: task general:format-prettier
+
+      - name: Check formatting
+        run: git diff --color --exit-code


### PR DESCRIPTION
On every push and pull request that affects relevant files, and periodically, check whether the formatting of supported
files is compliant with the Prettier style.