### PR TITLE
Add template workflow to validate Taskfiles

### DIFF
--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -1,0 +1,54 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-taskfiles.md
+name: Check Taskfiles
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-taskfiles.ya?ml"
+      - "**/Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-taskfiles.ya?ml"
+      - "**/Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    name: Validate ${{ matrix.file }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        file:
+          # TODO: add paths to any additional Taskfiles here
+          - ./**/Taskfile.yml
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download JSON schema for Taskfiles
+        id: download-schema
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/taskfile.json
+          file-url: https://json.schemastore.org/taskfile.json
+          location: ${{ runner.temp }}/taskfile-schema
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      - name: Validate ${{ matrix.file }}
+        run: |
+          # See: https://github.com/ajv-validator/ajv-cli#readme
+          ajv validate \
+            --strict=false \
+            -s "${{ steps.download-schema.outputs.file-path }}" \
+            -d "${{ matrix.file }}"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![Check Configuration Files Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-config-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-config-sync.yml)
 [![Check Markdown status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdown-task.yml)
 [![Check Prettier Formatting status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-prettier-formatting-task.yml)
+[![Check Taskfiles status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-taskfiles.yml)
+
 
 The [Arduino](https://www.arduino.cc/) Tooling Team's collection of reusable project infrastructure assets.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,6 +45,7 @@ tasks:
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-general-formatting-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-markdown-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-prettier-formatting-task.yml" \
+          "{{.WORKFLOW_TEMPLATES_PATH}}/check-taskfiles.yml" \
           "{{.WORKFLOWS_PATH}}"
 
   config:sync:

--- a/workflow-templates/check-taskfiles.md
+++ b/workflow-templates/check-taskfiles.md
@@ -1,0 +1,40 @@
+# "Check Taskfiles" workflow
+
+Workflow file: [check-taskfiles.yml](check-taskfiles.yml)
+
+Validate the repository's [Taskfiles](https://taskfile.dev/#/usage) against the JSON schema.
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Check Taskfiles status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-taskfiles.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-taskfiles.yml/badge.svg["Check Taskfiles status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-taskfiles.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to validate Taskfiles
+
+On every push or pull request that affects the repository's Taskfiles, and periodically, validate them
+against the JSON schema.
+```
+
+## PR message
+
+```markdown
+On every push or pull request that affects the repository's [Taskfiles](https://taskfile.dev/#/usage), and periodically, validate them against the JSON schema.
+```

--- a/workflow-templates/check-taskfiles.yml
+++ b/workflow-templates/check-taskfiles.yml
@@ -1,0 +1,54 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-taskfiles.md
+name: Check Taskfiles
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-taskfiles.ya?ml"
+      - "**/Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-taskfiles.ya?ml"
+      - "**/Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    name: Validate ${{ matrix.file }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        file:
+          # TODO: add paths to any additional Taskfiles here
+          - ./**/Taskfile.yml
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download JSON schema for Taskfiles
+        id: download-schema
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/taskfile.json
+          file-url: https://json.schemastore.org/taskfile.json
+          location: ${{ runner.temp }}/taskfile-schema
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      - name: Validate ${{ matrix.file }}
+        run: |
+          # See: https://github.com/ajv-validator/ajv-cli#readme
+          ajv validate \
+            --strict=false \
+            -s "${{ steps.download-schema.outputs.file-path }}" \
+            -d "${{ matrix.file }}"

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-taskfiles.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-taskfiles.yml
@@ -1,0 +1,54 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-taskfiles.md
+name: Check Taskfiles
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-taskfiles.ya?ml"
+      - "**/Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-taskfiles.ya?ml"
+      - "**/Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    name: Validate ${{ matrix.file }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        file:
+          # TODO: add paths to any additional Taskfiles here
+          - ./**/Taskfile.yml
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download JSON schema for Taskfiles
+        id: download-schema
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/taskfile.json
+          file-url: https://json.schemastore.org/taskfile.json
+          location: ${{ runner.temp }}/taskfile-schema
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      - name: Validate ${{ matrix.file }}
+        run: |
+          # See: https://github.com/ajv-validator/ajv-cli#readme
+          ajv validate \
+            --strict=false \
+            -s "${{ steps.download-schema.outputs.file-path }}" \
+            -d "${{ matrix.file }}"


### PR DESCRIPTION
On every push or pull request that affects the repository's [Taskfiles](https://taskfile.dev/#/usage), and periodically, validate them against the JSON schema.

I decided against the usual Task-based approach for this particular workflow because it seems problematic to use a task to validate the Taskfile that defines the task. If the Taskfile was invalid, then the task to validate it likely wouldn't run anyway. I think this is the sort of thing like the license check where you throw the workflow into the repository and forget about it until such time as someone mucks up the file it watches, when it comes to life and saves the day.

The workflow is also used in this repository's own CI. Due to the need to customize the template workflow