### PR TITLE
Add CI workflow to validate GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -1,0 +1,37 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-workflows-task.md
+name: Check Workflows
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
+      - "workflow-templates/*.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
+      - "workflow-templates/*.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate workflows
+        run: task --silent ci:validate

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Check Taskfiles status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-taskfiles.yml)
 [![Check YAML status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-yaml-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-yaml-task.yml)
 [![Sync Labels status](https://github.com/arduino/tooling-project-assets/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/sync-labels.yml)
+[![Check Workflows status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-workflows-task.yml)
 
 The [Arduino](https://www.arduino.cc/) Tooling Team's collection of reusable project infrastructure assets.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,6 +14,7 @@ tasks:
     desc: Check for problems with the project
     deps:
       - task: general:check-formatting
+      - task: ci:validate
       - task: config:validate
       - task: markdown:lint
       - task: markdown:check-links
@@ -81,6 +82,33 @@ tasks:
           -type f \
           -regex '.*\.ya?ml' \
           -exec cp '{}' "{{.WORKFLOW_TEMPLATE_COPIES_PATH}}" \;
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml
+  ci:validate:
+    desc: Validate GitHub Actions workflows against their JSON schema
+    vars:
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
+      WORKFLOW_SCHEMA_URL: https://json.schemastore.org/github-workflow
+      WORKFLOW_SCHEMA_PATH:
+        sh: mktemp -t workflow-schema-XXXXXXXXXX.json
+      WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
+      TEMPLATE_WORKFLOWS_DATA_PATH: "./workflow-templates/*.{yml,yaml}"
+    cmds:
+      - |
+        wget \
+          --quiet \
+          --output-document="{{.WORKFLOW_SCHEMA_PATH}}" \
+          {{.WORKFLOW_SCHEMA_URL}}
+      - |
+        npx ajv-cli validate \
+          --strict=false \
+          -s "{{.WORKFLOW_SCHEMA_PATH}}" \
+          -d "{{.WORKFLOWS_DATA_PATH}}"
+      - |
+        npx ajv-cli validate \
+          --strict=false \
+          -s "{{.WORKFLOW_SCHEMA_PATH}}" \
+          -d "{{.TEMPLATE_WORKFLOWS_DATA_PATH}}"
 
   config:validate:
     desc: Validate configuration files against their JSON schema

--- a/workflow-templates/assets/check-workflows-task/Taskfile.yml
+++ b/workflow-templates/assets/check-workflows-task/Taskfile.yml
@@ -1,0 +1,24 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml
+  ci:validate:
+    desc: Validate GitHub Actions workflows against their JSON schema
+    vars:
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
+      WORKFLOW_SCHEMA_URL: https://json.schemastore.org/github-workflow
+      WORKFLOW_SCHEMA_PATH:
+        sh: mktemp -t workflow-schema-XXXXXXXXXX.json
+      WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
+    cmds:
+      - |
+        wget \
+          --quiet \
+          --output-document="{{.WORKFLOW_SCHEMA_PATH}}" \
+          {{.WORKFLOW_SCHEMA_URL}}
+      - |
+        npx ajv-cli validate \
+          --strict=false \
+          -s "{{.WORKFLOW_SCHEMA_PATH}}" \
+          -d "{{.WORKFLOWS_DATA_PATH}}"

--- a/workflow-templates/check-workflows-task.md
+++ b/workflow-templates/check-workflows-task.md
@@ -1,0 +1,47 @@
+# "Check Workflows" workflow (Task)
+
+Workflow file: [check-workflows-task.yml](check-workflows-task.yml)
+
+Validate the repository's GitHub Actions workflows against the JSON schema.
+
+This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
+
+## Assets
+
+- [`Taskfile.yml`](assets/check-workflows-task/Taskfile.yml] - workflow validation task.
+  - Install to: repository root (or add the `ci:validate` task into the existing `Taskfile.yml`)
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Check Workflows status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-workflows-task.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-workflows-task.yml/badge.svg["Check Workflows status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-workflows-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to validate GitHub Actions workflows
+
+On every push or pull request that affects the repository's GitHub Actions workflows, and periodically, validate them
+against the JSON schema.
+```
+
+## PR message
+
+```markdown
+On every push or pull request that affects the repository's GitHub Actions workflows, and periodically, validate them against the JSON schema.
+```

--- a/workflow-templates/check-workflows-task.yml
+++ b/workflow-templates/check-workflows-task.yml
@@ -1,0 +1,35 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-workflows-task.md
+name: Check Workflows
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate workflows
+        run: task --silent ci:validate

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-workflows-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-workflows-task.yml
@@ -1,0 +1,35 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-workflows-task.md
+name: Check Workflows
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate workflows
+        run: task --silent ci:validate


### PR DESCRIPTION
On every push or pull request that affects the repository's GitHub Actions workflows, and periodically, validate them
against the JSON schema.