### PR TITLE
Attach source comment to task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,6 +24,7 @@ tasks:
     cmds:
       - npx prettier --write .
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
   general:check-formatting:
     desc: Check basic formatting style of all files
     cmds:

--- a/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
+++ b/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
@@ -1,8 +1,8 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
 # See: https://taskfile.dev/#/usage
 version: "3"
 
 tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
   general:check-formatting:
     desc: Check basic formatting style of all files
     cmds:


### PR DESCRIPTION
The idea is for each asset template to provide a link to its source to facilitate syncing improvements to and from the
template. In the case of tasks, most often they will be merged into a single Taskfile.yml. For this reason, placing the
source comment at the top of the template workflow asset Taskfile.yml will lead to the source comment being lost. Placing
the source comment directly above the tasks themselves will increase the chances of the source information being
distributed along with the tasks.