### PR TITLE
Add template workflow to lint YAML files

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,3 +1,6 @@
 {
-  "Exclude": ["LICENSE.txt"]
+  "Exclude": [
+    "LICENSE.txt",
+    "poetry.lock"
+  ]
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,12 @@ updates:
       - "topic: infrastructure"
     assignees:
       - per1234
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"
+    assignees:
+      - per1234

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -1,0 +1,81 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-yaml-task.md
+name: Check YAML
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".yamllint*"
+      - "poetry.lock"
+      - "pyproject.toml"
+      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  pull_request:
+    paths:
+      - ".yamllint*"
+      - "poetry.lock"
+      - "pyproject.toml"
+      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    name: ${{ matrix.configuration.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        configuration:
+          - name: Generate problem matcher output
+            # yamllint's "github" output type produces annotated diffs, but is not useful to humans reading the log.
+            format: github
+            # The other matrix job is used to set the result, so this job is configured to always pass.
+            continue-on-error: true
+          - name: Check formatting
+            # yamllint's "colored" output type is most suitable for humans reading the log.
+            format: colored
+            continue-on-error: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check YAML
+        continue-on-error: ${{ matrix.configuration.continue-on-error }}
+        run: task yaml:lint YAMLLINT_FORMAT=${{ matrix.configuration.format }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,74 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-yaml/.yamllint.yml
+# See: https://yamllint.readthedocs.io/en/stable/configuration.html
+# The code style defined in this file is the official standardized style to be used in all Arduino tooling projects and
+# should not be modified.
+# Note: Rules disabled solely because they are redundant to Prettier are marked with a "Prettier" comment.
+
+rules:
+  braces:
+    level: error
+    forbid: non-empty
+    min-spaces-inside: -1 # Prettier
+    max-spaces-inside: -1 # Prettier
+    min-spaces-inside-empty: -1 # Prettier
+    max-spaces-inside-empty: -1 # Prettier
+  brackets:
+    level: error
+    forbid: non-empty
+    min-spaces-inside: -1 # Prettier
+    max-spaces-inside: -1 # Prettier
+    min-spaces-inside-empty: -1 # Prettier
+    max-spaces-inside-empty: -1 # Prettier
+  colons: disable # Prettier
+  commas: disable # Prettier
+  comments: disable # Prettier
+  comments-indentation: disable # Prettier
+  document-end: disable # Prettier
+  document-start: disable
+  empty-lines: disable # Prettier
+  empty-values: disable
+  hyphens: disable # Prettier
+  indentation: disable # Prettier
+  key-duplicates: disable # Prettier
+  key-ordering: disable
+  line-length:
+    level: warning
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  new-line-at-end-of-file: disable # Prettier
+  new-lines: disable # Prettier
+  octal-values:
+    level: warning
+    forbid-implicit-octal: true
+    forbid-explicit-octal: false
+  quoted-strings: disable
+  trailing-spaces: disable # Prettier
+  truthy:
+    level: error
+    allowed-values:
+      - "true"
+      - "false"
+      - "on" # Used by GitHub Actions as a workflow key.
+    check-keys: true
+
+yaml-files:
+  # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+  - ".clang-format"
+  - ".clang-tidy"
+  - ".gemrc"
+  - ".yamllint"
+  - "glide.lock"
+  - "*.yml"
+  - "*.mir"
+  - "*.reek"
+  - "*.rviz"
+  - "*.sublime-syntax"
+  - "*.syntax"
+  - "*.yaml"
+  - "*.yaml-tmlanguage"
+  - "*.yaml.sed"
+  - "*.yml.mysql"
+
+ignore: |
+  /.git/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Check Markdown status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdown-task.yml)
 [![Check Prettier Formatting status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-prettier-formatting-task.yml)
 [![Check Taskfiles status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-taskfiles.yml)
-
+[![Check YAML status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-yaml-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-yaml-task.yml)
 
 The [Arduino](https://www.arduino.cc/) Tooling Team's collection of reusable project infrastructure assets.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,6 +17,7 @@ tasks:
       - task: config:validate
       - task: markdown:lint
       - task: markdown:check-links
+      - task: yaml:lint
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
   general:format-prettier:
@@ -46,6 +47,7 @@ tasks:
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-markdown-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-prettier-formatting-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-taskfiles.yml" \
+          "{{.WORKFLOW_TEMPLATES_PATH}}/check-yaml-task.yml" \
           "{{.WORKFLOWS_PATH}}"
 
   config:sync:
@@ -59,6 +61,7 @@ tasks:
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/shared/.editorconfig" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-markdown/.markdown-link-check.json" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-markdown/.markdownlint.yml" \
+          "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-yaml/.yamllint.yml" \
           "{{.REPOSITORY_ROOT_PATH}}"
 
   dependabot:sync:
@@ -137,3 +140,23 @@ tasks:
             exit $STATUS
           '
         fi
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/shared/Taskfile.yml
+  poetry:install-deps:
+    desc: Install dependencies managed by Poetry
+    cmds:
+      - poetry install --no-root
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/shared/Taskfile.yml
+  poetry:update-deps:
+    desc: Update all dependencies managed by Poetry to their newest versions
+    cmds:
+      - poetry update
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-yaml-task/Taskfile.yml
+  yaml:lint:
+    desc: Check for problems with YAML files
+    deps:
+      - task: poetry:install-deps
+    cmds:
+      - poetry run yamllint --format {{default "colored" .YAMLLINT_FORMAT}} .

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,72 @@
+[[package]]
+name = "pathspec"
+version = "0.8.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyyaml"
+version = "5.4.1"
+description = "YAML parser and emitter for Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[[package]]
+name = "yamllint"
+version = "1.26.1"
+description = "A linter for YAML files."
+category = "dev"
+optional = false
+python-versions = ">=3.5.*"
+
+[package.dependencies]
+pathspec = ">=0.5.3"
+pyyaml = "*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "9838d42b2ca063f9677efc32dac655df06d0947f2520111fd1ab33f981e0d5e9"
+
+[metadata.files]
+pathspec = [
+    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
+    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
+]
+pyyaml = [
+    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
+    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
+    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
+    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
+    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]
+yamllint = [
+    {file = "yamllint-1.26.1.tar.gz", hash = "sha256:87d9462b3ed7e9dfa19caa177f7a77cd9888b3dc4044447d6ae0ab233bcd1324"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "tooling-project-assets"
+version = "0.0.0"
+description = ""
+authors = ["Arduino <info@arduino.cc>"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+
+[tool.poetry.dev-dependencies]
+yamllint = "^v1.26.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/workflow-templates/assets/check-general-formatting-task/.ecrc
+++ b/workflow-templates/assets/check-general-formatting-task/.ecrc
@@ -1,3 +1,6 @@
 {
-  "Exclude": ["LICENSE.txt"]
+  "Exclude": [
+    "LICENSE.txt",
+    "poetry.lock"
+  ]
 }

--- a/workflow-templates/assets/check-yaml-task/Taskfile.yml
+++ b/workflow-templates/assets/check-yaml-task/Taskfile.yml
@@ -1,0 +1,11 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-yaml-task/Taskfile.yml
+  yaml:lint:
+    desc: Check for problems with YAML files
+    deps:
+      - task: poetry:install-deps
+    cmds:
+      - poetry run yamllint --format {{default "colored" .YAMLLINT_FORMAT}} .

--- a/workflow-templates/assets/check-yaml/.yamllint.yml
+++ b/workflow-templates/assets/check-yaml/.yamllint.yml
@@ -1,0 +1,74 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-yaml/.yamllint.yml
+# See: https://yamllint.readthedocs.io/en/stable/configuration.html
+# The code style defined in this file is the official standardized style to be used in all Arduino tooling projects and
+# should not be modified.
+# Note: Rules disabled solely because they are redundant to Prettier are marked with a "Prettier" comment.
+
+rules:
+  braces:
+    level: error
+    forbid: non-empty
+    min-spaces-inside: -1 # Prettier
+    max-spaces-inside: -1 # Prettier
+    min-spaces-inside-empty: -1 # Prettier
+    max-spaces-inside-empty: -1 # Prettier
+  brackets:
+    level: error
+    forbid: non-empty
+    min-spaces-inside: -1 # Prettier
+    max-spaces-inside: -1 # Prettier
+    min-spaces-inside-empty: -1 # Prettier
+    max-spaces-inside-empty: -1 # Prettier
+  colons: disable # Prettier
+  commas: disable # Prettier
+  comments: disable # Prettier
+  comments-indentation: disable # Prettier
+  document-end: disable # Prettier
+  document-start: disable
+  empty-lines: disable # Prettier
+  empty-values: disable
+  hyphens: disable # Prettier
+  indentation: disable # Prettier
+  key-duplicates: disable # Prettier
+  key-ordering: disable
+  line-length:
+    level: warning
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  new-line-at-end-of-file: disable # Prettier
+  new-lines: disable # Prettier
+  octal-values:
+    level: warning
+    forbid-implicit-octal: true
+    forbid-explicit-octal: false
+  quoted-strings: disable
+  trailing-spaces: disable # Prettier
+  truthy:
+    level: error
+    allowed-values:
+      - "true"
+      - "false"
+      - "on" # Used by GitHub Actions as a workflow key.
+    check-keys: true
+
+yaml-files:
+  # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+  - ".clang-format"
+  - ".clang-tidy"
+  - ".gemrc"
+  - ".yamllint"
+  - "glide.lock"
+  - "*.yml"
+  - "*.mir"
+  - "*.reek"
+  - "*.rviz"
+  - "*.sublime-syntax"
+  - "*.syntax"
+  - "*.yaml"
+  - "*.yaml-tmlanguage"
+  - "*.yaml.sed"
+  - "*.yml.mysql"
+
+ignore: |
+  /.git/

--- a/workflow-templates/assets/shared/Taskfile.yml
+++ b/workflow-templates/assets/shared/Taskfile.yml
@@ -1,0 +1,15 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/shared/Taskfile.yml
+  poetry:install-deps:
+    desc: Install dependencies managed by Poetry
+    cmds:
+      - poetry install --no-root
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/shared/Taskfile.yml
+  poetry:update-deps:
+    desc: Update all dependencies managed by Poetry to their newest versions
+    cmds:
+      - poetry update

--- a/workflow-templates/check-yaml-task.md
+++ b/workflow-templates/check-yaml-task.md
@@ -1,0 +1,83 @@
+# "Check YAML" workflow (Task)
+
+Workflow file: [check-yaml-task.yml](check-yaml-task.yml)
+
+Run [yamllint](https://github.com/adrienverge/yamllint) on the YAML files of the repository.
+
+NOTE: This workflow is focused on linting. Formatting checks for YAML are provided by the ["Check Prettier Formatting" workflow](check-prettier-formatting-task.md), so both should be used.
+
+This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
+
+## Installation
+
+The `yamllint` tool dependency is managed by [Poetry](https://python-poetry.org/).
+
+Install Poetry by following these instructions:<br />
+https://python-poetry.org/docs/#installation
+
+If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
+
+```
+poetry init --python="^3.9" --dev-dependency="yamllint@^1.26.1"
+poetry install
+```
+
+If already using Poetry, add the tool using this command:
+
+```
+poetry add --dev "yamllint@^1.26.1"
+```
+
+Make sure to commit the resulting `pyproject.toml` and `poetry.lock` files.
+
+## Assets
+
+- [.yamllint.yml](assets/check-yaml/.yamllint.yml) - `yamllint` [configuration file](https://yamllint.readthedocs.io/en/stable/configuration.html).
+  - Install to: repository root
+- [`Taskfile.yml`](assets/check-yaml-task/Taskfile.yml] - Linting task.
+  - Install to: repository root (or add the `yaml:lint` task into the existing `Taskfile.yml`)
+- [`Taskfile.yml`](assets/shared/Taskfile.yml] - Installation task.
+  - Add the `poetry:install-deps` task into the existing `Taskfile.yml`
+
+The code style defined in this file is the official standardized style to be used in all Arduino projects and should not be modified.
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Check YAML status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-yaml-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-yaml-task.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-yaml-task.yml/badge.svg["Check YAML status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-yaml-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to lint YAML files
+
+On every push and pull request that affects relevant files, and periodically, run yamllint to check the YAML files of
+the repository for issues.
+
+The .yamllint.yml file is used to configure yamllint:
+https://yamllint.readthedocs.io/en/stable/configuration.html
+```
+
+## PR message
+
+```markdown
+On every push and pull request that affects relevant files, and periodically, run [`yamllint`](https://github.com/adrienverge/yamllint) to check the YAML files of the repository for issues.
+
+The `.yamllint.yml` file is used to configure `yamllint`:
+https://yamllint.readthedocs.io/en/stable/configuration.html
+```

--- a/workflow-templates/check-yaml-task.yml
+++ b/workflow-templates/check-yaml-task.yml
@@ -1,0 +1,81 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-yaml-task.md
+name: Check YAML
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".yamllint*"
+      - "poetry.lock"
+      - "pyproject.toml"
+      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  pull_request:
+    paths:
+      - ".yamllint*"
+      - "poetry.lock"
+      - "pyproject.toml"
+      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    name: ${{ matrix.configuration.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        configuration:
+          - name: Generate problem matcher output
+            # yamllint's "github" output type produces annotated diffs, but is not useful to humans reading the log.
+            format: github
+            # The other matrix job is used to set the result, so this job is configured to always pass.
+            continue-on-error: true
+          - name: Check formatting
+            # yamllint's "colored" output type is most suitable for humans reading the log.
+            format: colored
+            continue-on-error: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check YAML
+        continue-on-error: ${{ matrix.configuration.continue-on-error }}
+        run: task yaml:lint YAMLLINT_FORMAT=${{ matrix.configuration.format }}

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-yaml-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-yaml-task.yml
@@ -1,0 +1,81 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-yaml-task.md
+name: Check YAML
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".yamllint*"
+      - "poetry.lock"
+      - "pyproject.toml"
+      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  pull_request:
+    paths:
+      - ".yamllint*"
+      - "poetry.lock"
+      - "pyproject.toml"
+      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      - "**/.clang-format"
+      - "**/.clang-tidy"
+      - "**/.gemrc"
+      - "**/glide.lock"
+      - "**.ya?ml*"
+      - "**.mir"
+      - "**.reek"
+      - "**.rviz"
+      - "**.sublime-syntax"
+      - "**.syntax"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    name: ${{ matrix.configuration.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        configuration:
+          - name: Generate problem matcher output
+            # yamllint's "github" output type produces annotated diffs, but is not useful to humans reading the log.
+            format: github
+            # The other matrix job is used to set the result, so this job is configured to always pass.
+            continue-on-error: true
+          - name: Check formatting
+            # yamllint's "colored" output type is most suitable for humans reading the log.
+            format: colored
+            continue-on-error: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check YAML
+        continue-on-error: ${{ matrix.configuration.continue-on-error }}
+        run: task yaml:lint YAMLLINT_FORMAT=${{ matrix.configuration.format }}


### PR DESCRIPTION
On every push and pull request that affects relevant files, and periodically, run [`yamllint`](https://github.com/adrienverge/yamllint) to check the YAML files of the repository for issues.

The `.yamllint.yml` file is used to configure `yamllint`:
https://yamllint.readthedocs.io/en/stable/configuration.html