### PR TITLE
Add template workflow to synchronize with shared repository labels

### DIFF
--- a/.github/workflows/check-configs.yml
+++ b/.github/workflows/check-configs.yml
@@ -7,11 +7,15 @@ on:
       - ".github/workflows/check-configs.yml"
       - "Taskfile.ya?ml"
       - "**/dependabot.ya?ml"
+      - "workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json"
+      - "workflow-templates/assets/sync-labels/*.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-configs.yml"
       - "Taskfile.ya?ml"
       - "**/dependabot.ya?ml"
+      - "workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json"
+      - "workflow-templates/assets/sync-labels/*.ya?ml"
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
     - cron: "0 8 * * TUE"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,123 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md
+name: Sync Labels
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/sync-labels.ya?ml"
+      - ".github/label-configuration-files/*.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/sync-labels.ya?ml"
+      - ".github/label-configuration-files/*.ya?ml"
+  schedule:
+    # Run daily at 8 AM UTC to sync with changes to shared label configurations.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+env:
+  CONFIGURATIONS_FOLDER: .github/label-configuration-files
+  CONFIGURATIONS_ARTIFACT: label-configuration-files
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download JSON schema for labels configuration file
+        id: download-schema
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
+          location: ${{ runner.temp }}/label-configuration-schema
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      - name: Validate local labels configuration
+        run: |
+          # See: https://github.com/ajv-validator/ajv-cli#readme
+          ajv validate \
+            -s "${{ steps.download-schema.outputs.file-path }}" \
+            -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
+
+  download:
+    needs: check
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        filename:
+          # Filenames of the shared configurations to apply to the repository in addition to the local configuration.
+          # https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/sync-labels
+          - universal.yml
+
+    steps:
+      - name: Download
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
+
+      - name: Pass configuration files to next job via workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: "*.ya?ml"
+          if-no-files-found: error
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+
+  sync:
+    needs: download
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
+
+      - name: Determine whether to dry run
+        id: dry-run
+        if: >
+          github.event == 'pull_request' ||
+          github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          # Use of this flag in the github-label-sync command will cause it to only check the validity of the
+          # configuration.
+          echo "::set-output name=flag::--dry-run"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download configuration files artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          path: ${{ env.CONFIGURATIONS_FOLDER }}
+
+      - name: Remove unneeded artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+
+      - name: Merge label configuration files
+        run: |
+          # Merge all configuration files
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.{yml,yaml} > "${{ env.MERGED_CONFIGURATION_PATH }}"
+
+      - name: Install github-label-sync
+        run: sudo npm install --global github-label-sync
+
+      - name: Sync labels
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # See: https://github.com/Financial-Times/github-label-sync
+          github-label-sync \
+            --labels "${{ env.MERGED_CONFIGURATION_PATH }}" \
+            ${{ steps.dry-run.outputs.flag }} \
+            ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Check Prettier Formatting status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-prettier-formatting-task.yml)
 [![Check Taskfiles status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-taskfiles.yml)
 [![Check YAML status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-yaml-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-yaml-task.yml)
+[![Sync Labels status](https://github.com/arduino/tooling-project-assets/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/sync-labels.yml)
 
 The [Arduino](https://www.arduino.cc/) Tooling Team's collection of reusable project infrastructure assets.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,6 +49,7 @@ tasks:
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-prettier-formatting-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-taskfiles.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-yaml-task.yml" \
+          "{{.WORKFLOW_TEMPLATES_PATH}}/sync-labels.yml" \
           "{{.WORKFLOWS_PATH}}"
 
   config:sync:
@@ -91,9 +92,12 @@ tasks:
       DEPENDABOT_SCHEMA_PATH:
         sh: mktemp -t dependabot-schema-XXXXXXXXXX.json
       DEPENDABOT_DATA_PATH: "**/dependabot.yml"
+      LABEL_CONFIG_SCHEMA_PATH: workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
+      LABEL_CONFIG_DATA_PATH: "workflow-templates/assets/sync-labels/*.{yml,yaml}"
     cmds:
       - wget --quiet --output-document="{{.DEPENDABOT_SCHEMA_PATH}}" {{.DEPENDABOT_SCHEMA_URL}}
       - npx ajv-cli@{{.AJV_CLI_VERSION}} validate -s "{{.DEPENDABOT_SCHEMA_PATH}}" -d "{{.DEPENDABOT_DATA_PATH}}"
+      - npx ajv-cli validate -s "{{.LABEL_CONFIG_SCHEMA_PATH}}" -d "{{.LABEL_CONFIG_DATA_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
   markdown:lint:

--- a/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
+++ b/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json",
+  "title": "Arduino tooling repository label configuration file JSON schema",
+  "description": "Required structure of the configuration file used to define GitHub issue/PR labels, as well as the standardized format for Arduino's tooling labels. See: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md",
+  "type": "array",
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string",
+        "maxLength": 50,
+        "anyOf": [
+          {
+            "$comment": "Standardized label format",
+            "pattern": "^.+: .+$"
+          },
+          {
+            "$comment": "Allowed exceptions to the standardized format",
+            "enum": ["help wanted"]
+          }
+        ]
+      },
+      "color": {
+        "enum": [
+          "940404",
+          "ff0000",
+          "ffa200",
+          "ffff00",
+          "00ff00",
+          "92a600",
+          "008000",
+          "00ba9e",
+          "00ffff",
+          "0000ff",
+          "800080",
+          "d876e3",
+          "ff00ff",
+          "c0c0c0"
+        ]
+      },
+      "description": {
+        "type": "string",
+        "maxLength": 100
+      },
+      "aliases": {
+        "type": "array"
+      },
+      "notes": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "additionalProperties": false,
+    "required": ["name", "color", "description"]
+  }
+}

--- a/workflow-templates/assets/sync-labels/tooling.yml
+++ b/workflow-templates/assets/sync-labels/tooling.yml
@@ -1,0 +1,21 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/sync-labels/tooling.yml
+# See: https://github.com/Financial-Times/github-label-sync#label-config-file
+
+- name: "os: windows"
+  color: "800080"
+  description: Specific to Windows operating system
+- name: "os: linux"
+  color: "800080"
+  description: Specific to Linux operating system
+- name: "os: macos"
+  color: "800080"
+  description: Specific to macOS operating system
+- name: "architecture: arm"
+  color: ff00ff
+  description: Specific to ARM host architecture
+- name: "topic: security"
+  color: ff0000
+  description: Related to the protection of user data
+  notes: |
+    Vulnerability disclosures are made following the procedure at:
+    https://github.com/arduino/.github/blob/master/SECURITY.md

--- a/workflow-templates/assets/sync-labels/universal.yml
+++ b/workflow-templates/assets/sync-labels/universal.yml
@@ -1,0 +1,96 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/sync-labels/universal.yml
+# See: https://github.com/Financial-Times/github-label-sync#label-config-file
+# Maximum lengths:
+# name: 50
+# description: 100
+
+- name: "conclusion: declined"
+  color: "940404"
+  description: Will not be worked on
+  aliases:
+    - wontfix
+- name: "conclusion: duplicate"
+  color: "ff0000"
+  description: Has already been submitted
+  aliases:
+    - duplicate
+- name: "conclusion: invalid"
+  color: "ff0000"
+  description: Issue/PR not valid
+  aliases:
+    - invalid
+- name: "conclusion: off topic"
+  color: "ff0000"
+  description: Off topic for this repository
+- name: "conclusion: moved"
+  color: "940404"
+  description: Issue/PR moved to another repository
+  notes: |
+    For use when it's not possible to do a true transfer
+    (PRs, different organizations, or maintainer doesn't have write permissions in target repo).
+- name: "conclusion: resolved"
+  color: "00ff00"
+  description: Issue was resolved
+- name: "priority: high"
+  color: "ffa200"
+  description: Resolution is a high priority
+- name: "priority: medium"
+  color: "ffff00"
+  description: Resolution is a medium priority
+- name: "priority: low"
+  color: "c0c0c0"
+  description: Resolution is a low priority
+- name: "status: changes requested"
+  color: "ffa200"
+  description: Changes to PR are required before merge
+- name: "status: in progress"
+  color: "0000ff"
+  description: Work is in progress on this
+- name: "status: on hold"
+  color: "940404"
+  description: Do not proceed at this time
+- name: "status: waiting for information"
+  color: "ffff00"
+  aliases:
+    - Waiting for feedback
+    - waiting for feedback
+  description: More information must be provided before work can proceed
+- name: "status: blocked"
+  color: "940404"
+  description: Progress on this prevented by an external cause
+- name: help wanted
+  color: "ffa200"
+  description: Assistance from the community is especially welcome
+  notes: |
+    Ideally this would be "status: help wanted", but GitHub gives this label special treatment so it's best to leave it
+    stock.
+- name: "topic: infrastructure"
+  color: "00ffff"
+  description: Related to repository infrastructure
+- name: "topic: code"
+  color: "00ffff"
+  description: Related to content of the project itself
+- name: "topic: documentation"
+  color: "00ffff"
+  description: Related to documentation for the project
+  aliases:
+    - documentation
+- name: "type: imperfection"
+  color: "ff0000"
+  description: Perceived defect in any part of project
+  aliases:
+    - bug
+  notes: This includes bugs, but avoids confusion for use in non-code contexts.
+- name: "type: enhancement"
+  color: "008000"
+  description: Proposed improvement
+  aliases:
+    - enhancement
+- name: "type: support"
+  color: "ff0000"
+  description: "OT: Request for help using the project"
+  aliases:
+    - question
+  notes: |
+    All support request issues must be closed as "conclusion: invalid", redirecting the user to the Arduino forum, but
+    it's still useful to label the closed issues and this type doesn't fit into the imperfection/enhancement dichotomy.

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
@@ -1,0 +1,123 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md
+name: Sync Labels
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/sync-labels.ya?ml"
+      - ".github/label-configuration-files/*.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/sync-labels.ya?ml"
+      - ".github/label-configuration-files/*.ya?ml"
+  schedule:
+    # Run daily at 8 AM UTC to sync with changes to shared label configurations.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+env:
+  CONFIGURATIONS_FOLDER: .github/label-configuration-files
+  CONFIGURATIONS_ARTIFACT: label-configuration-files
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download JSON schema for labels configuration file
+        id: download-schema
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
+          location: ${{ runner.temp }}/label-configuration-schema
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      - name: Validate local labels configuration
+        run: |
+          # See: https://github.com/ajv-validator/ajv-cli#readme
+          ajv validate \
+            -s "${{ steps.download-schema.outputs.file-path }}" \
+            -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
+
+  download:
+    needs: check
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        filename:
+          # Filenames of the shared configurations to apply to the repository in addition to the local configuration.
+          # https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/sync-labels
+          - universal.yml
+
+    steps:
+      - name: Download
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
+
+      - name: Pass configuration files to next job via workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: "*.ya?ml"
+          if-no-files-found: error
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+
+  sync:
+    needs: download
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
+
+      - name: Determine whether to dry run
+        id: dry-run
+        if: >
+          github.event == 'pull_request' ||
+          github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          # Use of this flag in the github-label-sync command will cause it to only check the validity of the
+          # configuration.
+          echo "::set-output name=flag::--dry-run"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download configuration files artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          path: ${{ env.CONFIGURATIONS_FOLDER }}
+
+      - name: Remove unneeded artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+
+      - name: Merge label configuration files
+        run: |
+          # Merge all configuration files
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.{yml,yaml} > "${{ env.MERGED_CONFIGURATION_PATH }}"
+
+      - name: Install github-label-sync
+        run: sudo npm install --global github-label-sync
+
+      - name: Sync labels
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # See: https://github.com/Financial-Times/github-label-sync
+          github-label-sync \
+            --labels "${{ env.MERGED_CONFIGURATION_PATH }}" \
+            ${{ steps.dry-run.outputs.flag }} \
+            ${{ github.repository }}

--- a/workflow-templates/sync-labels.md
+++ b/workflow-templates/sync-labels.md
@@ -1,0 +1,87 @@
+# "Sync Labels" workflow
+
+Workflow file: [sync-labels.yml](sync-labels.yml)
+
+Use [github-label-sync](https://github.com/Financial-Times/github-label-sync) to configure the repository's [issue/pull request labels](https://docs.github.com/en/github/managing-your-work-on-github/managing-labels) according to the universal, shared, and local label configuration files.
+
+Use of consistent labels across repositories makes repository maintenance and searching of issue and pull request trackers easier.
+
+Some label definitions in the configuration file contain a `notes` field. This provides additional information about the proper usage of the label when this might not be clear from the label name and description. The `notes` field is purely for documentation purposes and has no effect on the repository labels.
+
+## Non-universal labels
+
+Multiple labels data files can be merged to form the list of labels for the repository. The [universal labels](assets/sync-labels/universal.yml) must be used in all repositories, but some projects will benefit from the addition of other domain-specific labels.
+
+The configuration file structure is documented here: https://github.com/Financial-Times/github-label-sync#label-config-file
+
+Configuration files for labels that are applicable to multiple projects are hosted [here](assets/sync-labels).
+Add the file name to the `jobs.download.strategy.matrix.filename[]` in the workflow.
+
+The configuration file for labels that only apply to the specific project should be located at `.github/label-configuration-files/local.yml`
+
+### Maximum string lengths
+
+Label sync will fail with a `422: Validation Failed` error if a label configuration string exceeds the maximum length.
+
+- `name`: 50
+- `description`: 100
+  - Note: `description` is truncated at ~45 (depending on width) characters in the labeling menu, so make sure the meaning of the label is clear to the maintainer from the visible subset of the description.
+
+### Standardized label colors
+
+These colors have good contrast. When possible, follow the conventions established in the universal labels for the general meaning associated the colors.
+
+- `#940404`
+- `#ff0000`
+- `#ffa200`
+- `#ffff00`
+- `#00ff00`
+- `#92a600`
+- `#008000`
+- `#00ba9e`
+- `#00ffff`
+- `#0000ff`
+- `#800080`
+- `#d876e3`
+- `#ff00ff`
+- `#c0c0c0`
+
+#### Notes
+
+- Remove the `#` from the hex color code before adding it to the `color` field of the labels definition file.
+- Black and white should not be used due to lacking contrast with the GitHub page background colors (light and dark themes).
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Sync Labels status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/sync-labels.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/sync-labels.yml/badge.svg["Sync Labels status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/sync-labels.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to synchronize with shared repository labels
+
+On every push that changes relevant files, and periodically, configure the repository's issue and pull request labels
+according to the universal, shared, and local label configuration files.
+```
+
+## PR message
+
+```markdown
+On every push that changes relevant files, and periodically, use [github-label-sync](https://github.com/Financial-Times/github-label-sync) to configure the repository's issue/PR labels according to the universal, shared, and local label configuration files.
+```

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -1,0 +1,123 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md
+name: Sync Labels
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/sync-labels.ya?ml"
+      - ".github/label-configuration-files/*.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/sync-labels.ya?ml"
+      - ".github/label-configuration-files/*.ya?ml"
+  schedule:
+    # Run daily at 8 AM UTC to sync with changes to shared label configurations.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+env:
+  CONFIGURATIONS_FOLDER: .github/label-configuration-files
+  CONFIGURATIONS_ARTIFACT: label-configuration-files
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download JSON schema for labels configuration file
+        id: download-schema
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
+          location: ${{ runner.temp }}/label-configuration-schema
+
+      - name: Install JSON schema validator
+        run: sudo npm install --global ajv-cli
+
+      - name: Validate local labels configuration
+        run: |
+          # See: https://github.com/ajv-validator/ajv-cli#readme
+          ajv validate \
+            -s "${{ steps.download-schema.outputs.file-path }}" \
+            -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
+
+  download:
+    needs: check
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        filename:
+          # Filenames of the shared configurations to apply to the repository in addition to the local configuration.
+          # https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/sync-labels
+          - universal.yml
+
+    steps:
+      - name: Download
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
+
+      - name: Pass configuration files to next job via workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: "*.ya?ml"
+          if-no-files-found: error
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+
+  sync:
+    needs: download
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
+
+      - name: Determine whether to dry run
+        id: dry-run
+        if: >
+          github.event == 'pull_request' ||
+          github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          # Use of this flag in the github-label-sync command will cause it to only check the validity of the
+          # configuration.
+          echo "::set-output name=flag::--dry-run"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download configuration files artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          path: ${{ env.CONFIGURATIONS_FOLDER }}
+
+      - name: Remove unneeded artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+
+      - name: Merge label configuration files
+        run: |
+          # Merge all configuration files
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.{yml,yaml} > "${{ env.MERGED_CONFIGURATION_PATH }}"
+
+      - name: Install github-label-sync
+        run: sudo npm install --global github-label-sync
+
+      - name: Sync labels
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # See: https://github.com/Financial-Times/github-label-sync
+          github-label-sync \
+            --labels "${{ env.MERGED_CONFIGURATION_PATH }}" \
+            ${{ steps.dry-run.outputs.flag }} \
+            ${{ github.repository }}


### PR DESCRIPTION
On every push that changes relevant files, and periodically, configure the repository's issue and pull request labels
according to the universal, shared, and local label configuration files.

### Notes

- The workflow will fail due to being unable to download the bespoke JSON schema hosted here until the repository has been transferred to the `arduino` organization and made public.