### PR TITLE
Add template workflow to test Go code

### DIFF
--- a/workflow-templates/assets/test-go-task/Taskfile.yml
+++ b/workflow-templates/assets/test-go-task/Taskfile.yml
@@ -1,0 +1,20 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+vars:
+  DEFAULT_GO_PACKAGES:
+    sh: echo $(go list ./... | tr '\n' ' ')
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
+  go:test:
+    desc: Run unit tests
+    cmds:
+      - |
+        go test \
+          -v \
+          -short \
+          -run '{{default ".*" .GO_TEST_REGEX}}' \
+          {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} \
+          -coverprofile=coverage_unit.txt \
+          {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -1,0 +1,75 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/test-go-task.md
+name: Test Go
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/test-go-task.ya?ml"
+      - "go.mod"
+      - "go.sum"
+      - "Taskfile.ya?ml"
+      - "**.go"
+      - "**/testdata/**"
+  pull_request:
+    paths:
+      - ".github/workflows/test-go-task.ya?ml"
+      - "go.mod"
+      - "go.sum"
+      - "Taskfile.ya?ml"
+      - "**.go"
+      - "**/testdata/**"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Build application
+        run: task go:build
+
+      # Allow interested parties to easily try the build
+      - name: Save binary as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          # TODO: specify binary name here:
+          path: BINARY_NAME
+          name: BINARY_NAME
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Run tests
+        run: task go:test

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -1,0 +1,56 @@
+# "Test Go" workflow (Task)
+
+Workflow file: [test-go-task.yml](test-go-task.yml)
+
+Lint and check formatting of a [Go](https://golang.org/) module.
+
+This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
+
+## Assets
+
+- [`Taskfile.yml`](assets/test-go-task/Taskfile.yml]
+  - Install to: repository root (or add the `go:test` task into the existing `Taskfile.yml`)
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Test Go status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-go-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-go-task.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/test-go-task.yml/badge.svg["Test Go status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/test-go-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to test Go code
+
+On every push and pull request that affects relevant files:
+
+- Build the project.
+- Upload the binary as a workflow artifact to allow interested parties to try it out without needing to build it
+  themselves.
+- Run the project's Go code tests.
+```
+
+## PR message
+
+```markdown
+On every push and pull request that affects relevant files:
+
+- Build the project.
+- Upload the binary as a workflow artifact to allow interested parties to try it out without needing to build it
+  themselves.
+- Run the project's [Golang](https://golang.org/) code tests.
+```

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -1,0 +1,75 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/test-go-task.md
+name: Test Go
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/test-go-task.ya?ml"
+      - "go.mod"
+      - "go.sum"
+      - "Taskfile.ya?ml"
+      - "**.go"
+      - "**/testdata/**"
+  pull_request:
+    paths:
+      - ".github/workflows/test-go-task.ya?ml"
+      - "go.mod"
+      - "go.sum"
+      - "Taskfile.ya?ml"
+      - "**.go"
+      - "**/testdata/**"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Build application
+        run: task go:build
+
+      # Allow interested parties to easily try the build
+      - name: Save binary as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          # TODO: specify binary name here:
+          path: BINARY_NAME
+          name: BINARY_NAME
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Run tests
+        run: task go:test


### PR DESCRIPTION
On every push and pull request that affects relevant files:

- Build the project.
- Upload the binary as a workflow artifact to allow interested parties to try it out without needing to build it
  themselves.
- Run the project's Go code tests.