### PR TITLE
Add template workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = licence,ot
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =
+skip = ./.git,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -1,0 +1,37 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Spell check
+        run: task general:check-spelling

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Check YAML status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-yaml-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-yaml-task.yml)
 [![Sync Labels status](https://github.com/arduino/tooling-project-assets/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/sync-labels.yml)
 [![Check Workflows status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-workflows-task.yml)
+[![Spell Check status](https://github.com/arduino/tooling-project-assets/actions/workflows/spell-check-task.yml/badge.svg)](https:/github.com/arduino/tooling-project-assets/actions/workflows/spell-check-task.yml)
 
 The [Arduino](https://www.arduino.cc/) Tooling Team's collection of reusable project infrastructure assets.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,12 +9,14 @@ tasks:
       - task: dependabot:sync
       - task: markdown:fix
       - task: general:format-prettier
+      - task: general:correct-spelling
 
   check:
     desc: Check for problems with the project
     deps:
       - task: general:check-formatting
       - task: ci:validate
+      - task: general:check-spelling
       - task: config:validate
       - task: markdown:lint
       - task: markdown:check-links
@@ -37,6 +39,22 @@ tasks:
         fi
       - ec
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
+  general:check-spelling:
+    desc: Check for commonly misspelled words
+    deps:
+      - task: poetry:install-deps
+    cmds:
+      - poetry run codespell
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
+  general:correct-spelling:
+    desc: Correct commonly misspelled words where possible
+    deps:
+      - task: poetry:install-deps
+    cmds:
+      - poetry run codespell --write-changes
+
   ci:sync:
     desc: Sync CI workflows from templates
     vars:
@@ -51,6 +69,7 @@ tasks:
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-taskfiles.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-yaml-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/sync-labels.yml" \
+          "{{.WORKFLOW_TEMPLATES_PATH}}/spell-check-task.yml" \
           "{{.WORKFLOWS_PATH}}"
 
   config:sync:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,16 @@
 [[package]]
+name = "codespell"
+version = "2.1.0"
+description = "Codespell"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["check-manifest", "flake8", "pytest", "pytest-cov", "pytest-dependency"]
+hard-encoding-detection = ["chardet"]
+
+[[package]]
 name = "pathspec"
 version = "0.8.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -29,9 +41,13 @@ pyyaml = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "9838d42b2ca063f9677efc32dac655df06d0947f2520111fd1ab33f981e0d5e9"
+content-hash = "d764f8a629313b99f0f4b02c289111392adbfc663389069dde0511a2f6380cdb"
 
 [metadata.files]
+codespell = [
+    {file = "codespell-2.1.0-py3-none-any.whl", hash = "sha256:b864c7d917316316ac24272ee992d7937c3519be4569209c5b60035ac5d569b5"},
+    {file = "codespell-2.1.0.tar.gz", hash = "sha256:19d3fe5644fef3425777e66f225a8c82d39059dcfe9edb3349a8a2cf48383ee5"},
+]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.9"
 
 [tool.poetry.dev-dependencies]
 yamllint = "^v1.26.1"
+codespell = "^2.1.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/workflow-templates/assets/spell-check-task/Taskfile.yml
+++ b/workflow-templates/assets/spell-check-task/Taskfile.yml
@@ -1,0 +1,19 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
+  general:check-spelling:
+    desc: Check for commonly misspelled words
+    deps:
+      - task: poetry:install-deps
+    cmds:
+      - poetry run codespell
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
+  general:correct-spelling:
+    desc: Correct commonly misspelled words where possible
+    deps:
+      - task: poetry:install-deps
+    cmds:
+      - poetry run codespell --write-changes

--- a/workflow-templates/assets/spell-check/.codespellrc
+++ b/workflow-templates/assets/spell-check/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =
+skip = ./.git,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/spell-check-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/spell-check-task.yml
@@ -1,0 +1,37 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Spell check
+        run: task general:check-spelling

--- a/workflow-templates/spell-check-task.md
+++ b/workflow-templates/spell-check-task.md
@@ -1,0 +1,79 @@
+# "Spell Check" workflow (Task)
+
+Workflow file: [spell-check-task.yml](spell-check-task.yml)
+
+Use [codespell](https://github.com/codespell-project/codespell) to check for commonly misspelled words in the repository files.
+
+This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
+
+## Installation
+
+The `codespell` tool dependency is managed by [Poetry](https://python-poetry.org/).
+
+Install Poetry by following these instructions:<br />
+https://python-poetry.org/docs/#installation
+
+If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
+
+```
+poetry init --python="^3.9" --dev-dependency="codespell@^2.1.0"
+poetry install
+```
+
+If already using Poetry, add the tool using this command:
+
+```
+poetry add --dev "codespell@^2.1.0"
+```
+
+Make sure to commit the resulting `pyproject.toml` and `poetry.lock` files.
+
+## Assets
+
+- [.codespellrc](assets/spell-check/.codespellrc) - codespell configuration file.
+  - Install to: repository root
+- [`Taskfile.yml`](assets/spell-check-task/Taskfile.yml] - spell check and spelling correction tasks.
+  - Install to: repository root (or add the `general:general:check-spelling` and `general:correct-spelling` tasks into the existing `Taskfile.yml`)
+- [`Taskfile.yml`](assets/shared/Taskfile.yml] - Installation task.
+  - Add the `poetry:install-deps` task into the existing `Taskfile.yml`
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Spell Check status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/spell-check-task.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check-task.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to check for commonly misspelled words
+
+On every push, pull request, and periodically, use the codespell to check for commonly
+misspelled words.
+
+In the event of a false positive, the problematic word should be added, in all lowercase, to the ignore-words-list field
+of ./.codespellrc. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore
+list. The ignore list is comma-separated with no spaces.
+```
+
+## PR message
+
+```markdown
+On every push, pull request, and periodically, use [codespell](https://github.com/codespell-project/codespell) to check for commonly misspelled words.
+
+In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.
+```

--- a/workflow-templates/spell-check-task.yml
+++ b/workflow-templates/spell-check-task.yml
@@ -1,0 +1,37 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Spell check
+        run: task general:check-spelling


### PR DESCRIPTION
On every push, pull request, and periodically, use [codespell](https://github.com/codespell-project/codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.

The workflow is also used in this repository's own CI.