### PR TITLE
Add template workflow to lint and check formatting of Python files

### DIFF
--- a/workflow-templates/assets/check-python-task/Taskfile.yml
+++ b/workflow-templates/assets/check-python-task/Taskfile.yml
@@ -1,0 +1,19 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-python-task/Taskfile.yml
+  python:lint:
+    desc: Lint Python code
+    deps:
+      - task: poetry:install-deps
+    cmds:
+      - poetry run flake8 --show-source
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-python-task/Taskfile.yml
+  python:format:
+    desc: Format Python files
+    deps:
+      - task: poetry:install-deps
+    cmds:
+      - poetry run black .

--- a/workflow-templates/assets/check-python/.flake8
+++ b/workflow-templates/assets/check-python/.flake8
@@ -1,0 +1,12 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-python/.flake8
+# See: https://flake8.pycqa.org/en/latest/user/configuration.html
+# The code style defined in this file is the official standardized style to be used in all Arduino tooling projects and
+# should not be modified.
+
+[flake8]
+doctests = True
+# W503 and W504 are mutually exclusive. PEP 8 recommends line break before.
+ignore = W503
+max-complexity = 10
+max-line-length = 120
+select = E,W,F,C,N

--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -1,0 +1,98 @@
+# "Check Python" workflow (Task)
+
+Workflow file: [check-python-task.yml](check-python-task.yml)
+
+Run [flake8](https://flake8.pycqa.org/) and [black](https://github.com/psf/black) on the Python files of the repository.
+
+This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
+
+## Installation
+
+### 1. Add configuration files
+
+Copy the configuration files listed in the [**Assets**](#assets) section below into the project's repository.
+
+If the project already contains a [`pyproject.toml`](https://www.python.org/dev/peps/pep-0518/) file, then merge them.
+
+### 2. Install tool dependencies
+
+The tool dependencies of this workflow are managed by [Poetry](https://python-poetry.org/).
+
+Install Poetry by following these instructions:<br />
+https://python-poetry.org/docs/#installation
+
+If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
+
+```
+poetry init --python="^3.9" --dev-dependency="black@^21.5b0" --dev-dependency="flake8@^3.9.2" --dev-dependency="pep8-naming@^0.11.1"
+poetry install
+```
+
+If already using Poetry, add the tool using this command:
+
+```
+poetry add --dev "black@^21.5b0" "flake8@^3.9.2" "pep8-naming@^0.11.1"
+```
+
+Make sure to commit the resulting `pyproject.toml` and `poetry.lock` files.
+
+### 3. Configuration
+
+Add the following to `pyproject.toml`:
+
+```toml
+[tool.black]
+line-length = 120
+```
+
+## Assets
+
+- [`.flake8`](assets/check-python/.flake8) - flake8 configuration file.
+  - Install to: repository root
+- [`Taskfile.yml`](assets/check-python-task/Taskfile.yml] - Python linting and formatting tasks.
+  - Install to: repository root (or add the tasks into the existing `Taskfile.yml`)
+- [`Taskfile.yml`](assets/shared/Taskfile.yml] - Installation task.
+  - Add the `poetry:install-deps` task into the existing `Taskfile.yml`
+
+The code style defined in `pyproject.toml` and `.flake8` is the official standardized style to be used in all Arduino tooling projects and should not be modified.
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Check Python status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-python-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-python-task.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-python-task.yml/badge.svg["Check Python status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-python-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to lint and check formatting of Python files
+
+On every push and pull request that affects relevant files, and periodically, run flake8 to check the Python files of
+the repository for issues and black to check formatting.
+
+The .flake8 file is used to configure flake8:
+https://flake8.pycqa.org/en/latest/user/configuration.html
+```
+
+## PR message
+
+```markdown
+On every push and pull request that affects relevant files, and periodically, run [`flake8`](https://flake8.pycqa.org/) to check the Python files of the repository for issues and [black](https://github.com/psf/black) to check formatting.
+
+The `.flake8` file is used to configure `flake8`:
+https://flake8.pycqa.org/en/latest/user/configuration.html
+```

--- a/workflow-templates/check-python-task.yml
+++ b/workflow-templates/check-python-task.yml
@@ -1,0 +1,79 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-python-task.md
+name: Check Python
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-python-task.ya?ml"
+      - "**/.flake8"
+      - "**/poetry.lock"
+      - "**/pyproject.toml"
+      - "**/setup.cfg"
+      - "Taskfile.ya?ml"
+      - "**/tox.ini"
+      - "**.py"
+  pull_request:
+    paths:
+      - ".github/workflows/check-python-task.ya?ml"
+      - "**/.flake8"
+      - "**/poetry.lock"
+      - "**/pyproject.toml"
+      - "**/setup.cfg"
+      - "Taskfile.ya?ml"
+      - "**/tox.ini"
+      - "**.py"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Run flake8
+        run: task python:lint
+
+  formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Format Python code
+        run: task python:format
+
+      - name: Check formatting
+        run: git diff --color --exit-code

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
@@ -1,0 +1,79 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-python-task.md
+name: Check Python
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-python-task.ya?ml"
+      - "**/.flake8"
+      - "**/poetry.lock"
+      - "**/pyproject.toml"
+      - "**/setup.cfg"
+      - "Taskfile.ya?ml"
+      - "**/tox.ini"
+      - "**.py"
+  pull_request:
+    paths:
+      - ".github/workflows/check-python-task.ya?ml"
+      - "**/.flake8"
+      - "**/poetry.lock"
+      - "**/pyproject.toml"
+      - "**/setup.cfg"
+      - "Taskfile.ya?ml"
+      - "**/tox.ini"
+      - "**.py"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Run flake8
+        run: task python:lint
+
+  formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Format Python code
+        run: task python:format
+
+      - name: Check formatting
+        run: git diff --color --exit-code


### PR DESCRIPTION
On every push and pull request that affects relevant files, and periodically, run [`flake8`](https://flake8.pycqa.org/) to check the Python files of the repository for issues and [black](https://github.com/psf/black) to check formatting.

The `.flake8` file is used to configure `flake8`:
https://flake8.pycqa.org/en/latest/user/configuration.html