### PR TITLE
Correct workflow name text in "Deploy Website" workflow's badge markup

### DIFF
--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -40,7 +40,7 @@ Make sure to commit the resulting `pyproject.toml` and `poetry.lock` files.
 Markdown badge:
 
 ```markdown
-[![Deploy MkDocs Website status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-mkdocs-poetry.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-mkdocs-poetry.yml)
+[![Deploy Website status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-mkdocs-poetry.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-mkdocs-poetry.yml)
 ```
 
 Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
@@ -50,7 +50,7 @@ Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final
 Asciidoc badge:
 
 ```adoc
-image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/deploy-mkdocs-poetry.yml/badge.svg["Deploy MkDocs Website status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/deploy-mkdocs-poetry.yml"]
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/deploy-mkdocs-poetry.yml/badge.svg["Deploy Website status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/deploy-mkdocs-poetry.yml"]
 ```
 
 Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).


### PR DESCRIPTION
The text in the badge markup should match the workflow's name.