### PR TITLE
Remove/replace links to non-existent templates in "Deploy Website" (M…

### DIFF
--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -71,8 +71,4 @@ On every push to the repository's default branch, deploy the repository's [MkDoc
 
 ## Related
 
-- ["Check MkDocs Website" workflow](check-mkdocs.md)
-- ["Check Markdown" workflow](check-markdown.md)
-- ["Check Prettier Formatting" workflow](check-prettier-formatting.md)
-- ["Spell Check" workflow](spell-check.md)
-- ["Check YAML" workflow](check-yaml.md)
+- ["Check Website" workflow](check-mkdocs-task.md)


### PR DESCRIPTION
…kDocs, Poetry) template

This was a copy/paste error that came from the original workflow templates repository. While working on that project, I
found that properly maintaining the "Related" lists during development was difficult. I think it's better to add them in
once the collection has stabilized, or perhaps not at all?