### PR TITLE
Strip newline from Go build task's LDFLAGS value

### DIFF
--- a/workflow-templates/assets/release-go-task/Taskfile.yml
+++ b/workflow-templates/assets/release-go-task/Taskfile.yml
@@ -18,7 +18,7 @@ vars:
   TAG:
     sh: echo "`git tag --points-at=HEAD 2> /dev/null | head -n1`"
   VERSION: "{{ if .NIGHTLY }}nightly-{{ .TIMESTAMP_SHORT }}{{ else if .TAG }}{{ .TAG }}{{ else }}{{ .PACKAGE_NAME_PREFIX }}git-snapshot{{ end }}"
-  LDFLAGS: >
+  LDFLAGS: >-
     -ldflags
     '
     -X github.com/arduino/arduino-cli/version.versionString={{.VERSION}}


### PR DESCRIPTION
The default behavior of the YAML folded block style is to have a final newline. Even though it seems to work fine as-is,
since this variable defines a flag used in a command, it is more appropriate to not have a newline. This is achieved by
adding[ the "strip chomping indicator"](https://yaml.org/spec/1.2/spec.html#id2794534).

This is the way it is configured in Arduino Lint, where it is working nicely:
https://github.com/arduino/arduino-lint/blob/5ef264939ff22a4a825df2e44acdd5033dd16e00/Taskfile.yml#L281