### PR TITLE
Remove fork filter conditional from Go nightly build workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   create-nightly-artifacts:
-    # This workflow is only of value to the arduino/arduino-cli repository and
-    # would always fail in forks
-    if: github.repository == 'arduino/arduino-cli'
     runs-on: ubuntu-latest
 
     steps:

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   create-nightly-artifacts:
-    # This workflow is only of value to the arduino/arduino-cli repository and
-    # would always fail in forks
-    if: github.repository == 'arduino/arduino-cli'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This conditional was intended to prevent the workflow from causing confusion and annoyance to contributors with no need
or interest in publishing a nightly build as it failed daily in their forks due to the necessary secrets not having been
defined.

Since the time this was added to the workflow, GitHub Actions has been changed so that, even after enabling workflows
globally, scheduled workflows are disabled in forks. The forker must manually enable each scheduled workflow. I think
that the sort of contributor who is savvy enough to enable workflows is also savvy enough to understand from the workflow
name that it does not apply to their fork and skip enabling it. Even if they did accidentally enable it, they will
remember doing so when the workflow fails later that day.