### PR TITLE
Do a shallow checkout of repository in nightly Go build workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1


### PR DESCRIPTION
The previous configuration caused a full checkout of the repository. This likely originated as a copy/paste from the Go
release workflow. It is required in that workflow to allow the generation of the changelog from the commit history, but
it is not needed in the nightly, which does not get a changelog.