### PR TITLE
Quote all paths in Go release workflows

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -78,10 +78,10 @@ jobs:
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x dist/arduino-cli_osx_darwin_amd64/arduino-cli
+          chmod +x "dist/arduino-cli_osx_darwin_amd64/arduino-cli"
           PACKAGE_FILENAME="$(basename dist/arduino-cli_nightly-*_macOS_64bit.tar.gz)"
           tar -czvf "dist/$PACKAGE_FILENAME" \
-          -C dist/arduino-cli_osx_darwin_amd64/  arduino-cli   \
+          -C "dist/arduino-cli_osx_darwin_amd64/" "arduino-cli" \
           -C ../../ LICENSE.txt
           CLI_CHECKSUM="$(shasum -a 256 "dist/$PACKAGE_FILENAME" | cut -d " " -f 1)"
           perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CLI_CHECKSUM}  ${PACKAGE_FILENAME}/g;" dist/*-checksums.txt

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -64,7 +64,7 @@ jobs:
           security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
           security default-keychain -s "${{ env.KEYCHAIN }}"
           security unlock-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
-          security import "${{ env.INSTALLER_CERT_MAC_PATH }}" -k "${{ env.KEYCHAIN }}" -f pkcs12 -A -T /usr/bin/codesign -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+          security import "${{ env.INSTALLER_CERT_MAC_PATH }}" -k "${{ env.KEYCHAIN }}" -f pkcs12 -A -T "/usr/bin/codesign" -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
           security set-key-partition-list -S apple-tool:,apple: -s -k "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
 
       - name: Install gon for code signing and app notarization

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -78,10 +78,10 @@ jobs:
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x dist/arduino-cli_osx_darwin_amd64/arduino-cli
+          chmod +x "dist/arduino-cli_osx_darwin_amd64/arduino-cli"
           PACKAGE_FILENAME="$(basename dist/arduino-cli_nightly-*_macOS_64bit.tar.gz)"
           tar -czvf "dist/$PACKAGE_FILENAME" \
-          -C dist/arduino-cli_osx_darwin_amd64/  arduino-cli   \
+          -C "dist/arduino-cli_osx_darwin_amd64/" "arduino-cli" \
           -C ../../ LICENSE.txt
           CLI_CHECKSUM="$(shasum -a 256 "dist/$PACKAGE_FILENAME" | cut -d " " -f 1)"
           perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CLI_CHECKSUM}  ${PACKAGE_FILENAME}/g;" dist/*-checksums.txt

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -64,7 +64,7 @@ jobs:
           security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
           security default-keychain -s "${{ env.KEYCHAIN }}"
           security unlock-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
-          security import "${{ env.INSTALLER_CERT_MAC_PATH }}" -k "${{ env.KEYCHAIN }}" -f pkcs12 -A -T /usr/bin/codesign -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+          security import "${{ env.INSTALLER_CERT_MAC_PATH }}" -k "${{ env.KEYCHAIN }}" -f pkcs12 -A -T "/usr/bin/codesign" -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
           security set-key-partition-list -S apple-tool:,apple: -s -k "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
 
       - name: Install gon for code signing and app notarization


### PR DESCRIPTION
Even though they are not necessary, it is best practices to quote paths. Since the paths in the workflow use the project
name, it might be that quoting is necessary for a specific project.