### PR TITLE
Remove project-specific configuration from MkDocs configuration template

### DIFF
--- a/workflow-templates/assets/mkdocs/mkdocs.yml
+++ b/workflow-templates/assets/mkdocs/mkdocs.yml
@@ -34,7 +34,7 @@ markdown_extensions:
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
       emoji_index: !!python/name:pymdownx.emoji.twemoji
   - pymdownx.magiclink:
-      repo: contributor-guide
+      repo:
       repo_url_shorthand: true
       user: arduino
   - pymdownx.superfences


### PR DESCRIPTION
The template is intended to leave all fields that must be configured per-project empty. This one was missed while I was
cleaning out the source file.