### PR TITLE
Fail Go release template workflows if artifact source files not found

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
+          if-no-files-found: error
           name: dist
           path: dist
 
@@ -89,6 +90,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
+          if-no-files-found: error
           name: dist
           path: dist
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
+          if-no-files-found: error
           name: dist
           path: dist
 
@@ -97,6 +98,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
+          if-no-files-found: error
           name: dist
           path: dist
 

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
+          if-no-files-found: error
           name: dist
           path: dist
 
@@ -89,6 +90,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
+          if-no-files-found: error
           name: dist
           path: dist
 

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
+          if-no-files-found: error
           name: dist
           path: dist
 
@@ -97,6 +98,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
+          if-no-files-found: error
           name: dist
           path: dist
 


### PR DESCRIPTION
The `actions/upload-artifact` action's [default behavior](https://github.com/actions/upload-artifact#customization-if-no-files-are-found) is to only issue a warning if no files are found at the path.
In these usages of the action, the absence of the files which are intended to be uploaded to a workflow artifact
indicates that something has gone horribly wrong. For this reason, the workflow should be configured to fail immediately
if this occurs.