### PR TITLE
Bring taskfiles into compliance with the official styleguide

### DIFF
--- a/workflow-templates/assets/release-go-task/DistTasks.yml
+++ b/workflow-templates/assets/release-go-task/DistTasks.yml
@@ -20,7 +20,7 @@ version: "3"
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
   GO_VERSION: "1.14.7"
-  CHECKSUM_FILE: "{{ .VERSION }}-checksums.txt"
+  CHECKSUM_FILE: "{{.VERSION}}-checksums.txt"
 
 tasks:
   all:
@@ -37,176 +37,176 @@ tasks:
 
   Windows_32bit:
     desc: Builds Windows 32 bit binaries
-    dir: "{{ .DIST_DIR }}"
+    dir: "{{.DIST_DIR}}"
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
-        {{ .CONTAINER }}:{{ .CONTAINER_TAG }} \
-        --build-cmd "{{ .BUILD_COMMAND }}" \
-        -p "{{ .BUILD_PLATFORM }}"
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
 
-        zip {{ .PACKAGE_NAME}} {{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe ../LICENSE.txt -j
-        sha256sum {{ .PACKAGE_NAME }} >> {{ .CHECKSUM_FILE }}
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
+        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
-      PLATFORM_DIR: "{{ .PROJECT_NAME }}_windows_386"
-      BUILD_COMMAND: "go build -o {{ .DIST_DIR }}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe {{ .LDFLAGS }}"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}"
       BUILD_PLATFORM: "windows/386"
-      CONTAINER_TAG: "{{ .GO_VERSION }}-main"
+      CONTAINER_TAG: "{{.GO_VERSION}}-main"
       PACKAGE_PLATFORM: "Windows_32bit"
-      PACKAGE_NAME: "{{ .PROJECT_NAME }}_{{ .VERSION }}_{{ .PACKAGE_PLATFORM }}.zip"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
 
   Windows_64bit:
     desc: Builds Windows 64 bit binaries
-    dir: "{{ .DIST_DIR }}"
+    dir: "{{.DIST_DIR}}"
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
-        {{ .CONTAINER }}:{{ .CONTAINER_TAG }} \
-        --build-cmd "{{ .BUILD_COMMAND }}" \
-        -p "{{ .BUILD_PLATFORM }}"
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
 
-        zip {{ .PACKAGE_NAME}} {{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe ../LICENSE.txt -j
-        sha256sum {{ .PACKAGE_NAME }} >> {{ .CHECKSUM_FILE }}
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
+        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
-      PLATFORM_DIR: "{{ .PROJECT_NAME }}_windows_amd64"
-      BUILD_COMMAND: "go build -o {{ .DIST_DIR }}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe {{ .LDFLAGS }}"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_amd64"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}"
       BUILD_PLATFORM: "windows/amd64"
-      CONTAINER_TAG: "{{ .GO_VERSION }}-main"
+      CONTAINER_TAG: "{{.GO_VERSION}}-main"
       PACKAGE_PLATFORM: "Windows_64bit"
-      PACKAGE_NAME: "{{ .PROJECT_NAME }}_{{ .VERSION }}_{{ .PACKAGE_PLATFORM }}.zip"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
 
   Linux_32bit:
     desc: Builds Linux 32 bit binaries
-    dir: "{{ .DIST_DIR }}"
+    dir: "{{.DIST_DIR}}"
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
-        {{ .CONTAINER }}:{{ .CONTAINER_TAG }} \
-        --build-cmd "{{ .BUILD_COMMAND }}" \
-        -p "{{ .BUILD_PLATFORM }}"
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -C ../.. LICENSE.txt  -f {{ .PACKAGE_NAME }}
-        sha256sum {{ .PACKAGE_NAME }} >> {{ .CHECKSUM_FILE }}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
-      PLATFORM_DIR: "{{ .PROJECT_NAME }}_linux_amd32"
-      BUILD_COMMAND: "go build -o {{ .DIST_DIR }}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{ .LDFLAGS }}"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/386"
-      CONTAINER_TAG: "{{ .GO_VERSION }}-main"
+      CONTAINER_TAG: "{{.GO_VERSION}}-main"
       PACKAGE_PLATFORM: "Linux_32bit"
-      PACKAGE_NAME: "{{ .PROJECT_NAME }}_{{ .VERSION }}_{{ .PACKAGE_PLATFORM }}.tar.gz"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   Linux_64bit:
     desc: Builds Linux 64 bit binaries
-    dir: "{{ .DIST_DIR }}"
+    dir: "{{.DIST_DIR}}"
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
-        {{ .CONTAINER }}:{{ .CONTAINER_TAG }} \
-        --build-cmd "{{ .BUILD_COMMAND }}" \
-        -p "{{ .BUILD_PLATFORM }}"
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -C ../.. LICENSE.txt  -f {{ .PACKAGE_NAME }}
-        sha256sum {{ .PACKAGE_NAME }} >> {{ .CHECKSUM_FILE }}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
-      PLATFORM_DIR: "{{ .PROJECT_NAME }}_linux_amd64"
-      BUILD_COMMAND: "go build -o {{ .DIST_DIR }}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{ .LDFLAGS }}"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd64"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/amd64"
-      CONTAINER_TAG: "{{ .GO_VERSION }}-main"
+      CONTAINER_TAG: "{{.GO_VERSION}}-main"
       PACKAGE_PLATFORM: "Linux_64bit"
-      PACKAGE_NAME: "{{ .PROJECT_NAME }}_{{ .VERSION }}_{{ .PACKAGE_PLATFORM }}.tar.gz"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   Linux_ARMv7:
     desc: Builds Linux ARMv7 binaries
-    dir: "{{ .DIST_DIR }}"
+    dir: "{{.DIST_DIR}}"
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
-        {{ .CONTAINER }}:{{ .CONTAINER_TAG }} \
-        --build-cmd "{{ .BUILD_COMMAND }}" \
-        -p "{{ .BUILD_PLATFORM }}"
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -C ../.. LICENSE.txt  -f {{ .PACKAGE_NAME }}
-        sha256sum {{ .PACKAGE_NAME }} >> {{ .CHECKSUM_FILE }}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
-      PLATFORM_DIR: "{{ .PROJECT_NAME }}_linux_arm_7"
-      BUILD_COMMAND: "go build -o {{ .DIST_DIR }}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{ .LDFLAGS }}"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/armv7"
-      CONTAINER_TAG: "{{ .GO_VERSION }}-arm"
+      CONTAINER_TAG: "{{.GO_VERSION}}-arm"
       PACKAGE_PLATFORM: "Linux_ARMv7"
-      PACKAGE_NAME: "{{ .PROJECT_NAME }}_{{ .VERSION }}_{{ .PACKAGE_PLATFORM }}.tar.gz"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   Linux_ARMv6:
     desc: Builds Linux ARMv6 binaries
-    dir: "{{ .DIST_DIR }}"
+    dir: "{{.DIST_DIR}}"
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
-        {{ .CONTAINER }}:{{ .CONTAINER_TAG }} \
-        --build-cmd "{{ .BUILD_COMMAND }}" \
-        -p "{{ .BUILD_PLATFORM }}"
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -C ../.. LICENSE.txt  -f {{ .PACKAGE_NAME }}
-        sha256sum {{ .PACKAGE_NAME }} >> {{ .CHECKSUM_FILE }}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
-      PLATFORM_DIR: "{{ .PROJECT_NAME }}_linux_arm_6"
-      BUILD_COMMAND: "go build -o {{ .DIST_DIR }}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{ .LDFLAGS }}"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/armv6"
-      CONTAINER_TAG: "{{ .GO_VERSION }}-arm"
+      CONTAINER_TAG: "{{.GO_VERSION}}-arm"
       PACKAGE_PLATFORM: "Linux_ARMv6"
-      PACKAGE_NAME: "{{ .PROJECT_NAME }}_{{ .VERSION }}_{{ .PACKAGE_PLATFORM }}.tar.gz"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   Linux_ARM64:
     desc: Builds Linux ARM64 binaries
-    dir: "{{ .DIST_DIR }}"
+    dir: "{{.DIST_DIR}}"
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
-        {{ .CONTAINER }}:{{ .CONTAINER_TAG }} \
-        --build-cmd "{{ .BUILD_COMMAND }}" \
-        -p "{{ .BUILD_PLATFORM }}"
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -C ../.. LICENSE.txt  -f {{ .PACKAGE_NAME }}
-        sha256sum {{ .PACKAGE_NAME }} >> {{ .CHECKSUM_FILE }}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
-      PLATFORM_DIR: "{{ .PROJECT_NAME }}_linux_arm_6"
-      BUILD_COMMAND: "go build -o {{ .DIST_DIR }}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{ .LDFLAGS }}"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/arm64"
-      CONTAINER_TAG: "{{ .GO_VERSION }}-arm"
+      CONTAINER_TAG: "{{.GO_VERSION}}-arm"
       PACKAGE_PLATFORM: "Linux_ARM64"
-      PACKAGE_NAME: "{{ .PROJECT_NAME }}_{{ .VERSION }}_{{ .PACKAGE_PLATFORM }}.tar.gz"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   macOS_64bit:
     desc: Builds Mac OS X 64 bit binaries
-    dir: "{{ .DIST_DIR }}"
+    dir: "{{.DIST_DIR}}"
     cmds:
       - |
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
-        {{ .CONTAINER }}:{{ .CONTAINER_TAG }} \
-        --build-cmd "{{ .BUILD_COMMAND }}" \
-        -p "{{ .BUILD_PLATFORM }}"
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -C ../.. LICENSE.txt  -f {{ .PACKAGE_NAME }}
-        sha256sum {{ .PACKAGE_NAME }} >> {{ .CHECKSUM_FILE }}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
-      PLATFORM_DIR: "{{ .PROJECT_NAME }}_osx_darwin_amd64"
-      BUILD_COMMAND: "go build -o {{ .DIST_DIR }}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{ .LDFLAGS }}"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "darwin/amd64"
-      CONTAINER_TAG: "{{ .GO_VERSION }}-darwin"
+      CONTAINER_TAG: "{{.GO_VERSION}}-darwin"
       PACKAGE_PLATFORM: "macOS_64bit"
-      PACKAGE_NAME: "{{ .PROJECT_NAME }}_{{ .VERSION }}_{{ .PACKAGE_PLATFORM }}.tar.gz"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"

--- a/workflow-templates/assets/release-go-task/Taskfile.yml
+++ b/workflow-templates/assets/release-go-task/Taskfile.yml
@@ -17,14 +17,14 @@ vars:
     sh: echo "{{now | date "20060102"}}"
   TAG:
     sh: echo "`git tag --points-at=HEAD 2> /dev/null | head -n1`"
-  VERSION: "{{ if .NIGHTLY }}nightly-{{ .TIMESTAMP_SHORT }}{{ else if .TAG }}{{ .TAG }}{{ else }}{{ .PACKAGE_NAME_PREFIX }}git-snapshot{{ end }}"
+  VERSION: "{{if .NIGHTLY}}nightly-{{.TIMESTAMP_SHORT}}{{else if .TAG}}{{.TAG}}{{else}}{{.PACKAGE_NAME_PREFIX}}git-snapshot{{end}}"
   CONFIGURATION_PACKAGE: TODO
   LDFLAGS: >-
     -ldflags
     '
-    -X {{ .CONFIGURATION_PACKAGE }}.version={{.VERSION}}
-    -X {{ .CONFIGURATION_PACKAGE }}.commit={{.COMMIT}}
-    -X {{ .CONFIGURATION_PACKAGE }}.buildTimestamp={{.TIMESTAMP}}
+    -X {{.CONFIGURATION_PACKAGE}}.version={{.VERSION}}
+    -X {{.CONFIGURATION_PACKAGE}}.commit={{.COMMIT}}
+    -X {{.CONFIGURATION_PACKAGE}}.buildTimestamp={{.TIMESTAMP}}
     '
 
 tasks: {}


### PR DESCRIPTION
The Task documentation provides specific directives for how Taskfiles should be styled:
https://taskfile.dev/#/styleguide

The is one remaining thing that might be considered a style violation: the task names in the Go release system's DistTasks.yml, which use `_` instead of `-`, in contradiction to:
https://taskfile.dev/#/styleguide?id=separate-task-name-words-with-a-dash

However, the current names match the "package platform" name used as an identifier elsewhere.
