### PR TITLE
Remove useless comments re: actions/download-artifact from Go release workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -51,7 +51,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: dist
-          # to ensure compatibility with v1
           path: dist
 
       - name: Import Code-Signing Certificates
@@ -112,7 +111,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: dist
-          # to ensure compatibility with v1
           path: dist
 
       - name: Read CHANGELOG

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -51,7 +51,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: dist
-          # to ensure compatibility with v1
           path: dist
 
       - name: Import Code-Signing Certificates
@@ -112,7 +111,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: dist
-          # to ensure compatibility with v1
           path: dist
 
       - name: Read CHANGELOG


### PR DESCRIPTION
Some cryptic comments were added referring to a "v1". These are explained here:
https://github.com/actions/download-artifact#compatibility-between-v1-and-v2

It was definitely important to explain the reason for the need to add the `path` input in the commit/PR that updated the
action from v1 to v2. But this information is not of ongoing value to the reader of the workflow code. We only need to
understand how the version of the action that is currently in use works, and that is fairly clear just from the input
name, with details readily available in the action's documentation. For this reason, the comments only serve to make the
workflow more confusing.