### PR TITLE
Add manual trigger events to Go nightly template workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -1,10 +1,13 @@
 # Source: https://github.com/arduino/.github/blob/master/workflow-templates/publish-go-nightly-task.md
 name: Publish Nightly Build
 
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   schedule:
     # run every day at 1AM
     - cron: "0 1 * * *"
+  workflow_dispatch:
+  repository_dispatch:
 
 jobs:
   create-nightly-artifacts:

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -1,10 +1,13 @@
 # Source: https://github.com/arduino/.github/blob/master/workflow-templates/publish-go-nightly-task.md
 name: Publish Nightly Build
 
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   schedule:
     # run every day at 1AM
     - cron: "0 1 * * *"
+  workflow_dispatch:
+  repository_dispatch:
 
 jobs:
   create-nightly-artifacts:


### PR DESCRIPTION
A situation might arise where it is desirable to immediately trigger the nightly workflow. For example:

- Testing after changes to the workflow
- Testing after changes to or affecting the secrets used by the workflow
- Testing after changes to the download server infrastructure
- Immediately pushing a project change via the nightly distribution channel

I have found that the manual workflow trigger events stay harmlessly out of my way until the time when they become very
convenient in situations like the ones I listed above.

Although I haven't found a need for the `repository_dispatch` event yet, I think its could be valuable in the event that
it was necessary to trigger the nightly on multiple projects, in which case being able to automate the trigger would be
convenient.