### PR TITLE
Replace discouraged shell syntax in Go release taskfile dynamic variable

### DIFF
--- a/workflow-templates/assets/release-go-task/Taskfile.yml
+++ b/workflow-templates/assets/release-go-task/Taskfile.yml
@@ -16,7 +16,7 @@ vars:
   TIMESTAMP_SHORT:
     sh: echo "{{now | date "20060102"}}"
   TAG:
-    sh: echo "`git tag --points-at=HEAD 2> /dev/null | head -n1`"
+    sh: echo "$(git tag --points-at=HEAD 2> /dev/null | head -n1)"
   VERSION: "{{if .NIGHTLY}}nightly-{{.TIMESTAMP_SHORT}}{{else if .TAG}}{{.TAG}}{{else}}{{.PACKAGE_NAME_PREFIX}}git-snapshot{{end}}"
   CONFIGURATION_PACKAGE: TODO
   LDFLAGS: >-


### PR DESCRIPTION
The backticks command substitution syntax is discouraged in favor of the modern `$()` syntax for the reasons described here:
- http://mywiki.wooledge.org/BashFAQ/082
- https://github.com/koalaman/shellcheck/wiki/SC2006

The modern syntax is already in use for other [dynamic variables](https://taskfile.dev/#/usage?id=dynamic-variables) in the taskfile, so this change also provides consistency.