### PR TITLE
Report all failures of Go nightly template workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -125,8 +125,13 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+  report:
+    runs-on: ubuntu-latest
+    needs: publish-nightly
+    if: failure() # Run if publish-nightly or any of its job dependencies failed
+
+    steps:
       - name: Report failure
-        if: failure()
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.DD_API_KEY }}

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -125,8 +125,13 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+  report:
+    runs-on: ubuntu-latest
+    needs: publish-nightly
+    if: failure() # Run if publish-nightly or any of its job dependencies failed
+
+    steps:
       - name: Report failure
-        if: failure()
         uses: masci/datadog@v1
         with:
           api-key: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
Previously, the configuration of the workflow was such that a Datadog report was only submitted when the
`publish-nightly` job failed. In the event one of the other jobs failed, the `publish-nightly` job never ran, and neither
did the failure handling step inside the job.

We already had a real life event where the Arduino CLI nightly was failing due to a notarization problem, which was not
reported due to the workflow configuration.