### PR TITLE
Use actively maintained release creation action in Go release workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -121,16 +121,6 @@ jobs:
           name: dist
           path: dist
 
-      - name: Read CHANGELOG
-        id: changelog
-        run: |
-          body="$(cat dist/CHANGELOG.md)"
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo "$body"
-          echo "::set-output name=BODY::$body"
-
       - name: Identify Prerelease
         # This is a workaround while waiting for create-release action
         # to implement auto pre-release based on tag
@@ -140,25 +130,14 @@ jobs:
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
-      - name: Create Github Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Github Release and upload artifacts
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: ${{ steps.changelog.outputs.BODY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bodyFile: dist/CHANGELOG.md
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
-
-      - name: Upload release files on Github
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/*
-          tag: ${{ github.ref }}
-          file_glob: true
+          artifacts: dist/*
 
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -121,16 +121,6 @@ jobs:
           name: dist
           path: dist
 
-      - name: Read CHANGELOG
-        id: changelog
-        run: |
-          body="$(cat dist/CHANGELOG.md)"
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo "$body"
-          echo "::set-output name=BODY::$body"
-
       - name: Identify Prerelease
         # This is a workaround while waiting for create-release action
         # to implement auto pre-release based on tag
@@ -140,25 +130,14 @@ jobs:
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
-      - name: Create Github Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Github Release and upload artifacts
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: ${{ steps.changelog.outputs.BODY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bodyFile: dist/CHANGELOG.md
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
-
-      - name: Upload release files on Github
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/*
-          tag: ${{ github.ref }}
-          file_glob: true
+          artifacts: dist/*
 
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3


### PR DESCRIPTION
The `actions/create-release` action is no longer maintained. We have switched to using the `ncipollo/release-action`
action in multiple tooling project workflows and have had no problems with it. It perfectly satisfies all the
requirements for this workflow which the other did not.