### PR TITLE
Add `go:build` task installation to "Test Go" workflow docs

### DIFF
--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -10,6 +10,8 @@ This is the version of the workflow for projects using the [Task](https://taskfi
 
 - [`Taskfile.yml`](assets/test-go-task/Taskfile.yml]
   - Install to: repository root (or add the `go:test` task into the existing `Taskfile.yml`)
+- [`Taskfile.yml`](assets/shared/go/Taskfile.yml] - Build task.
+  - Merge the `go:build` task into the existing `Taskfile.yml`.
 
 ## Readme badge
 


### PR DESCRIPTION
The "Test Go" template workflow builds the Go project and uploads it to a workflow artifact to facilitate beta testing of
PRs. This is done by calling a `go:build` task, but the documentation for the workflow did not provide instructions for
installing such a task in the taskfile.