### PR TITLE
Correct source comment URLs in template workflows

### DIFF
--- a/workflow-templates/check-toc-task.yml
+++ b/workflow-templates/check-toc-task.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/.github/blob/master/workflow-templates/check-toc-task.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-toc-task.md
 name: Check ToC
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-toc-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-toc-task.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/.github/blob/master/workflow-templates/check-toc-task.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-toc-task.md
 name: Check ToC
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-poetry.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-poetry.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/.github/blob/master/workflow-templates/deploy-mkdocs-poetry.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/deploy-mkdocs-poetry.md
 name: Deploy Website
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/.github/blob/master/workflow-templates/publish-go-nightly-task.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/publish-go-nightly-task.md
 name: Publish Nightly Build
 
 on:

--- a/workflow-templates/deploy-mkdocs-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-poetry.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/.github/blob/master/workflow-templates/deploy-mkdocs-poetry.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/deploy-mkdocs-poetry.md
 name: Deploy Website
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -1,4 +1,4 @@
-# Source: https://github.com/arduino/.github/blob/master/workflow-templates/publish-go-nightly-task.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/publish-go-nightly-task.md
 name: Publish Nightly Build
 
 on:


### PR DESCRIPTION
The original plan was for the workflow templates to be hosted in the arduino/.github repository. The workflows that were
the source content already had comments pointing to what was assumed to be their future URL in that repository and I
forgot to update some of them for the new planned location in the arduino/tooling-project-assets repository.