### PR TITLE
Remove related links from template workflow documentation

### DIFF
--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -10,7 +10,6 @@ While some workflows can be added to any repository without any modification, ot
 - List of asset files which must be added to the repository along with the workflow
 - Markup for status badges that can be added to the readme
 - Stock commit messages
-- Links to related workflows
 
 ## Workflow template strategy
 

--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -68,7 +68,3 @@ On every push to the repository's default branch, deploy the repository's MkDocs
 ```markdown
 On every push to the repository's default branch, deploy the repository's [MkDocs](https://www.mkdocs.org/)-based static website to [GitHub Pages](https://pages.github.com/).
 ```
-
-## Related
-
-- ["Check Website" workflow](check-mkdocs-task.md)

--- a/workflow-templates/publish-go-nightly-task.md
+++ b/workflow-templates/publish-go-nightly-task.md
@@ -63,7 +63,3 @@ On a daily schedule:
 
 This will enable everyone to participate to the project's development via beta testing.
 ```
-
-## Related
-
-- ["Release" workflow (Go, Task)](release-go-task.md)

--- a/workflow-templates/release-go-task.md
+++ b/workflow-templates/release-go-task.md
@@ -77,7 +77,3 @@ On every push of a tag named with a version format:
   - If the tag has [a pre-release version suffix](https://semver.org/), the GitHub release will be marked as a pre-release.
 - Upload the builds to Arduino's downloads server.
 ```
-
-## Related
-
-- ["Publish Nightly Build" workflow (Go, Task)](publish-go-nightly-task.md)


### PR DESCRIPTION
At the moment, the related links are far from comprehensive. In their current state, they would do more harm than good by
giving the impression that the ones listed were the only related workflows. At the current state of active development,
it is too difficult to maintain the links. So it's best to just remove them.