### PR TITLE
Sync the repository's "Check Python" assets from templates

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -66,6 +66,7 @@ tasks:
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-general-formatting-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-markdown-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-prettier-formatting-task.yml" \
+          "{{.WORKFLOW_TEMPLATES_PATH}}/check-python-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-taskfiles.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/check-yaml-task.yml" \
           "{{.WORKFLOW_TEMPLATES_PATH}}/sync-labels.yml" \
@@ -81,6 +82,7 @@ tasks:
       - |
         cp \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/shared/.editorconfig" \
+          "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-python/.flake8" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-markdown/.markdown-link-check.json" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-markdown/.markdownlint.yml" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-yaml/.yamllint.yml" \


### PR DESCRIPTION
The repository uses the unmodified "Check Python" workflow and .flake8 configuration file from the templates, so sync of these files should
be facilitated and enforced by adding them to the task created for that purpose.