### PR TITLE
Add template workflow to check for problems with shell scripts

### DIFF
--- a/workflow-templates/assets/check-shell-task/Taskfile.yml
+++ b/workflow-templates/assets/check-shell-task/Taskfile.yml
@@ -1,0 +1,71 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-shell-task/Taskfile.yml
+  shell:format:
+    desc: Format shell script files
+    cmds:
+      - |
+        if ! which shfmt &>/dev/null; then
+          echo "shfmt not installed or not in PATH. Please install: https://github.com/mvdan/sh#shfmt"
+          exit 1
+        fi
+      - shfmt -w .
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-shell-task/Taskfile.yml
+  shell:check:
+    desc: Check for problems with shell scripts
+    cmds:
+      - |
+        if ! which shellcheck &>/dev/null; then
+          echo "shellcheck not installed or not in PATH. Please install: https://github.com/koalaman/shellcheck#installing"
+          exit 1
+        fi
+      - |
+        # There is something odd about shellcheck that causes the task to always exit on the first fail, despite any
+        # measures that would prevent this with any other command. So it's necessary to call shellcheck only once with
+        # the list of script paths as an argument. This could lead to exceeding the maximum command length on Windows if
+        # the repository contained a large number of scripts, but it's unlikely to happen in reality.
+        shellcheck \
+          --format={{default "tty" .SHELLCHECK_FORMAT}} \
+          $(
+            # The odd method for escaping . in the regex is required for windows compatibility because mvdan.cc/sh gives
+            # \ characters special treatment on Windows in an attempt to support them as path separators.
+            find . \
+              -path ".git" -prune -or \
+              \( \
+                -regextype posix-extended \
+                -regex '.*[.](bash|sh)' -and \
+                -type f \
+              \)
+          )
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-shell-task/Taskfile.yml
+  shell:check-mode:
+    desc: Check for non-executable shell scripts
+    cmds:
+      - |
+        EXIT_STATUS=0
+        while read -r nonExecutableScriptPath; do
+          # The while loop always runs once, even if no file was found
+          if [[ "$nonExecutableScriptPath" == "" ]]; then
+            continue
+          fi
+
+          echo "::error file=${nonExecutableScriptPath}::non-executable script file: $nonExecutableScriptPath";
+          EXIT_STATUS=1
+        done <<<"$(
+          # The odd approach to escaping `.` in the regex is required for windows compatibility because mvdan.cc/sh
+          # gives `\` characters special treatment on Windows in an attempt to support them as path separators.
+          find . \
+            -path ".git" -prune -or \
+            \( \
+              -regextype posix-extended \
+              -regex '.*[.](bash|sh)' -and \
+              -type f -and \
+              -not -executable \
+              -print \
+            \)
+        )"
+        exit $EXIT_STATUS

--- a/workflow-templates/check-shell-task.md
+++ b/workflow-templates/check-shell-task.md
@@ -1,0 +1,62 @@
+# "Check Shell Scripts" workflow (Task)
+
+Workflow file: [check-shell-task.yml](check-shell-task.yml)
+
+Check the repository's shell scripts for problems:
+
+- Static analysis using [ShellCheck](https://github.com/koalaman/shellcheck).
+- Formatting using [shfmt](https://github.com/mvdan/sh).
+- Forgotten executable script file permissions.
+
+This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
+
+## Assets
+
+- [`.editorconfig`](assets/shared/.editorconfig) - `shfmt` will use this [configuration file](https://editorconfig.org/).
+  - Install to: repository root
+- [`Taskfile.yml`](assets/check-prettier-formatting-task/Taskfile.yml] - Tasks for checking shell scripts.
+  - Install to: repository root (or add the tasks into the existing `Taskfile.yml`)
+
+The formatting style defined in `.editorconfig` is the official standardized style to be used in all Arduino tooling projects and should not be modified.
+
+## Readme badge
+
+Markdown badge:
+
+```markdown
+[![Check Shell Scripts status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-shell-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-shell-task.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-shell-task.yml/badge.svg["Check Shell Scripts status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-shell-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add CI workflow to check for problems with shell scripts
+
+On every push or pull request that modifies one of the shell scripts in the repository, and periodically, the workflow:
+
+- Runs ShellCheck to detect common problems.
+- Runs shfmt to check formatting.
+- Checks for forgotten executable script file permissions.
+```
+
+## PR message
+
+```markdown
+On every push or pull request that modifies one of the shell scripts in the repository, and periodically, the workflow:
+
+- Runs [ShellCheck](https://github.com/koalaman/shellcheck) to detect common problems.
+- Runs [`shfmt`](https://github.com/mvdan/sh) to check formatting.
+- Checks for forgotten executable script file permissions.
+```

--- a/workflow-templates/check-shell-task.yml
+++ b/workflow-templates/check-shell-task.yml
@@ -1,0 +1,119 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-shell-task.md
+name: Check Shell Scripts
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-shell-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.editorconfig"
+      - "**.bash"
+      - "**.sh"
+  pull_request:
+    paths:
+      - ".github/workflows/check-shell-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.editorconfig"
+      - "**.bash"
+      - "**.sh"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by tool changes.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    name: ${{ matrix.configuration.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        configuration:
+          - name: Generate problem matcher output
+            # ShellCheck's "gcc" output format is required for annotated diffs, but inferior for humans reading the log.
+            format: gcc
+            # The other matrix job is used to set the result, so this job is configured to always pass.
+            continue-on-error: true
+          - name: ShellCheck
+            # ShellCheck's "tty" output format is most suitable for humans reading the log.
+            format: tty
+            continue-on-error: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - uses: liskin/gh-problem-matcher-wrap@v1
+        continue-on-error: ${{ matrix.configuration.continue-on-error }}
+        with:
+          linters: gcc
+          run: task --silent shell:check SHELLCHECK_FORMAT=${{ matrix.configuration.format }}
+
+  formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Download shfmt
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: mvdan/sh
+          excludes: prerelease, draft
+          asset: _linux_amd64
+          target: ${{ env.SHFMT_INSTALL_PATH }}
+
+      - name: Install shfmt
+        run: |
+          # Executable permissions of release assets are lost
+          chmod +x "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}"
+          # Standardize binary name
+          mv "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}" "${{ env.SHFMT_INSTALL_PATH }}/shfmt"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.SHFMT_INSTALL_PATH }}" >> "$GITHUB_PATH"
+
+      - name: Format shell scripts
+        run: task --silent shell:format
+
+      - name: Check formatting
+        run: git diff --color --exit-code
+
+  executable:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check for non-executable scripts
+        run: task --silent shell:check-mode

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-shell-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-shell-task.yml
@@ -1,0 +1,119 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-shell-task.md
+name: Check Shell Scripts
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-shell-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.editorconfig"
+      - "**.bash"
+      - "**.sh"
+  pull_request:
+    paths:
+      - ".github/workflows/check-shell-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - "**/.editorconfig"
+      - "**.bash"
+      - "**.sh"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by tool changes.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    name: ${{ matrix.configuration.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        configuration:
+          - name: Generate problem matcher output
+            # ShellCheck's "gcc" output format is required for annotated diffs, but inferior for humans reading the log.
+            format: gcc
+            # The other matrix job is used to set the result, so this job is configured to always pass.
+            continue-on-error: true
+          - name: ShellCheck
+            # ShellCheck's "tty" output format is most suitable for humans reading the log.
+            format: tty
+            continue-on-error: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - uses: liskin/gh-problem-matcher-wrap@v1
+        continue-on-error: ${{ matrix.configuration.continue-on-error }}
+        with:
+          linters: gcc
+          run: task --silent shell:check SHELLCHECK_FORMAT=${{ matrix.configuration.format }}
+
+  formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Download shfmt
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: mvdan/sh
+          excludes: prerelease, draft
+          asset: _linux_amd64
+          target: ${{ env.SHFMT_INSTALL_PATH }}
+
+      - name: Install shfmt
+        run: |
+          # Executable permissions of release assets are lost
+          chmod +x "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}"
+          # Standardize binary name
+          mv "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}" "${{ env.SHFMT_INSTALL_PATH }}/shfmt"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.SHFMT_INSTALL_PATH }}" >> "$GITHUB_PATH"
+
+      - name: Format shell scripts
+        run: task --silent shell:format
+
+      - name: Check formatting
+        run: git diff --color --exit-code
+
+  executable:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Check for non-executable scripts
+        run: task --silent shell:check-mode


### PR DESCRIPTION
On every push or pull request that modifies one of the shell scripts in the repository, and periodically, the workflow:

- Runs ShellCheck to detect common problems.
- Runs shfmt to check formatting.
- Checks for forgotten executable script file permissions.