### PR TITLE
Add flake8 problem matcher to "Check Python" workflow

### DIFF
--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -49,7 +49,10 @@ jobs:
           version: 3.x
 
       - name: Run flake8
-        run: task python:lint
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: flake8
+          run: task python:lint
 
   formatting:
     runs-on: ubuntu-latest

--- a/workflow-templates/check-python-task.yml
+++ b/workflow-templates/check-python-task.yml
@@ -49,7 +49,10 @@ jobs:
           version: 3.x
 
       - name: Run flake8
-        run: task python:lint
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: flake8
+          run: task python:lint
 
   formatting:
     runs-on: ubuntu-latest

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
@@ -49,7 +49,10 @@ jobs:
           version: 3.x
 
       - name: Run flake8
-        run: task python:lint
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: flake8
+          run: task python:lint
 
   formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This uses the [`liskin/gh-problem-matcher-wrap](https://github.com/liskin/gh-problem-matcher-wrap) to define a [problem matcher](https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md) for the flake8 run workflow step, which generates GitHub annotations and GitHub Actions workflow run log decorations for any flake8 violations.

- Log decoration demo: https://github.com/per1234/tooling-project-assets/runs/2871787576?check_suite_focus=true#step:6:33
- Annotation demo: https://github.com/per1234/tooling-project-assets/commit/787c12e880f7917d8fc0d80a0dc2552402df13d6