### PR TITLE
Add pytest problem matcher to "Test Python" workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
@@ -45,4 +45,7 @@ jobs:
           version: 3.x
 
       - name: Run tests
-        run: task python:test
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: pytest
+          run: task python:test

--- a/workflow-templates/test-python-poetry-task.yml
+++ b/workflow-templates/test-python-poetry-task.yml
@@ -45,4 +45,7 @@ jobs:
           version: 3.x
 
       - name: Run tests
-        run: task python:test
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: pytest
+          run: task python:test


### PR DESCRIPTION
This uses the [`liskin/gh-problem-matcher-wrap](https://github.com/liskin/gh-problem-matcher-wrap) to define a [problem matcher](https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md) for the pytest run workflow step, which generates GitHub annotations and GitHub Actions workflow run log decorations for any test failures.

- Log decoration demo: https://github.com/per1234/tooling-project-assets/runs/2871859078?check_suite_focus=true#step:6:55
- Annotation demo: https://github.com/per1234/tooling-project-assets/commit/a2748dae5cbfdc96ade0ce66eff8ee1219ef8ee2#diff-40dc4b8df2ea2d97bd0d3e4562dd53cfee7c226a268e3e0f6adcde8c2b6e616c