### PR TITLE
Avoid globbing in Markdown link check find command on Windows

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -180,7 +180,10 @@ tasks:
             exit 1
           fi
           STATUS=0
-          for file in $(find -name "*.md"); do
+          # Using -regex instead of -name to avoid Task's behavior of globbing even when quoted on Windows
+          # The odd method for escaping . in the regex is required for windows compatibility because mvdan.cc/sh gives
+          # \ characters special treatment on Windows in an attempt to support them as path separators.
+          for file in $(find . -regex ".*[.]md"); do
             markdown-link-check \
               --quiet \
               --config "./.markdown-link-check.json" \
@@ -191,7 +194,7 @@ tasks:
         else
           npx --package=markdown-link-check --call='
             STATUS=0
-            for file in $(find -name "*.md"); do
+            for file in $(find . -regex ".*[.]md"); do
               markdown-link-check \
                 --quiet \
                 --config "./.markdown-link-check.json" \

--- a/workflow-templates/assets/check-markdown-task/Taskfile.yml
+++ b/workflow-templates/assets/check-markdown-task/Taskfile.yml
@@ -27,7 +27,10 @@ tasks:
             exit 1
           fi
           STATUS=0
-          for file in $(find -name "*.md"); do
+          # Using -regex instead of -name to avoid Task's behavior of globbing even when quoted on Windows
+          # The odd method for escaping . in the regex is required for windows compatibility because mvdan.cc/sh gives
+          # \ characters special treatment on Windows in an attempt to support them as path separators.
+          for file in $(find . -regex ".*[.]md"); do
             markdown-link-check \
               --quiet \
               --config "./.markdown-link-check.json" \
@@ -38,7 +41,7 @@ tasks:
         else
           npx --package=markdown-link-check --call='
             STATUS=0
-            for file in $(find -name "*.md"); do
+            for file in $(find . -regex ".*[.]md"); do
               markdown-link-check \
                 --quiet \
                 --config "./.markdown-link-check.json" \


### PR DESCRIPTION
For some reason, Task expands the quoted glob when the "Check Markdown" template's `markdown:check-links` task is run on
Windows, and only on Windows. This causes a spurious failure of the task when there is more than one Markdown file in the
repository. On Linux, the glob is passed as a string literal to `find`, which handles it correctly.

I found two workarounds for this annoying behavior:

- Escape the quotes or the glob.
- Use `-regex` instead of `-name`.

The `find` command resulting from the first workaround only works on Windows. The `find` command resulting from the
second workaround  works on both Windows and Linux. I feel that having a different command for each operating system
makes the task even more difficult to maintain than it already is, so I opted for the second workaround, and applied it
to the Linux command as well for the sake of consistency (even though the previous command was already working on Linux).