### PR TITLE
Configure `markdown:check-links` task to check all links on Windows

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -179,6 +179,9 @@ tasks:
             echo "markdown-link-check not found or not in PATH. Please install: https://github.com/tcort/markdown-link-check#readme"
             exit 1
           fi
+          # Default behavior of the task on Windows is to exit the task when the first broken link causes a non-zero
+          # exit status, but it's better to check all links before exiting.
+          set +o errexit
           STATUS=0
           for file in $(find -name "*.md"); do
             markdown-link-check \

--- a/workflow-templates/assets/check-markdown-task/Taskfile.yml
+++ b/workflow-templates/assets/check-markdown-task/Taskfile.yml
@@ -26,6 +26,9 @@ tasks:
             echo "markdown-link-check not found or not in PATH. Please install: https://github.com/tcort/markdown-link-check#readme"
             exit 1
           fi
+          # Default behavior of the task on Windows is to exit the task when the first broken link causes a non-zero
+          # exit status, but it's better to check all links before exiting.
+          set +o errexit
           STATUS=0
           for file in $(find -name "*.md"); do
             markdown-link-check \


### PR DESCRIPTION
Task has the odd behavior of treating the [`markdown-link-check`](https://github.com/tcort/markdown-link-check) exit status as though the [`errexit` shell option](https://linuxcommand.org/lc3_man_pages/seth.html) was set, exiting the task when the first broken link causes a non-zero exit status. But it's preferable to check all links before exiting with the appropriate exit status to allow the contributor to fix them all in one shot if there are multiple broken links.

Fortunately, in this case it respects the option value if it is set explicitly in the task.

Task has the opposite behavior on Linux, handling the `markdown-link-check` exit status as if the `errexit` shell option as
unset by default, which is the desired result.