### PR TITLE
Use environment variable to define Go distribution dir in release workflows

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -12,8 +12,11 @@ on:
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
   PROJECT_NAME: TODO
+  # As defined by the Taskfile's DIST_DIR variable
+  DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: TODO
+  ARTIFACT_NAME: dist
 
 jobs:
   create-nightly-artifacts:
@@ -38,8 +41,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           if-no-files-found: error
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   notarize-macos:
     runs-on: macos-latest
@@ -52,9 +55,9 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
+          name: ${{ env.ARTIFACT_NAME }}
           # to ensure compatibility with v1
-          path: dist
+          path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
         env:
@@ -98,20 +101,20 @@ jobs:
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "dist/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}"
-          PACKAGE_FILENAME="$(basename dist/${{ env.PROJECT_NAME }}_nightly-*_macOS_64bit.tar.gz)"
-          tar -czvf "dist/$PACKAGE_FILENAME" \
-          -C "dist/${{ env.PROJECT_NAME }}_osx_darwin_amd64/" "${{ env.PROJECT_NAME }}" \
+          chmod +x "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}"
+          PACKAGE_FILENAME="$(basename ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_nightly-*_macOS_64bit.tar.gz)"
+          tar -czvf "${{ env.DIST_DIR }}/$PACKAGE_FILENAME" \
+          -C "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
-          CHECKSUM="$(shasum -a 256 dist/$PACKAGE_FILENAME | cut -d " " -f 1)"
-          perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CHECKSUM} ${PACKAGE_FILENAME}/g;" dist/*-checksums.txt
+          CHECKSUM="$(shasum -a 256 ${{ env.DIST_DIR }}/$PACKAGE_FILENAME | cut -d " " -f 1)"
+          perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CHECKSUM} ${PACKAGE_FILENAME}/g;" ${{ env.DIST_DIR }}/*-checksums.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           if-no-files-found: error
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   publish-nightly:
     runs-on: ubuntu-latest
@@ -121,16 +124,16 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: dist
+          name: ${{ env.ARTIFACT_NAME }}
           # to ensure compatibility with v1
-          path: dist
+          path: ${{ env.DIST_DIR }}
 
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "dist/*"
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
           PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
-          PLUGIN_STRIP_PREFIX: "dist/"
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -9,8 +9,11 @@ on:
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
   PROJECT_NAME: TODO
+  # As defined by the Taskfile's DIST_DIR variable
+  DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: TODO
+  ARTIFACT_NAME: dist
 
 jobs:
   create-release-artifacts:
@@ -28,7 +31,7 @@ jobs:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
           filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
           case-insensitive-regex: true
-          changelog-file-path: "dist/CHANGELOG.md"
+          changelog-file-path: "${{ env.DIST_DIR }}/CHANGELOG.md"
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1
@@ -43,8 +46,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           if-no-files-found: error
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   notarize-macos:
     runs-on: macos-latest
@@ -57,8 +60,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
         env:
@@ -102,20 +105,20 @@ jobs:
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x dist/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}
+          chmod +x ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}
           TAG="${GITHUB_REF/refs\/tags\//}"
-          tar -czvf "dist/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz" \
-          -C dist/${{ env.PROJECT_NAME }}_osx_darwin_amd64/  ${{ env.PROJECT_NAME }}   \
+          tar -czvf "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz" \
+          -C ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/  ${{ env.PROJECT_NAME }}   \
           -C ../../ LICENSE.txt
-          CHECKSUM="$(shasum -a 256 dist/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz | cut -d " " -f 1)"
-          perl -pi -w -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM}  ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" dist/*-checksums.txt
+          CHECKSUM="$(shasum -a 256 ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz | cut -d " " -f 1)"
+          perl -pi -w -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM}  ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" ${{ env.DIST_DIR }}/*-checksums.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           if-no-files-found: error
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   create-release:
     runs-on: ubuntu-latest
@@ -128,8 +131,8 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
       - name: Identify Prerelease
         # This is a workaround while waiting for create-release action
@@ -144,17 +147,17 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          bodyFile: dist/CHANGELOG.md
+          bodyFile: ${{ env.DIST_DIR }}/CHANGELOG.md
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
-          artifacts: dist/*
+          artifacts: ${{ env.DIST_DIR }}/*
 
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "dist/*"
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
           PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-          PLUGIN_STRIP_PREFIX: "dist/"
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -12,8 +12,11 @@ on:
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
   PROJECT_NAME: TODO
+  # As defined by the Taskfile's DIST_DIR variable
+  DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: TODO
+  ARTIFACT_NAME: dist
 
 jobs:
   create-nightly-artifacts:
@@ -38,8 +41,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           if-no-files-found: error
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   notarize-macos:
     runs-on: macos-latest
@@ -52,9 +55,9 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
+          name: ${{ env.ARTIFACT_NAME }}
           # to ensure compatibility with v1
-          path: dist
+          path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
         env:
@@ -98,20 +101,20 @@ jobs:
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "dist/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}"
-          PACKAGE_FILENAME="$(basename dist/${{ env.PROJECT_NAME }}_nightly-*_macOS_64bit.tar.gz)"
-          tar -czvf "dist/$PACKAGE_FILENAME" \
-          -C "dist/${{ env.PROJECT_NAME }}_osx_darwin_amd64/" "${{ env.PROJECT_NAME }}" \
+          chmod +x "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}"
+          PACKAGE_FILENAME="$(basename ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_nightly-*_macOS_64bit.tar.gz)"
+          tar -czvf "${{ env.DIST_DIR }}/$PACKAGE_FILENAME" \
+          -C "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
-          CHECKSUM="$(shasum -a 256 dist/$PACKAGE_FILENAME | cut -d " " -f 1)"
-          perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CHECKSUM} ${PACKAGE_FILENAME}/g;" dist/*-checksums.txt
+          CHECKSUM="$(shasum -a 256 ${{ env.DIST_DIR }}/$PACKAGE_FILENAME | cut -d " " -f 1)"
+          perl -pi -w -e "s/.*${PACKAGE_FILENAME}/${CHECKSUM} ${PACKAGE_FILENAME}/g;" ${{ env.DIST_DIR }}/*-checksums.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           if-no-files-found: error
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   publish-nightly:
     runs-on: ubuntu-latest
@@ -121,16 +124,16 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: dist
+          name: ${{ env.ARTIFACT_NAME }}
           # to ensure compatibility with v1
-          path: dist
+          path: ${{ env.DIST_DIR }}
 
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "dist/*"
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
           PLUGIN_TARGET: "${{ env.AWS_PLUGIN_TARGET }}nightly"
-          PLUGIN_STRIP_PREFIX: "dist/"
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -9,8 +9,11 @@ on:
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
   PROJECT_NAME: TODO
+  # As defined by the Taskfile's DIST_DIR variable
+  DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: TODO
+  ARTIFACT_NAME: dist
 
 jobs:
   create-release-artifacts:
@@ -28,7 +31,7 @@ jobs:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
           filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
           case-insensitive-regex: true
-          changelog-file-path: "dist/CHANGELOG.md"
+          changelog-file-path: "${{ env.DIST_DIR }}/CHANGELOG.md"
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1
@@ -43,8 +46,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           if-no-files-found: error
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   notarize-macos:
     runs-on: macos-latest
@@ -57,8 +60,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
         env:
@@ -102,20 +105,20 @@ jobs:
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x dist/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}
+          chmod +x ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}
           TAG="${GITHUB_REF/refs\/tags\//}"
-          tar -czvf "dist/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz" \
-          -C dist/${{ env.PROJECT_NAME }}_osx_darwin_amd64/  ${{ env.PROJECT_NAME }}   \
+          tar -czvf "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz" \
+          -C ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/  ${{ env.PROJECT_NAME }}   \
           -C ../../ LICENSE.txt
-          CHECKSUM="$(shasum -a 256 dist/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz | cut -d " " -f 1)"
-          perl -pi -w -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM}  ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" dist/*-checksums.txt
+          CHECKSUM="$(shasum -a 256 ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz | cut -d " " -f 1)"
+          perl -pi -w -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM}  ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" ${{ env.DIST_DIR }}/*-checksums.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           if-no-files-found: error
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   create-release:
     runs-on: ubuntu-latest
@@ -128,8 +131,8 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
       - name: Identify Prerelease
         # This is a workaround while waiting for create-release action
@@ -144,17 +147,17 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          bodyFile: dist/CHANGELOG.md
+          bodyFile: ${{ env.DIST_DIR }}/CHANGELOG.md
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
-          artifacts: dist/*
+          artifacts: ${{ env.DIST_DIR }}/*
 
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "dist/*"
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/*"
           PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
-          PLUGIN_STRIP_PREFIX: "dist/"
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
The Go project release and nightly build workflows contained many hardcoded references to the folder that contains the
build binaries. Even though there will likely not be a need to customize this path for each project, it is set by a
variable in the project-specific taskfile, and so should be in the workflows that rely on that value as well.