### PR TITLE
Remove Python dependencies caching step

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-versioned-poetry.yml
@@ -56,14 +56,6 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('./pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.yml
@@ -56,14 +56,6 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('./pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
During the development phase of the previous attempt at setting up an official collection of template workflows, I
investigated dependencies caching and added it to all workflows where applicable. Afterwards, doubts were raised about
whether it provided any benefits. I don't know enough about this subject to make a call on that and I have been unable to
get any more information on the subject.

Since the caching significantly increases the complexity of the workflows, which may make them more difficult to maintain
and contribute to, I think it's best to just remove all the caching for now. I hope to eventually be able to revisit this
topic and restore caching in any workflows where it is definitely beneficial.

This particular caching step was in[ the source workflow in the Arduino CLI repository ](https://github.com/arduino/arduino-cli/blob/2173c1246c8f55715ed48c337ed08b31f7fed983/.github/workflows/publish-docs.yaml#L73)from the very beginning, and was my
inspiration for using caching in the first place. However, none of the other workflows with Python dependencies have
caching at this point, so having this one as an exception to the otherwise fairly standardized workflow format is confusing.

### Related
- https://github.com/arduino/library-registry/pull/8
- https://github.com/per1234/.github/commit/f1cadde71474887dc6a5a5c38411364496d27c04