### PR TITLE
Remove useless comments re: actions/download-artifact from Go release workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          # to ensure compatibility with v1
           path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
@@ -125,7 +124,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          # to ensure compatibility with v1
           path: ${{ env.DIST_DIR }}
 
       - name: Upload release files on Arduino downloads servers

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          # to ensure compatibility with v1
           path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
@@ -125,7 +124,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          # to ensure compatibility with v1
           path: ${{ env.DIST_DIR }}
 
       - name: Upload release files on Arduino downloads servers


### PR DESCRIPTION
Some cryptic comments were added referring to a "v1". These are explained here:
https://github.com/actions/download-artifact#compatibility-between-v1-and-v2

It was definitely important to explain the reason for the need to add the `path` input in the commit/PR that updated the
action from v1 to v2. But this information is not of ongoing value to the reader of the workflow code. We only need to
understand how the version of the action that is currently in use works, and that is fairly clear just from the input
name, with details readily available in the action's documentation. For this reason, the comments only serve to make the
workflow more confusing.

I missed this set when I did the equivalent removal from the release workflow in https://github.com/per1234/tooling-project-assets/pull/50