### PR TITLE
Use consistent approach for installing tools from release assets

### DIFF
--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -30,31 +30,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
-      - name: Get data for latest editorconfig-checker release
-        id: get-release-data
-        uses: octokit/request-action@v2.x
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download latest editorconfig-checker release binary package
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
         with:
-          # Pre-releases are ignored
-          route: GET /repos/:owner/:repo/releases/latest
-          # The following inputs result in "Unexpected input" warnings on the workflow run log and summary page,
-          # but they are correct
-          owner: editorconfig-checker
-          repo: editorconfig-checker
-
-      - name: Download release binary
-        id: download-release
-        uses: carlosperate/download-file-action@v1.0.3
-        with:
-          # See: https://github.com/editorconfig-checker/editorconfig-checker/releases
-          file-url: https://github.com/editorconfig-checker/editorconfig-checker/releases/download/${{ fromJson(steps.get-release-data.outputs.data).tag_name }}/ec-linux-amd64.tar.gz
-          location: ${{ env.EC_INSTALL_PATH }}
+          repository: editorconfig-checker/editorconfig-checker
+          excludes: prerelease, draft
+          asset: linux-amd64.tar.gz
+          target: ${{ env.EC_INSTALL_PATH }}
 
       - name: Install editorconfig-checker
         run: |
           cd "${{ env.EC_INSTALL_PATH }}"
-          tar --extract --file="${{ steps.download-release.outputs.file-path }}"
+          tar --extract --file="${{ steps.download.outputs.name }}"
           # Give the binary a standard name
           mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
           # Add installation to PATH:

--- a/workflow-templates/check-general-formatting-task.yml
+++ b/workflow-templates/check-general-formatting-task.yml
@@ -30,31 +30,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
-      - name: Get data for latest editorconfig-checker release
-        id: get-release-data
-        uses: octokit/request-action@v2.x
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download latest editorconfig-checker release binary package
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
         with:
-          # Pre-releases are ignored
-          route: GET /repos/:owner/:repo/releases/latest
-          # The following inputs result in "Unexpected input" warnings on the workflow run log and summary page,
-          # but they are correct
-          owner: editorconfig-checker
-          repo: editorconfig-checker
-
-      - name: Download release binary
-        id: download-release
-        uses: carlosperate/download-file-action@v1.0.3
-        with:
-          # See: https://github.com/editorconfig-checker/editorconfig-checker/releases
-          file-url: https://github.com/editorconfig-checker/editorconfig-checker/releases/download/${{ fromJson(steps.get-release-data.outputs.data).tag_name }}/ec-linux-amd64.tar.gz
-          location: ${{ env.EC_INSTALL_PATH }}
+          repository: editorconfig-checker/editorconfig-checker
+          excludes: prerelease, draft
+          asset: linux-amd64.tar.gz
+          target: ${{ env.EC_INSTALL_PATH }}
 
       - name: Install editorconfig-checker
         run: |
           cd "${{ env.EC_INSTALL_PATH }}"
-          tar --extract --file="${{ steps.download-release.outputs.file-path }}"
+          tar --extract --file="${{ steps.download.outputs.name }}"
           # Give the binary a standard name
           mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
           # Add installation to PATH:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-general-formatting-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-general-formatting-task.yml
@@ -30,31 +30,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
-      - name: Get data for latest editorconfig-checker release
-        id: get-release-data
-        uses: octokit/request-action@v2.x
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download latest editorconfig-checker release binary package
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
         with:
-          # Pre-releases are ignored
-          route: GET /repos/:owner/:repo/releases/latest
-          # The following inputs result in "Unexpected input" warnings on the workflow run log and summary page,
-          # but they are correct
-          owner: editorconfig-checker
-          repo: editorconfig-checker
-
-      - name: Download release binary
-        id: download-release
-        uses: carlosperate/download-file-action@v1.0.3
-        with:
-          # See: https://github.com/editorconfig-checker/editorconfig-checker/releases
-          file-url: https://github.com/editorconfig-checker/editorconfig-checker/releases/download/${{ fromJson(steps.get-release-data.outputs.data).tag_name }}/ec-linux-amd64.tar.gz
-          location: ${{ env.EC_INSTALL_PATH }}
+          repository: editorconfig-checker/editorconfig-checker
+          excludes: prerelease, draft
+          asset: linux-amd64.tar.gz
+          target: ${{ env.EC_INSTALL_PATH }}
 
       - name: Install editorconfig-checker
         run: |
           cd "${{ env.EC_INSTALL_PATH }}"
-          tar --extract --file="${{ steps.download-release.outputs.file-path }}"
+          tar --extract --file="${{ steps.download.outputs.name }}"
           # Give the binary a standard name
           mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
           # Add installation to PATH:


### PR DESCRIPTION
I settled on a new approach to installing from release assets when that is the best available source for a tool
dependency (i.e., not available from npm or Poetry) during the development of the "Check Shell Scripts" template workflow.

I think it is beneficial to make the template worflows consistent where possible. Since I think the new approach is a
small improvement over the old one that was previously used in the "Check General Formatting" template workflow, this one
should be updated.