### PR TITLE
Correct URL in source comment

### DIFF
--- a/workflow-templates/assets/test-python/__init__.py
+++ b/workflow-templates/assets/test-python/__init__.py
@@ -1,5 +1,5 @@
 # Source:
-# https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-integration/__init__.py
+# https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-python/__init__.py
 # Copyright 2021 ARDUINO SA (http://www.arduino.cc/)
 #
 # This software is released under the GNU General Public License version 3,


### PR DESCRIPTION
The URL in this comment was not pointing to the template file source location.