### PR TITLE
Make Taskfile installation instructions generic

### DIFF
--- a/workflow-templates/check-general-formatting-task.md
+++ b/workflow-templates/check-general-formatting-task.md
@@ -9,7 +9,7 @@ Use [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-
 - [`.editorconfig`](assets/shared/.editorconfig)
   - Install to: repository root
 - [`Taskfile.yml`](assets/check-general-formatting-task/Taskfile.yml) - formatting check [task](https://taskfile.dev/).
-  - Install to: repository root (or add the `general:check-formatting` task into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`.ecrc`](assets/check-general-formatting-task/.ecrc) - editorconfig-checker configuration file.
 
 The formatting style defined in `.editorconfig` is the official standardized style to be used in all Arduino tooling projects and should not be modified.

--- a/workflow-templates/check-go-task.md
+++ b/workflow-templates/check-go-task.md
@@ -7,7 +7,7 @@ Lint and check formatting of a [Go](https://golang.org/) module.
 ## Assets
 
 - [`Taskfile.yml`](assets/check-go-task/Taskfile.yml) - Linting and formatting [tasks](https://taskfile.dev/).
-  - Install to: repository root (or add the tasks into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 
 ## Readme badge
 

--- a/workflow-templates/check-markdown-task.md
+++ b/workflow-templates/check-markdown-task.md
@@ -18,7 +18,7 @@ This is the version of the workflow for projects using the [Task](https://taskfi
 - [`.markdownlint.yml`](assets/check-markdown/.markdownlint.yml) - markdownlint configuration file.
   - Install to: repository root
 - [`Taskfile.yml`](assets/check-markdown-task/Taskfile.yml) - Markdown tasks.
-  - Install to: repository root (or add the `markdown:fix`, `markdown:lint`, and `markdown:check-links` tasks into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 
 The code style defined in `.markdownlint.yml` is the official standardized style to be used in all Arduino tooling projects and should not be modified.
 

--- a/workflow-templates/check-mkdocs-task.md
+++ b/workflow-templates/check-mkdocs-task.md
@@ -13,9 +13,9 @@ See [the "Deploy Website" (MkDocs, Poetry) workflow documentation](deploy-mkdocs
 ## Assets
 
 - [`Taskfile.yml`](assets/check-yaml-task/Taskfile.yml) - Build task.
-  - Install to: repository root (or add the `website:build` task into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/shared/Taskfile.yml) - Installation task.
-  - Add the `poetry:install-deps` task into the existing `Taskfile.yml`
+  - Merge into `Taskfile.yml`
 - Website assets - See [the "Deploy Website" (MkDocs, Poetry) workflow documentation](deploy-mkdocs-poetry.md#assets).
 
 ## Readme badge

--- a/workflow-templates/check-prettier-formatting-task.md
+++ b/workflow-templates/check-prettier-formatting-task.md
@@ -17,7 +17,7 @@ This is the version of the workflow for projects using the [Task](https://taskfi
 ## Assets
 
 - [`Taskfile.yml`](assets/check-prettier-formatting-task/Taskfile.yml) - Formatting task.
-  - Install to: repository root (or add the `general:format-prettier` task into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 
 ## Configuration
 

--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -50,9 +50,9 @@ line-length = 120
 - [`.flake8`](assets/check-python/.flake8) - flake8 configuration file.
   - Install to: repository root
 - [`Taskfile.yml`](assets/check-python-task/Taskfile.yml) - Python linting and formatting tasks.
-  - Install to: repository root (or add the tasks into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/shared/Taskfile.yml) - Installation task.
-  - Add the `poetry:install-deps` task into the existing `Taskfile.yml`
+  - Merge into `Taskfile.yml`
 
 The code style defined in `pyproject.toml` and `.flake8` is the official standardized style to be used in all Arduino tooling projects and should not be modified.
 

--- a/workflow-templates/check-shell-task.md
+++ b/workflow-templates/check-shell-task.md
@@ -15,7 +15,7 @@ This is the version of the workflow for projects using the [Task](https://taskfi
 - [`.editorconfig`](assets/shared/.editorconfig) - `shfmt` will use this [configuration file](https://editorconfig.org/).
   - Install to: repository root
 - [`Taskfile.yml`](assets/check-prettier-formatting-task/Taskfile.yml] - Tasks for checking shell scripts.
-  - Install to: repository root (or add the tasks into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 
 The formatting style defined in `.editorconfig` is the official standardized style to be used in all Arduino tooling projects and should not be modified.
 

--- a/workflow-templates/check-toc-task.md
+++ b/workflow-templates/check-toc-task.md
@@ -11,7 +11,7 @@ This is the version of the workflow for projects using the [Task](https://taskfi
 ## Assets
 
 - [`Taskfile.yml`](assets/check-toc-task/Taskfile.yml) - Table of contents generation task.
-  - Install to: repository root (or add the `markdown:toc` task into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 
 ## Readme badge
 

--- a/workflow-templates/check-workflows-task.md
+++ b/workflow-templates/check-workflows-task.md
@@ -9,7 +9,7 @@ This is the version of the workflow for projects using the [Task](https://taskfi
 ## Assets
 
 - [`Taskfile.yml`](assets/check-workflows-task/Taskfile.yml) - workflow validation task.
-  - Install to: repository root (or add the `ci:validate` task into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 
 ## Readme badge
 

--- a/workflow-templates/check-yaml-task.md
+++ b/workflow-templates/check-yaml-task.md
@@ -35,9 +35,9 @@ Make sure to commit the resulting `pyproject.toml` and `poetry.lock` files.
 - [`.yamllint.yml`](assets/check-yaml/.yamllint.yml) - `yamllint` [configuration file](https://yamllint.readthedocs.io/en/stable/configuration.html).
   - Install to: repository root
 - [`Taskfile.yml`](assets/check-yaml-task/Taskfile.yml) - Linting task.
-  - Install to: repository root (or add the `yaml:lint` task into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/shared/Taskfile.yml) - Installation task.
-  - Add the `poetry:install-deps` task into the existing `Taskfile.yml`
+  - Merge into `Taskfile.yml`
 
 The code style defined in this file is the official standardized style to be used in all Arduino projects and should not be modified.
 

--- a/workflow-templates/publish-go-tester-task.md
+++ b/workflow-templates/publish-go-tester-task.md
@@ -11,7 +11,7 @@ This is the version of the workflow for projects using the [Task](https://taskfi
 ## Assets
 
 - [`Taskfile.yml`](assets/release-go-task/Taskfile.yml) - [variables](https://taskfile.dev/#/usage?id=variables) providing project-specific data to the build system.
-  - Install to: repository root (or merge into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`DistTasks.yml`](assets/release-go-task/DistTasks.yml) - general purpose tasks for making production builds of Go projects.
   - Install to: repository root
 

--- a/workflow-templates/release-go-task.md
+++ b/workflow-templates/release-go-task.md
@@ -9,7 +9,7 @@ This is the version of the workflow for projects using the [Task](https://taskfi
 ## Assets
 
 - [`Taskfile.yml`](assets/release-go-task/Taskfile.yml) - [variables](https://taskfile.dev/#/usage?id=variables) providing project-specific data to the build system.
-  - Install to: repository root (or merge into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`DistTasks.yml`](assets/release-go-task/DistTasks.yml) - general purpose tasks for making production builds of Go projects.
   - Install to: repository root
 - [`gon.config.hcl`](assets/shared/gon.config.hcl) - [gon](https://github.com/mitchellh/gon) configuration file for macOS signing and notarization.

--- a/workflow-templates/spell-check-task.md
+++ b/workflow-templates/spell-check-task.md
@@ -33,9 +33,9 @@ Make sure to commit the resulting `pyproject.toml` and `poetry.lock` files.
 - [`.codespellrc`](assets/spell-check/.codespellrc) - codespell configuration file.
   - Install to: repository root
 - [`Taskfile.yml`](assets/spell-check-task/Taskfile.yml) - spell check and spelling correction tasks.
-  - Install to: repository root (or add the `general:general:check-spelling` and `general:correct-spelling` tasks into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/shared/Taskfile.yml) - Installation task.
-  - Add the `poetry:install-deps` task into the existing `Taskfile.yml`
+  - Merge into `Taskfile.yml`
 
 ## Readme badge
 

--- a/workflow-templates/test-go-integration-task.md
+++ b/workflow-templates/test-go-integration-task.md
@@ -31,9 +31,9 @@ Make sure to commit the resulting `pyproject.toml` and `poetry.lock` files.
 ## Assets
 
 - [`Taskfile.yml`](assets/test-go-integration-task/Taskfile.yml) - Test runner task.
-  - Install to: repository root (or add the `go:test-integration` task into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/shared/go/Taskfile.yml) - Build task.
-  - Merge the `go:build` task into the existing `Taskfile.yml`.
+  - Merge into `Taskfile.yml`.
 - [`__init__.py`](assets/test-python/__init__.py) - Template for Python integration tests.
   - Install to: `tests/`
 - [`test_all.py`](assets/test-integration/test_all.py) - Template for Python integration tests.

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -9,9 +9,9 @@ This is the version of the workflow for projects using the [Task](https://taskfi
 ## Assets
 
 - [`Taskfile.yml`](assets/test-go-task/Taskfile.yml]
-  - Install to: repository root (or add the `go:test` task into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/shared/go/Taskfile.yml] - Build task.
-  - Merge the `go:build` task into the existing `Taskfile.yml`.
+  - Merge into `Taskfile.yml`.
 
 ## Readme badge
 

--- a/workflow-templates/test-python-poetry-task.md
+++ b/workflow-templates/test-python-poetry-task.md
@@ -31,9 +31,9 @@ Make sure to commit the resulting `pyproject.toml` and `poetry.lock` files.
 ## Assets
 
 - [`Taskfile.yml`](assets/test-python-poetry-task/Taskfile.yml) - Test runner task.
-  - Install to: repository root (or add the `python:test` task into the existing `Taskfile.yml`)
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/shared/Taskfile.yml) - Installation task.
-  - Add the `poetry:install-deps` task into the existing `Taskfile.yml`
+  - Merge into `Taskfile.yml`
 - [`__init__.py`](assets/test-python/__init__.py) - Python module file.
   - Install to: `tests/`
 - [`pytest.ini`](assets/test-python/pytest.ini) - [pytest](https://pytest.org) configuration file.


### PR DESCRIPTION
Most of the template workflows have Taskfiles as assets. Previously, the instructions for installing these assets were
specific to each template. This increases the effort required to maintain the documentation and the likelihood that it
will get out of sync with the content of the assets. After reflection, I decided that this information does not provide a
significant benefit. Generic Taskfile installation instructions should be sufficient for the target reader.