### PR TITLE
Add template for minimal issue templates and infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,8 @@
+---
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/minimal/bug-report.md
+name: Bug report
+about: Report a problem with the code or documentation in this repository.
+title: ""
+labels: "type: imperfection"
+assignees: ""
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+# Source:
+# https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/github-actions/config.yml
+contact_links:
+  - name: Learn about using this project
+    url: https://github.com/arduino/tooling-project-assets#readme
+    about: Detailed usage documentation is available here.
+  - name: Learn about GitHub Actions
+    url: https://docs.github.com/en/actions
+    about: Everything you need to know to get started with GitHub Actions.
+  - name: Learn about GitHub issue templates
+    url: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests
+    about: Information about GitHub's issue template feature.
+  - name: Support request
+    url: https://forum.arduino.cc/
+    about: We can help you out on the Arduino Forum!
+  - name: Discuss development work on the project
+    url: https://groups.google.com/a/arduino.cc/g/developers
+    about: Arduino Developers Mailing List

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,8 @@
+---
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/minimal/feature-request.md
+name: Feature request
+about: Suggest an enhancement to this project.
+title: ""
+labels: "type: enhancement"
+assignees: ""
+---

--- a/.github/workflows/check-community-health-sync.yml
+++ b/.github/workflows/check-community-health-sync.yml
@@ -1,0 +1,49 @@
+# This repository contains intentionally duplicated copies of GitHub community health files in use for this repository's
+# own purposes
+#
+# This workflow checks that the copies are in sync.
+# If the workflow fails, run `task fix` and commit.
+
+name: Check Community Health Files Sync
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-community-health-sync.ya?ml"
+      - "Taskfile.ya?ml"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "issue-templates/**"
+  pull_request:
+    paths:
+      - ".github/workflows/check-community-health-sync.ya?ml"
+      - "Taskfile.ya?ml"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "issue-templates/**"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Sync files
+        run: task --silent github:sync
+
+      - name: Check file duplicates sync
+        run: |
+          git add .
+          if ! git diff --color --exit-code HEAD; then
+            echo "::error::File duplicates are out of sync. Please run \"task fix\""
+            exit 1
+          fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,7 @@ tasks:
       - task: ci:sync
       - task: config:sync
       - task: dependabot:sync
+      - task: github:sync
       - task: markdown:fix
       - task: general:format-prettier
       - task: general:correct-spelling
@@ -107,6 +108,18 @@ tasks:
           -type f \
           -regex '.*\.ya?ml' \
           -exec cp '{}' "{{.WORKFLOW_TEMPLATE_COPIES_PATH}}" \;
+
+  github:sync:
+    desc: Sync GitHub community health files
+    vars:
+      ISSUE_TEMPLATES_INSTALLATION_PATH: "./.github/ISSUE_TEMPLATE"
+      ISSUE_TEMPLATES_PATH: "./issue-templates"
+    cmds:
+      - |
+        cp \
+          "{{.ISSUE_TEMPLATES_PATH}}/minimal/bug-report.md" \
+          "{{.ISSUE_TEMPLATES_PATH}}/minimal/feature-request.md" \
+          "{{.ISSUE_TEMPLATES_INSTALLATION_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml
   ci:validate:

--- a/issue-templates/README.md
+++ b/issue-templates/README.md
@@ -1,0 +1,21 @@
+# GitHub issue templates
+
+A menu of issue categories will be presented when the user begins the issue creation process. This "template chooser" also contains links to relevant information, which can redirect support requests or other inappropriate/unproductive uses of the issue tracker.
+
+A link to the default organization level [security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository) (using [the default organization-level one](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) if one is not present for the repository) is displayed in the template chooser, helping to ensure that vulnerability disclosures are done according to policy.
+
+If none of the issue types are applicable, the user can click the "Open a blank issue" link at the bottom of the issue template chooser page to get the previous issue creation behavior.
+
+The issue will be automatically labeled on creation according to the configuration of the template.
+
+The templates can pre-fill the issue body with text prompting the reporter to provide the standardized details required for every issue of that type.
+
+Each subfolder contains a set of issue templates for a specific application. Documentation is provided in each, which includes:
+
+- Installation instructions
+- Stock commit and pull request messages
+
+## References
+
+- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates
+- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

--- a/issue-templates/minimal/README.md
+++ b/issue-templates/minimal/README.md
@@ -1,0 +1,59 @@
+# Minimal issue template
+
+Even in cases where pre-filling the issue body with a template is not wanted, the GitHub template system has some very useful features:
+
+- Template chooser allows redirecting support requests via "Contact Links", and also provides a prominent link to security policy to guide vulnerability disclosures.
+- Encouraging the reporter to fit their report into a specific issue category results in more clarity.
+- Automatic labeling according to template choice allows the reporter to do the initial classification.
+
+This is the minimal issue template, applicable to any Arduino tooling project, in order to gain these benefits.
+
+## Installation
+
+### Assets
+
+- [`bug-report.md`](bug-report.md) - bug report issue template
+  - Install to: `.github/ISSUE_TEMPLATE/`
+- [`feature-request.md`](feature-request.md) - feature request issue template
+  - Install to: `.github/ISSUE_TEMPLATE/`
+- Template chooser - select the appropriate `config.yml` template chooser configuration file for the project type from the [`template-choosers` folder](../template-choosers).
+  - Install to: `.github/ISSUE_TEMPLATE/`
+
+### Configuration
+
+Replace `REPO_OWNER/REPO_NAME` in the `contact_links[0].url` field of `config.yml`.
+
+Add links for any additional relevant resources to the `contact_links[]` field of `config.yml`.
+
+Reference: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
+## Commit message
+
+```
+Add maintenance automation features from GitHub issue templates system
+
+Although providing a structured template for filling information into an issue report is not appropriate for this
+project, the GitHub issue template system offers some additional useful features for automating issue tracker
+maintenance tasks:
+
+- Template chooser allows redirecting support requests via "Contact Links", and also provides a prominent link to
+  security policy to guide vulnerability disclosures.
+- Encouraging the reporter to fit their report into a specific issue category results in more clarity.
+- Automatic labeling according to template choice allows the reporter to do the initial classification.
+
+This minimal issue template system provides these benefits without making any changes to the actual issue writing
+process.
+```
+
+## PR message
+
+```markdown
+Although providing a structured template for filling information into an issue report is not appropriate for this project, the [GitHub issue template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) system offers some additional useful features for automating issue tracker maintenance tasks:
+
+- [Template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) allows redirecting support requests via "Contact Links", and also provides a prominent link to
+  security policy to guide vulnerability disclosures.
+- Encouraging the reporter to fit their report into a specific issue category results in more clarity.
+- Automatic [labeling](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) according to template choice allows the reporter to do the initial classification.
+
+This minimal issue template system provides these benefits without making any changes to the actual issue writing process.
+```

--- a/issue-templates/minimal/bug-report.md
+++ b/issue-templates/minimal/bug-report.md
@@ -1,0 +1,8 @@
+---
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/minimal/bug-report.md
+name: Bug report
+about: Report a problem with the code or documentation in this repository.
+title: ""
+labels: "type: imperfection"
+assignees: ""
+---

--- a/issue-templates/minimal/feature-request.md
+++ b/issue-templates/minimal/feature-request.md
@@ -1,0 +1,8 @@
+---
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/minimal/feature-request.md
+name: Feature request
+about: Suggest an enhancement to this project.
+title: ""
+labels: "type: enhancement"
+assignees: ""
+---

--- a/issue-templates/template-choosers/general/config.yml
+++ b/issue-templates/template-choosers/general/config.yml
@@ -1,0 +1,13 @@
+# Source:
+# https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/general/config.yml
+contact_links:
+  - name: Learn about using this project
+    # TODO: Replace REPO_OWNER/REPO_NAME with the repository owner and name
+    url: https://github.com/REPO_OWNER/REPO_NAME#readme
+    about: Detailed usage documentation is available here.
+  - name: Support request
+    url: https://forum.arduino.cc/
+    about: We can help you out on the Arduino Forum!
+  - name: Discuss development work on the project
+    url: https://groups.google.com/a/arduino.cc/g/developers
+    about: Arduino Developers Mailing List

--- a/issue-templates/template-choosers/github-actions/config.yml
+++ b/issue-templates/template-choosers/github-actions/config.yml
@@ -1,0 +1,16 @@
+# Source:
+# https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/github-actions/config.yml
+contact_links:
+  - name: Learn about using this project
+    # TODO: Replace REPO_OWNER/REPO_NAME with the repository owner and name
+    url: https://github.com/REPO_OWNER/REPO_NAME#readme
+    about: Detailed usage documentation is available here.
+  - name: Learn about GitHub Actions
+    url: https://docs.github.com/en/actions
+    about: Everything you need to know to get started with GitHub Actions.
+  - name: Support request
+    url: https://forum.arduino.cc/
+    about: We can help you out on the Arduino Forum!
+  - name: Discuss development work on the project
+    url: https://groups.google.com/a/arduino.cc/g/developers
+    about: Arduino Developers Mailing List


### PR DESCRIPTION
Although providing a structured template for filling information into an issue report is not appropriate for this project, the [GitHub issue template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) system offers some additional useful features for automating issue tracker maintenance tasks:

- [Template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) allows redirecting support requests via "Contact Links", and also provides a prominent link to
  security policy to guide vulnerability disclosures.
- Encouraging the reporter to fit their report into a specific issue category results in more clarity.
- Automatic [labeling](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) according to template choice allows the reporter to do the initial classification.

This minimal issue template system provides these benefits without making any changes to the actual issue writing process.

---
In addition to the template, the issue templates are also installed for use in this repository.
Demo (missing the security policy link due to the repo being under my account):
![image](https://user-images.githubusercontent.com/8572152/123343431-98805780-d506-11eb-922b-8ee42c810b3c.png)
