### PR TITLE
Remove outdated direct dependency on click Python package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -52,11 +52,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "click"
-version = "7.1.2"
+version = "8.0.1"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "codespell"
@@ -289,7 +292,7 @@ pyyaml = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "eb5d983af0418510636b9ea48f2d5e3702b2382e4b218d161b1f0d8446484517"
+content-hash = "5dcbcc66ce035cec726a14035c7cc584abe4602eadb9f8139779904a0dd3e16b"
 
 [metadata.files]
 appdirs = [
@@ -309,8 +312,8 @@ black = [
     {file = "black-21.6b0.tar.gz", hash = "sha256:dc132348a88d103016726fe360cb9ede02cecf99b76e3660ce6c596be132ce04"},
 ]
 click = [
-    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
-    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+    {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
+    {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
 ]
 codespell = [
     {file = "codespell-2.1.0-py3-none-any.whl", hash = "sha256:b864c7d917316316ac24272ee992d7937c3519be4569209c5b60035ac5d569b5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ black = "^21.5b0"
 flake8 = "^3.9.2"
 pep8-naming = "^0.11.1"
 pytest = "^6.2.4"
-click = "<7.2"
 GitPython = "^3.1.1"
 
 [build-system]


### PR DESCRIPTION
The versioned website helper script previously had a direct dependency on `click`. This was rendered unnecessary when the script was simplified (https://github.com/per1234/tooling-project-assets/pull/79) but I forgot to update `pyproject.toml` accordingly at that time.

There is still an indirect dependency on `click` via `black`, so it remains in `poetry.lock`.