### PR TITLE
Change versioned website template instructions to omit tests

### DIFF
--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -20,7 +20,7 @@ Install the [`deploy-mkdocs-versioned-poetry.yml`](deploy-mkdocs-versioned-poetr
 ### Assets
 
 - Base assets - See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs-poetry.md#assets)
-- [`siteversion`](assets/deploy-mkdocs-versioned/siteversion/) - versioning helper script.
+- [`siteversion.py`](assets/deploy-mkdocs-versioned/siteversion/siteversion.py) - versioning helper script.
   - Install to: `docs/siteversion/`
 
 ### Dependencies


### PR DESCRIPTION
Originally, the tests were integrated into the script, so there was no choice regarding whether they should be installed along with it. 

Since then, the tests have been separated. There should not be any need for modifications to the script code downstream, so it's sufficient to test it here in the upstream repo and the test files would only represent pointless clutter downstream.