### PR TITLE
Link to specific section containing MkDocs dependencies install info

### DIFF
--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -27,7 +27,7 @@ Install the [`deploy-mkdocs-versioned-poetry.yml`](deploy-mkdocs-versioned-poetr
 
 ### Define base dependencies
 
-See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs-poetry.md#installation) for the instructions to install the base dependencies
+See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs-poetry.md#dependencies) for the instructions to install the base dependencies
 
 ### Define additional dependencies
 


### PR DESCRIPTION
The versioned website template references the documentation from the standard MkDocs website template for all the
information that is the same for both. Since the time it was written, the installation instructions have been organized
into dedicated subsections for each category of installation work. So it is now possible to link directly to the
dependencies installation information:
https://github.com/per1234/tooling-project-assets/blob/main/workflow-templates/deploy-mkdocs-poetry.md#dependencies