### PR TITLE
Sanitize git log output used in for Go release template

### DIFF
--- a/workflow-templates/assets/release-go-task/Taskfile.yml
+++ b/workflow-templates/assets/release-go-task/Taskfile.yml
@@ -10,7 +10,7 @@ vars:
   DIST_DIR: "dist"
   # build vars
   COMMIT:
-    sh: echo "$(git log -n 1 --format=%h)"
+    sh: echo "$(git log --no-show-signature -n 1 --format=%h)"
   TIMESTAMP:
     sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   TIMESTAMP_SHORT:


### PR DESCRIPTION
This is a sync of a downstream fix: https://github.com/arduino/arduino-cli/pull/1344

The Go release system uses a `git log` command to determine the commit in order to populate the
output of the application's `version` command. The expected output of the command is solely the short hash. With the
previous command, that expectation was not realized under the following conditions:

- The `log.showSignature` Git configuration option is set to true.
- The commit being built was signed (as is always the case when a commit is made via the GitHub web interface).

In this case, the signing information is shown in addition to the hash, breaking the build system.