### PR TITLE
Install latest version of ShellCheck

### DIFF
--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -28,6 +28,10 @@ jobs:
     name: ${{ matrix.configuration.name }}
     runs-on: ubuntu-latest
 
+    env:
+      # See: https://github.com/koalaman/shellcheck/releases/latest
+      SHELLCHECK_RELEASE_ASSET_SUFFIX: .linux.x86_64.tar.xz
+
     strategy:
       fail-fast: false
 
@@ -44,6 +48,11 @@ jobs:
             continue-on-error: false
 
     steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -52,6 +61,24 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
+
+      - name: Download latest ShellCheck release binary package
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: koalaman/shellcheck
+          excludes: prerelease, draft
+          asset: ${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}
+          target: ${{ env.INSTALL_PATH }}
+
+      - name: Install ShellCheck
+        run: |
+          cd "${{ env.INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download.outputs.name }}"
+          EXTRACTION_FOLDER="$(basename "${{ steps.download.outputs.name }}" "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}")"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
 
       - uses: liskin/gh-problem-matcher-wrap@v1
         continue-on-error: ${{ matrix.configuration.continue-on-error }}

--- a/workflow-templates/check-shell-task.yml
+++ b/workflow-templates/check-shell-task.yml
@@ -28,6 +28,10 @@ jobs:
     name: ${{ matrix.configuration.name }}
     runs-on: ubuntu-latest
 
+    env:
+      # See: https://github.com/koalaman/shellcheck/releases/latest
+      SHELLCHECK_RELEASE_ASSET_SUFFIX: .linux.x86_64.tar.xz
+
     strategy:
       fail-fast: false
 
@@ -44,6 +48,11 @@ jobs:
             continue-on-error: false
 
     steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -52,6 +61,24 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
+
+      - name: Download latest ShellCheck release binary package
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: koalaman/shellcheck
+          excludes: prerelease, draft
+          asset: ${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}
+          target: ${{ env.INSTALL_PATH }}
+
+      - name: Install ShellCheck
+        run: |
+          cd "${{ env.INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download.outputs.name }}"
+          EXTRACTION_FOLDER="$(basename "${{ steps.download.outputs.name }}" "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}")"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
 
       - uses: liskin/gh-problem-matcher-wrap@v1
         continue-on-error: ${{ matrix.configuration.continue-on-error }}

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-shell-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-shell-task.yml
@@ -28,6 +28,10 @@ jobs:
     name: ${{ matrix.configuration.name }}
     runs-on: ubuntu-latest
 
+    env:
+      # See: https://github.com/koalaman/shellcheck/releases/latest
+      SHELLCHECK_RELEASE_ASSET_SUFFIX: .linux.x86_64.tar.xz
+
     strategy:
       fail-fast: false
 
@@ -44,6 +48,11 @@ jobs:
             continue-on-error: false
 
     steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -52,6 +61,24 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
+
+      - name: Download latest ShellCheck release binary package
+        id: download
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: koalaman/shellcheck
+          excludes: prerelease, draft
+          asset: ${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}
+          target: ${{ env.INSTALL_PATH }}
+
+      - name: Install ShellCheck
+        run: |
+          cd "${{ env.INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download.outputs.name }}"
+          EXTRACTION_FOLDER="$(basename "${{ steps.download.outputs.name }}" "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}")"
+          # Add installation to PATH:
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
 
       - uses: liskin/gh-problem-matcher-wrap@v1
         continue-on-error: ${{ matrix.configuration.continue-on-error }}


### PR DESCRIPTION
The version preinstalled in the GitHub Actions runner, and the one in the APT and Snap package repositories is two years
out of date. Use of the latest stable release will provide the highest quality feedback.