### PR TITLE
Report all errors when schema validation occurs

### DIFF
--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
+            --all-errors \
             --strict=false \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ matrix.file }}"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
+            --all-errors \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -142,11 +142,13 @@ tasks:
           {{.WORKFLOW_SCHEMA_URL}}
       - |
         npx ajv-cli validate \
+          --all-errors \
           --strict=false \
           -s "{{.WORKFLOW_SCHEMA_PATH}}" \
           -d "{{.WORKFLOWS_DATA_PATH}}"
       - |
         npx ajv-cli validate \
+          --all-errors \
           --strict=false \
           -s "{{.WORKFLOW_SCHEMA_PATH}}" \
           -d "{{.TEMPLATE_WORKFLOWS_DATA_PATH}}"
@@ -172,10 +174,23 @@ tasks:
       MARKDOWNLINT_DATA_PATH: "**/.markdownlint.{yml,yaml}"
     cmds:
       - wget --quiet --output-document="{{.DEPENDABOT_SCHEMA_PATH}}" {{.DEPENDABOT_SCHEMA_URL}}
-      - npx ajv-cli@{{.AJV_CLI_VERSION}} validate -s "{{.DEPENDABOT_SCHEMA_PATH}}" -d "{{.DEPENDABOT_DATA_PATH}}"
-      - npx ajv-cli validate -s "{{.LABEL_CONFIG_SCHEMA_PATH}}" -d "{{.LABEL_CONFIG_DATA_PATH}}"
+      - |
+        npx ajv-cli@{{.AJV_CLI_VERSION}} validate \
+          --all-errors \
+          -s "{{.DEPENDABOT_SCHEMA_PATH}}" \
+          -d "{{.DEPENDABOT_DATA_PATH}}"
+      - |
+        npx ajv-cli validate \
+          --all-errors \
+          -s "{{.LABEL_CONFIG_SCHEMA_PATH}}" \
+          -d "{{.LABEL_CONFIG_DATA_PATH}}"
       - wget --quiet --output-document="{{.MARKDOWNLINT_SCHEMA_PATH}}" {{.MARKDOWNLINT_SCHEMA_URL}}
-      - npx ajv-cli validate --allow-union-types -s "{{.MARKDOWNLINT_SCHEMA_PATH}}" -d "{{.MARKDOWNLINT_DATA_PATH}}"
+      - |
+        npx ajv-cli validate \
+          --all-errors \
+          --allow-union-types \
+          -s "{{.MARKDOWNLINT_SCHEMA_PATH}}" \
+          -d "{{.MARKDOWNLINT_DATA_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
   markdown:lint:

--- a/workflow-templates/assets/check-workflows-task/Taskfile.yml
+++ b/workflow-templates/assets/check-workflows-task/Taskfile.yml
@@ -19,6 +19,7 @@ tasks:
           {{.WORKFLOW_SCHEMA_URL}}
       - |
         npx ajv-cli validate \
+          --all-errors \
           --strict=false \
           -s "{{.WORKFLOW_SCHEMA_PATH}}" \
           -d "{{.WORKFLOWS_DATA_PATH}}"

--- a/workflow-templates/check-taskfiles.yml
+++ b/workflow-templates/check-taskfiles.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
+            --all-errors \
             --strict=false \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ matrix.file }}"

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-taskfiles.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-taskfiles.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
+            --all-errors \
             --strict=false \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ matrix.file }}"

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
+            --all-errors \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
 

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
+            --all-errors \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
 


### PR DESCRIPTION
The templates and the repository's CI system use the `ajv-cli` JSON schema validator to check the data format of various
files. The default behavior of `ajv-cli` is to bail out on the first error.

I think it is slightly more convenient to get all the errors at once to allow fixing all of them in one go rather than having to repeatedly run the validation before discovering all of them. This behavior is provided by adding the `--all-errors` flag to the `ajv-cli`' commands.