### PR TITLE
Define name for workflow step that runs ShellCheck

### DIFF
--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -80,7 +80,8 @@ jobs:
           # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
 
-      - uses: liskin/gh-problem-matcher-wrap@v1
+      - name: Run ShellCheck
+        uses: liskin/gh-problem-matcher-wrap@v1
         continue-on-error: ${{ matrix.configuration.continue-on-error }}
         with:
           linters: gcc

--- a/workflow-templates/check-shell-task.yml
+++ b/workflow-templates/check-shell-task.yml
@@ -80,7 +80,8 @@ jobs:
           # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
 
-      - uses: liskin/gh-problem-matcher-wrap@v1
+      - name: Run ShellCheck
+        uses: liskin/gh-problem-matcher-wrap@v1
         continue-on-error: ${{ matrix.configuration.continue-on-error }}
         with:
           linters: gcc

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-shell-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-shell-task.yml
@@ -80,7 +80,8 @@ jobs:
           # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
 
-      - uses: liskin/gh-problem-matcher-wrap@v1
+      - name: Run ShellCheck
+        uses: liskin/gh-problem-matcher-wrap@v1
         continue-on-error: ${{ matrix.configuration.continue-on-error }}
         with:
           linters: gcc


### PR DESCRIPTION
The omission of the optional [`name` key](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsname) in the step of the "Check Shell Scripts" workflow that runs [ShellCheck ](https://www.shellcheck.net/)caused it to be [identified in the workflow run logs ](https://github.com/per1234/tooling-project-assets/runs/2995528999?check_suite_focus=true#step:4:1)as "Run liskin/gh-problem-matcher-wrap@v1", which is unlikely to mean anything to the reader.

Use of a descriptive name for this step makes the logs easier to understand, which is especially important for this step as it is the one that will fail if a script has a ShellCheck rule violation.