### PR TITLE
Make commit/PR message for "Check ToC" template universally applicable

### DIFF
--- a/workflow-templates/check-toc-task.md
+++ b/workflow-templates/check-toc-task.md
@@ -48,14 +48,14 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to check for missed updates to readme ToC
+Add CI workflow to check for missed updates to generated ToC
 
-On every push or pull request that affects the repository's README.md, check whether the table of contents matches the
-content.
+On every push or pull request that affects the repository's Markdown files that contain a generated table of contents,
+check whether the table of contents matches the file structure.
 ```
 
 ## PR message
 
 ```markdown
-On every push or pull request that affects the repository's `README.md`, use [markdown-toc](https://github.com/jonschlinkert/markdown-toc) to check whether the table of contents matches the content.
+On every push or pull request that affects the repository's Markdown files that contain a generated table of contents, use [markdown-toc](https://github.com/jonschlinkert/markdown-toc) to check whether the table of contents matches the file structure.
 ```


### PR DESCRIPTION
Previously, the provided commit and PR messages specified that the workflow was used for table of contents in README.md.

Although the stock template workflow does check this file, it is designed to allow it to easily be configured to check
any arbitrary files, and the documentation provides instructions for doing so. The commit and PR messages should be
written so as to be applicable for any installation of the template so that they can simply be copy/pasted without any
modification.