### PR TITLE
Remove obsolete x-prefix from installation script comparison

### DIFF
--- a/other/installation-script/install.sh
+++ b/other/installation-script/install.sh
@@ -80,7 +80,7 @@ checkLatestVersion() {
   elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
     CHECKLATESTVERSION_TAG=$(wget -q -O - $CHECKLATESTVERSION_LATEST_URL | grep -o "<title>Release $CHECKLATESTVERSION_REGEX · ${PROJECT_OWNER}/${PROJECT_NAME}" | grep -o "$CHECKLATESTVERSION_REGEX")
   fi
-  if [ "x$CHECKLATESTVERSION_TAG" = "x" ]; then
+  if [ "$CHECKLATESTVERSION_TAG" = "" ]; then
     echo "Cannot determine latest tag."
     exit 1
   fi


### PR DESCRIPTION
From https://github.com/koalaman/shellcheck/wiki/SC2268

> Some older shells would get confused if the first argument started with a dash, or consisted of ! or (. As a
> workaround, people would prefix variables and values to be compared with x to ensure the left-hand side always started
> with an alphanumeric character.
>
> POSIX ensures this is not necessary, and all modern shells now follow suite.

This obsolete practice is used by the template installation script in a comparison of the release's Git tag name. Since
it would be extremely unusual to start a tag name with any of these characters (or impossible in the case of `-`, since
it is prohibited by Git), it's unlikely this would be necessary even in the days when this bug was prevalent in shells.
In addition, this bug was fixed quite some years ago, making it unlikely that it even exists on any user's system.

So this practice makes the script code more complex without providing any real benefit. Since it is a violation of
ShellCheck rule SC2268 and causing a CI failure, it is best to just remove it.