### PR TITLE
Enable JSON schema validator support for "format" keyword

### DIFF
--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -43,7 +43,11 @@ jobs:
           location: ${{ runner.temp }}/taskfile-schema
 
       - name: Install JSON schema validator
-        run: sudo npm install --global ajv-cli
+        run: |
+          sudo npm install \
+            --global \
+            ajv-cli \
+            ajv-formats
 
       - name: Validate ${{ matrix.file }}
         run: |
@@ -51,5 +55,6 @@ jobs:
           ajv validate \
             --all-errors \
             --strict=false \
+            -c ajv-formats \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ matrix.file }}"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -37,13 +37,18 @@ jobs:
           location: ${{ runner.temp }}/label-configuration-schema
 
       - name: Install JSON schema validator
-        run: sudo npm install --global ajv-cli
+        run: |
+          sudo npm install \
+            --global \
+            ajv-cli \
+            ajv-formats
 
       - name: Validate local labels configuration
         run: |
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
             --all-errors \
+            -c ajv-formats \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -141,17 +141,25 @@ tasks:
           --output-document="{{.WORKFLOW_SCHEMA_PATH}}" \
           {{.WORKFLOW_SCHEMA_URL}}
       - |
-        npx ajv-cli validate \
-          --all-errors \
-          --strict=false \
-          -s "{{.WORKFLOW_SCHEMA_PATH}}" \
-          -d "{{.WORKFLOWS_DATA_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -c ajv-formats \
+            -s "{{.WORKFLOW_SCHEMA_PATH}}" \
+            -d "{{.WORKFLOWS_DATA_PATH}}"
       - |
-        npx ajv-cli validate \
-          --all-errors \
-          --strict=false \
-          -s "{{.WORKFLOW_SCHEMA_PATH}}" \
-          -d "{{.TEMPLATE_WORKFLOWS_DATA_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -c ajv-formats \
+            -s "{{.WORKFLOW_SCHEMA_PATH}}" \
+            -d "{{.TEMPLATE_WORKFLOWS_DATA_PATH}}"
 
   config:validate:
     desc: Validate configuration files against their JSON schema
@@ -180,17 +188,27 @@ tasks:
           -s "{{.DEPENDABOT_SCHEMA_PATH}}" \
           -d "{{.DEPENDABOT_DATA_PATH}}"
       - |
-        npx ajv-cli validate \
-          --all-errors \
-          -s "{{.LABEL_CONFIG_SCHEMA_PATH}}" \
-          -d "{{.LABEL_CONFIG_DATA_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -c ajv-formats \
+            -s "{{.LABEL_CONFIG_SCHEMA_PATH}}" \
+            -d "{{.LABEL_CONFIG_DATA_PATH}}"
       - wget --quiet --output-document="{{.MARKDOWNLINT_SCHEMA_PATH}}" {{.MARKDOWNLINT_SCHEMA_URL}}
       - |
-        npx ajv-cli validate \
-          --all-errors \
-          --allow-union-types \
-          -s "{{.MARKDOWNLINT_SCHEMA_PATH}}" \
-          -d "{{.MARKDOWNLINT_DATA_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            --allow-union-types \
+            -c ajv-formats \
+            -s "{{.MARKDOWNLINT_SCHEMA_PATH}}" \
+            -d "{{.MARKDOWNLINT_DATA_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
   markdown:lint:

--- a/workflow-templates/assets/check-workflows-task/Taskfile.yml
+++ b/workflow-templates/assets/check-workflows-task/Taskfile.yml
@@ -18,8 +18,12 @@ tasks:
           --output-document="{{.WORKFLOW_SCHEMA_PATH}}" \
           {{.WORKFLOW_SCHEMA_URL}}
       - |
-        npx ajv-cli validate \
-          --all-errors \
-          --strict=false \
-          -s "{{.WORKFLOW_SCHEMA_PATH}}" \
-          -d "{{.WORKFLOWS_DATA_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -c ajv-formats \
+            -s "{{.WORKFLOW_SCHEMA_PATH}}" \
+            -d "{{.WORKFLOWS_DATA_PATH}}"

--- a/workflow-templates/check-taskfiles.yml
+++ b/workflow-templates/check-taskfiles.yml
@@ -43,7 +43,11 @@ jobs:
           location: ${{ runner.temp }}/taskfile-schema
 
       - name: Install JSON schema validator
-        run: sudo npm install --global ajv-cli
+        run: |
+          sudo npm install \
+            --global \
+            ajv-cli \
+            ajv-formats
 
       - name: Validate ${{ matrix.file }}
         run: |
@@ -51,5 +55,6 @@ jobs:
           ajv validate \
             --all-errors \
             --strict=false \
+            -c ajv-formats \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ matrix.file }}"

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-taskfiles.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-taskfiles.yml
@@ -43,7 +43,11 @@ jobs:
           location: ${{ runner.temp }}/taskfile-schema
 
       - name: Install JSON schema validator
-        run: sudo npm install --global ajv-cli
+        run: |
+          sudo npm install \
+            --global \
+            ajv-cli \
+            ajv-formats
 
       - name: Validate ${{ matrix.file }}
         run: |
@@ -51,5 +55,6 @@ jobs:
           ajv validate \
             --all-errors \
             --strict=false \
+            -c ajv-formats \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ matrix.file }}"

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
@@ -37,13 +37,18 @@ jobs:
           location: ${{ runner.temp }}/label-configuration-schema
 
       - name: Install JSON schema validator
-        run: sudo npm install --global ajv-cli
+        run: |
+          sudo npm install \
+            --global \
+            ajv-cli \
+            ajv-formats
 
       - name: Validate local labels configuration
         run: |
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
             --all-errors \
+            -c ajv-formats \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
 

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -37,13 +37,18 @@ jobs:
           location: ${{ runner.temp }}/label-configuration-schema
 
       - name: Install JSON schema validator
-        run: sudo npm install --global ajv-cli
+        run: |
+          sudo npm install \
+            --global \
+            ajv-cli \
+            ajv-formats
 
       - name: Validate local labels configuration
         run: |
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
             --all-errors \
+            -c ajv-formats \
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
 


### PR DESCRIPTION
Support for[ the JSON schema "format" keyword](https://json-schema.org/understanding-json-schema/reference/string.html#format) was moved to a separate package in [ajv v7.0.0](https://github.com/ajv-validator/ajv/releases/tag/v7.0.0) ([ajv-cli v4.0.0](https://github.com/ajv-validator/ajv-cli/releases/tag/v4.0.0)). If this [ajv-formats](https://github.com/ajv-validator/ajv-formats) package is not installed and specified as a module via the `ajv-cli` command, validation against any schema that uses `"format"` fails, even when the instance document is completely valid. Even though none of the JSON schemas currently in use by the templates and CI system have a `"format"` keyword, there's no reason one couldn't be added at any moment, so it's safest to just add
support now.

The change to ajv was done for [security purposes](https://github.com/ajv-validator/ajv/blob/master/docs/security.md#security-risks-of-trusted-schemas) when used with untrusted data, which is not a concern here.