### PR TITLE
Fix file patterns used to match both YAML file extensions in label sync template

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -72,7 +72,9 @@ jobs:
       - name: Pass configuration files to next job via workflow artifact
         uses: actions/upload-artifact@v2
         with:
-          path: "*.ya?ml"
+          path: |
+            *.yaml
+            *.yml
           if-no-files-found: error
           name: ${{ env.CONFIGURATIONS_ARTIFACT }}
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -115,7 +115,8 @@ jobs:
       - name: Merge label configuration files
         run: |
           # Merge all configuration files
-          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.{yml,yaml} > "${{ env.MERGED_CONFIGURATION_PATH }}"
+          shopt -s extglob
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) > "${{ env.MERGED_CONFIGURATION_PATH }}"
 
       - name: Install github-label-sync
         run: sudo npm install --global github-label-sync

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
@@ -72,7 +72,9 @@ jobs:
       - name: Pass configuration files to next job via workflow artifact
         uses: actions/upload-artifact@v2
         with:
-          path: "*.ya?ml"
+          path: |
+            *.yaml
+            *.yml
           if-no-files-found: error
           name: ${{ env.CONFIGURATIONS_ARTIFACT }}
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/sync-labels.yml
@@ -115,7 +115,8 @@ jobs:
       - name: Merge label configuration files
         run: |
           # Merge all configuration files
-          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.{yml,yaml} > "${{ env.MERGED_CONFIGURATION_PATH }}"
+          shopt -s extglob
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) > "${{ env.MERGED_CONFIGURATION_PATH }}"
 
       - name: Install github-label-sync
         run: sudo npm install --global github-label-sync

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -72,7 +72,9 @@ jobs:
       - name: Pass configuration files to next job via workflow artifact
         uses: actions/upload-artifact@v2
         with:
-          path: "*.ya?ml"
+          path: |
+            *.yaml
+            *.yml
           if-no-files-found: error
           name: ${{ env.CONFIGURATIONS_ARTIFACT }}
 

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -115,7 +115,8 @@ jobs:
       - name: Merge label configuration files
         run: |
           # Merge all configuration files
-          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.{yml,yaml} > "${{ env.MERGED_CONFIGURATION_PATH }}"
+          shopt -s extglob
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) > "${{ env.MERGED_CONFIGURATION_PATH }}"
 
       - name: Install github-label-sync
         run: sudo npm install --global github-label-sync


### PR DESCRIPTION
Because I have noticed both `.yml` and `.yaml` in use in Arduino tooling projects, I decided to add in support for both in the templates. This was done as a bit of an afterthought and not tested well. The expected failure of the label sync workflow while it was hosted in the staging repository masked the unexpected failure caused by these bugs.