### PR TITLE
Add missing asset to docs for "Test Integration" workflow (Go, Task) template

### DIFF
--- a/workflow-templates/test-go-integration-task.md
+++ b/workflow-templates/test-go-integration-task.md
@@ -16,6 +16,8 @@ Install the [`test-go-integration-task.yml`](test-go-integration-task.yml) GitHu
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/go-task/Taskfile.yml) - Build task.
   - Merge into `Taskfile.yml`.
+- [`Taskfile.yml`](assets/poetry-task/Taskfile.yml) - Dependencies installation task.
+  - Merge into `Taskfile.yml`
 - [`__init__.py`](assets/test-python/__init__.py) - Template for Python integration tests.
   - Install to: `tests/`
 - [`test_all.py`](assets/test-integration/test_all.py) - Template for Python integration tests.


### PR DESCRIPTION
The template requires the installation of the `poetry:install-deps` task, but this "asset" was not mentioned in the
installation instructions.