### PR TITLE
Update "Check Python" template's black dependency to ^21.7b0

### DIFF
--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -31,14 +31,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="black@^21.5b0" --dev-dependency="flake8@^3.9.2" --dev-dependency="pep8-naming@^0.12.0"
+poetry init --python="^3.9" --dev-dependency="black@^21.7b0" --dev-dependency="flake8@^3.9.2" --dev-dependency="pep8-naming@^0.12.0"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "black@^21.5b0" "flake8@^3.9.2" "pep8-naming@^0.12.0"
+poetry add --dev "black@^21.7b0" "flake8@^3.9.2" "pep8-naming@^0.12.0"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
This is the latest version, which we have already updating to using in several projects, including this one (https://github.com/arduino/tooling-project-assets/pull/108), with no problems.