### PR TITLE
Use Go 1.16 in all templates

### DIFF
--- a/workflow-templates/assets/cobra/docsgen/go.mod
+++ b/workflow-templates/assets/cobra/docsgen/go.mod
@@ -2,7 +2,7 @@
 // TODO: replace MODULE_NAME with the project's module name
 module MODULE_NAME/docsgen
 
-go 1.14
+go 1.16
 
 replace MODULE_NAME => ../
 

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -3,7 +3,7 @@ name: Check Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
@@ -3,7 +3,7 @@ name: Check Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -3,7 +3,7 @@ name: Test Integration
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9"
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -3,7 +3,7 @@ name: Test Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -3,7 +3,7 @@ name: Test Integration
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9"
 

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -3,7 +3,7 @@ name: Test Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.14"
+  GO_VERSION: "1.16"
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:


### PR DESCRIPTION
We are now using Go 1.16 in the release and nightly templates (https://github.com/arduino/tooling-project-assets/pull/110), I think it makes sense to use the same version for testing, linting, and command line documentation generation.