### PR TITLE
Bump GitPython dependency of "Deploy Website" workflow (versioned, MkDocs, Poetry) template

### DIFF
--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -33,7 +33,7 @@ See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs
 
 1. Run this command:
    ```
-   poetry add --dev "gitpython@^3.1.1" "mike@^1.0.1"
+   poetry add --dev "gitpython@^3.1.19" "mike@^1.0.1"
    ```
 1. Commit the resulting `pyproject.toml` and `poetry.lock` files.
 


### PR DESCRIPTION
Since we are using GitPython 3.1.19 when testing the versioning helper script used by this template  (https://github.com/arduino/tooling-project-assets/pull/112), it seems best to specify that as the minimum version.