### PR TITLE
Update "Check YAML" template's yamllint dependency to ^1.26.2

### DIFF
--- a/workflow-templates/check-yaml-task.md
+++ b/workflow-templates/check-yaml-task.md
@@ -33,14 +33,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="yamllint@^1.26.1"
+poetry init --python="^3.9" --dev-dependency="yamllint@^1.26.2"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "yamllint@^1.26.1"
+poetry add --dev "yamllint@^1.26.2"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
The update makes a fix to the tool's package metadata which is not directly relevant to its functionality, but is essential to preserve compatibility with Poetry.

We are already using the new version in this project's own infrastructure (https://github.com/arduino/tooling-project-assets/pull/116).