### PR TITLE
Add Git configuration files to template `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,3 +55,6 @@ indent_style = space
 [*.{yaml,yml}]
 indent_size = 2
 indent_style = space
+
+[{.gitconfig,.gitmodules}]
+indent_style = tab

--- a/workflow-templates/assets/general/.editorconfig
+++ b/workflow-templates/assets/general/.editorconfig
@@ -55,3 +55,6 @@ indent_style = space
 [*.{yaml,yml}]
 indent_size = 2
 indent_style = space
+
+[{.gitconfig,.gitmodules}]
+indent_style = tab


### PR DESCRIPTION
[The `.gitmodules` file](https://git-scm.com/docs/gitmodules) defines the properties of a repository's submodules. The file automatically generated by Git submodule commands use tabs for indentation.

It uses the same file format as [the Git configuration file](https://git-scm.com/docs/git-config#_configuration_file) (e.g., `.gitconfig`). Even though the `.gitconfig` file is not likely to be found under the repository tree, it's possible the `.editorconfig` might end up being used outside the project specific scope so I added it to the file pattern.