### PR TITLE
Generate tester builds on the modification of any relevant file

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-tester-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-tester-task.yml
@@ -9,6 +9,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
+      - "DistTasks.ya?ml"
       - "**.go"
   pull_request:
     paths:
@@ -16,6 +17,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
+      - "DistTasks.ya?ml"
       - "**.go"
   workflow_dispatch:
   repository_dispatch:

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -9,6 +9,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
+      - "DistTasks.ya?ml"
       - "**.go"
   pull_request:
     paths:
@@ -16,6 +17,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
+      - "DistTasks.ya?ml"
       - "**.go"
   workflow_dispatch:
   repository_dispatch:


### PR DESCRIPTION
Tester builds are intended to facilitate pull request review and beta testing. For the sake of efficiency, the paths
filter should be configured to skip tester build generation on changes that have no effect on the binary, but also so
that they are always generated on any modification to a relevant file. Since the `DistTasks.yml` file is used to build
the application, it is very much relevant.