### PR TITLE
Fix invalid tester build version prefix

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-tester-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-tester-task.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build
         run: |
-          PACKAGE_NAME_PREFIX="${{ github.workflow }}"
+          PACKAGE_NAME_PREFIX="test"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.event.number }}"
           fi

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build
         run: |
-          PACKAGE_NAME_PREFIX="${{ github.workflow }}"
+          PACKAGE_NAME_PREFIX="test"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.event.number }}"
           fi


### PR DESCRIPTION
Previously, the workflow name value was used as a component of the "PACKAGE_NAME_PREFIX" used to add identifying information to the version output and file names of tester builds. That happened to work when used with the "test" name
of [the source workflow](https://github.com/arduino/arduino-cli/blob/e31a717ebc34fff80892dbbe25a9d4581906e13a/.github/workflows/test.yaml). However, due to a lack of quoting in the build commands, once the tester build operation was moved to a dedicated workflow with a more descriptive name, it broke the build.

Example:
```
task: [dist:Windows_32bit] docker run -v `pwd`/..:/home/build -w /home/build \
-e CGO_ENABLED=1 \
docker.elastic.co/beats-dev/golang-crossbuild:1.16.4-main \
--build-cmd "go build -o dist/arduino-lint_windows_386/arduino-lint.exe -ldflags ' -X github.com/arduino/arduino-lint/internal/configuration.Version=Publish Tester Build-fd29502e32d5386607787a5e82e058dffda5a63a-git-snapshot -X github.com/arduino/arduino-lint/internal/configuration.Commit=fd29502 -X github.com/arduino/arduino-lint/internal/configuration.Timestamp=2021-08-05T22:23:50Z '" \
-p "windows/386"

zip arduino-lint_Publish Tester Build-fd29502e32d5386607787a5e82e058dffda5a63a-git-snapshot_Windows_32bit.zip arduino-lint_windows_386/arduino-lint.exe ../LICENSE.txt -j
sha256sum arduino-lint_Publish Tester Build-fd29502e32d5386607787a5e82e058dffda5a63a-git-snapshot_Windows_32bit.zip >> Publish Tester Build-fd29502e32d5386607787a5e82e058dffda5a63a-git-snapshot-checksums.txt
```
Although it could be supported with appropriate quoting, the use of the workflow name doesn't really make sense in this application. The sole use of the workflow name should be to identify the workflow to humans. It's not really suitable for
machine consumption such as file names. So the best fix for this specific bug is to hard code the identifier in the prefix, retaining the original "test" for consistency.