### PR TITLE
Run Go integration tests on all operating systems

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -34,7 +34,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        operating-system:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    runs-on: ${{ matrix.operating-system }}
 
     steps:
       - name: Checkout repository

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -34,7 +34,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        operating-system:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    runs-on: ${{ matrix.operating-system }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Bugs can sometimes be operating system-specific, so it's important to test with all of them. This was done in[ the source
workflow](https://github.com/arduino/arduino-cli/blob/e31a717ebc34fff80892dbbe25a9d4581906e13a/.github/workflows/test.yaml), but ended up being lost when the  integration testing functionality was moved to a dedicated workflow.