### PR TITLE
Add Codecov upload step to "Test Go" workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -10,6 +10,7 @@ on:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
+      - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
@@ -18,6 +19,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
+      - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
@@ -54,3 +56,11 @@ jobs:
 
       - name: Run tests
         run: task go:test
+
+      - name: Send unit tests coverage to Codecov
+        if: matrix.operating-system == 'ubuntu-latest'
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage_unit.txt
+          flags: unit
+          fail_ci_if_error: true

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -40,9 +40,11 @@ Markdown badge:
 
 ```markdown
 [![Test Go status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-go-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-go-task.yml)
+[![Codecov](https://codecov.io/gh/REPO_OWNER/REPO_NAME/branch/main/graph/badge.svg)](https://codecov.io/gh/REPO_OWNER/REPO_NAME)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+- Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+- If the coverage badge should reflect the coverage for a branch named something other than `main`, adjust the badge URL accordingly.
 
 ---
 
@@ -50,9 +52,11 @@ Asciidoc badge:
 
 ```adoc
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/test-go-task.yml/badge.svg["Test Go status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/test-go-task.yml"]
+image:https://codecov.io/gh/{repository-owner}/{repository-name}/branch/main/graph/badge.svg["Codecov", link="https://codecov.io/gh/{repository-owner}/{repository-name}"]
 ```
 
-Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+- Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+- If the coverage badge should reflect the coverage for a branch named something other than `main`, adjust the badge URL accordingly.
 
 ## Commit message
 

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -10,6 +10,7 @@ on:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
+      - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
@@ -18,6 +19,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
+      - "codecov.ya?ml"
       - "go.mod"
       - "go.sum"
       - "Taskfile.ya?ml"
@@ -54,3 +56,11 @@ jobs:
 
       - name: Run tests
         run: task go:test
+
+      - name: Send unit tests coverage to Codecov
+        if: matrix.operating-system == 'ubuntu-latest'
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage_unit.txt
+          flags: unit
+          fail_ci_if_error: true


### PR DESCRIPTION
This will record the project's test coverage data on Codecov, as was done in [the source workflow](https://github.com/arduino/arduino-cli/blob/e31a717ebc34fff80892dbbe25a9d4581906e13a/.github/workflows/test.yaml), but somehow didn't make it into the template.

Markup is provided for badges that will display the % coverage and link to the project's data (e.g., [![Codecov](https://codecov.io/gh/arduino/arduino-lint/graph/badge.svg)](https://codecov.io/gh/arduino/arduino-lint)).