### PR TITLE
Add support for multiple modules to "Check Go" workflow

### DIFF
--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -116,7 +116,16 @@ jobs:
         run: git diff --color --exit-code
 
   check-config:
+    name: check-config (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -128,6 +137,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Run go mod tidy
+        working-directory: ${{ matrix.module.path }}
         run: go mod tidy
 
       - name: Check whether any tidying was needed

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
@@ -116,7 +116,16 @@ jobs:
         run: git diff --color --exit-code
 
   check-config:
+    name: check-config (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -128,6 +137,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Run go mod tidy
+        working-directory: ${{ matrix.module.path }}
         run: go mod tidy
 
       - name: Check whether any tidying was needed


### PR DESCRIPTION
The `check-config` job of the "Check Go" workflow runs a check to see whether there were any missed updates to the `go.mod` and `go.sum` files. Previously, only a single module was supported. But a project might have multiple modules, as is the case with any project that uses the Cobra command line reference generation system.

The use of a job matrix will allow the workflow to accommodate any number of modules a project may contain, at any location.