### PR TITLE
Make go:lint task compatible with Go 1.16

### DIFF
--- a/workflow-templates/assets/check-go-task/Taskfile.yml
+++ b/workflow-templates/assets/check-go-task/Taskfile.yml
@@ -30,14 +30,12 @@ tasks:
     desc: Lint Go code
     cmds:
       - |
-        PROJECT_PATH="$PWD"
-        # `go get` and `go list` commands must be run from a temporary folder to avoid polluting go.mod
-        cd "$(mktemp -d "${TMPDIR-${TMP-/tmp}}/task-temporary-XXXXX")"
-        go get golang.org/x/lint/golint
-        GOLINT_PATH="$(go list -f '{{"{{"}}.Target{{"}}"}}' golang.org/x/lint/golint || echo "false")"
-        # `golint` must be run from the module folder
-        cd "$PROJECT_PATH"
-        "$GOLINT_PATH" \
+        if ! which golint &>/dev/null; then
+          echo "golint not installed or not in PATH. Please install: https://github.com/golang/lint#installation"
+          exit 1
+        fi
+      - |
+        golint \
           {{default "-min_confidence 0.8 -set_exit_status" .GO_LINT_FLAGS}} \
           {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -88,6 +88,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install golint
+        run: go install golang.org/x/lint/golint@latest
+
       - name: Check style
         run: task --silent go:lint
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
@@ -88,6 +88,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install golint
+        run: go install golang.org/x/lint/golint@latest
+
       - name: Check style
         run: task --silent go:lint
 


### PR DESCRIPTION
The update from Go 1.14 to 1.16 broke the task that runs golint. The good news is that[ the new `go install` command ](https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies)eliminates the need for the workaround of running the `go get golang.org/x/lint/golint` command from outside the project path to avoid polluting go.mod/go.sum.

The bad news is the `go list` command used to get the path of the golint installation does not work in the "module-aware
mode" that is now the default (and will be the only as of Go 1.17):
```
missing go.sum entry for module providing package golang.org/x/lint/golint; to add:
        go mod download golang.org/x/lint
task: Command "go list -f {{".Target}}" golang.org/x/lint/golint" failed: exit status 1
```
In the end, I gave up on making the task work as before. I think it's better to require
the user to install golint and put the installation in the system PATH, displaying a helpful message when this has not
been done.

We plan to evaluate golangci-lint as a replacement for golint, and perhaps this will change the situation, but for now at
least the check is back to a relatively functional state again.