### PR TITLE
Add missing install docs for "Check Go" asset

### DIFF
--- a/workflow-templates/assets/go-task/Taskfile.yml
+++ b/workflow-templates/assets/go-task/Taskfile.yml
@@ -2,6 +2,8 @@
 version: "3"
 
 vars:
+  DEFAULT_GO_PACKAGES:
+    sh: echo $(go list ./... | tr '\n' ' ')
   LDFLAGS:
 
 tasks:

--- a/workflow-templates/assets/test-go-task/Taskfile.yml
+++ b/workflow-templates/assets/test-go-task/Taskfile.yml
@@ -1,10 +1,6 @@
 # See: https://taskfile.dev/#/usage
 version: "3"
 
-vars:
-  DEFAULT_GO_PACKAGES:
-    sh: echo $(go list ./... | tr '\n' ' ')
-
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
   go:test:

--- a/workflow-templates/check-go-task.md
+++ b/workflow-templates/check-go-task.md
@@ -12,6 +12,8 @@ Install the [`check-go-task.yml`](check-go-task.yml) GitHub Actions workflow to 
 
 - [`Taskfile.yml`](assets/check-go-task/Taskfile.yml) - Linting and formatting [tasks](https://taskfile.dev/).
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
+- [`Taskfile.yml`](assets/go-task/Taskfile.yml) - `DEFAULT_GO_PACKAGES` variable
+  - Merge into `Taskfile.yml`
 
 ### Configuration
 

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -14,6 +14,8 @@ Install the [`test-go-task.yml`](test-go-task.yml) GitHub Actions workflow to `.
 
 - [`Taskfile.yml`](assets/test-go-task/Taskfile.yml)
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
+- [`Taskfile.yml`](assets/go-task/Taskfile.yml) - `DEFAULT_GO_PACKAGES` variable
+  - Merge into `Taskfile.yml`
 
 ### Configuration
 


### PR DESCRIPTION
The tasks used by "Check Go" and "Test Go" workflows use the `DEFAULT_GO_PACKAGES` taskfile variable, which provides a list of all the repository's Go packages. The variable was previously located in the "test-go-task" assets, and so implicitly covered by the "Test Go" workflow's installation instructions. However, it was not present in the assets for the "Check Go" workflow.

The solution is to move this shared asset to the general purpose "go-task" assets and add instructions to both workflows' docs for the installation of that asset.