### PR TITLE
Remove superfluous checkout step from "Release" workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -125,9 +125,6 @@ jobs:
     needs: notarize-macos
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -125,9 +125,6 @@ jobs:
     needs: notarize-macos
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
The `create-release` job of the "Release" workflow creates a GitHub release and uploads the built binaries as release assets. Since the binaries come from the workflow artifact, there is no need for this job to checkout the repository. The pre-release identification step uses [the `GITHUB_REF` environment variable defined by GitHub Actions](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables), which is not dependent on the runner having a repository checked out.

This means the checkout step serves no purpose. Since it makes the workflow less efficient and more difficult to maintain, it must be removed.

---
Demonstration workflow run with this change: https://github.com/per1234/arduino-lint/runs/3276843334
The resulting release: https://github.com/per1234/arduino-lint/releases/tag/1.2.4