### PR TITLE
Run formatting task after documentation generation

### DIFF
--- a/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
+++ b/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
@@ -9,6 +9,7 @@ tasks:
     desc: Create all generated documentation content
     deps:
       - task: go:cli-docs
+    cmds:
       # Make the formatting consistent with the non-generated Markdown
       - task: general:format-prettier
 


### PR DESCRIPTION
The tasks under [the `deps` key](https://taskfile.dev/#/usage?id=task-dependencies) run in parallel, which is not appropriate for the task that is intended to format the output from the documentation generation tasks. The generation tasks will typically be able to run concurrently, so the `go:cli-docs` task can stay in `deps`, but the formatting task must be[ placed in `cmds`](https://taskfile.dev/#/usage?id=calling-another-task), which will cause it to run after
all tasks in `deps` have finished.