### PR TITLE
Bump `github.com/spf13/cobra` command docs generation dependency to v1.2.1

### DIFF
--- a/workflow-templates/assets/cobra/docsgen/go.mod
+++ b/workflow-templates/assets/cobra/docsgen/go.mod
@@ -8,5 +8,5 @@ replace MODULE_NAME => ../
 
 require (
 	MODULE_NAME v0.0.0
-	github.com/spf13/cobra v1.1.1
+	github.com/spf13/cobra v1.2.1
 )


### PR DESCRIPTION
I reviewed [the changes since v1.1.1](https://github.com/spf13/cobra/compare/v1.1.1...v1.2.1) and [tested it in Arduino Lint](https://github.com/arduino/arduino-lint/pull/253) and found it to be OK.