### PR TITLE
Add explanatory comment re: release asset upload warning

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -147,6 +147,8 @@ jobs:
           bodyFile: ${{ env.DIST_DIR }}/CHANGELOG.md
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
+          # NOTE: "Artifact is a directory" warnings are expected and don't indicate a problem
+          # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
       - name: Upload release files on Arduino downloads servers

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -147,6 +147,8 @@ jobs:
           bodyFile: ${{ env.DIST_DIR }}/CHANGELOG.md
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
+          # NOTE: "Artifact is a directory" warnings are expected and don't indicate a problem
+          # (all the files we need are in the DIST_DIR root)
           artifacts: ${{ env.DIST_DIR }}/*
 
       - name: Upload release files on Arduino downloads servers


### PR DESCRIPTION
The subfolders that remain in the Go release system's build output cause a bunch of warnings in the workflow run summary and logs resulting from the step that uploads the archives as release assets:

```
Warning: Artifact is a directory:dist/serial-discovery_0.0.42_Linux_32bit/. Directories can not be uploaded to a release.
Warning: Artifact is a directory:dist/serial-discovery_0.0.42_Linux_64bit/. Directories can not be uploaded to a release.
Warning: Artifact is a directory:dist/serial-discovery_0.0.42_Linux_ARM64/. Directories can not be uploaded to a release.
Warning: Artifact is a directory:dist/serial-discovery_0.0.42_Linux_ARMv6/. Directories can not be uploaded to a release.
Warning: Artifact is a directory:dist/serial-discovery_0.0.42_Linux_ARMv7/. Directories can not be uploaded to a release.
Warning: Artifact is a directory:dist/serial-discovery_0.0.42_macOS_64bit/. Directories can not be uploaded to a release.
Warning: Artifact is a directory:dist/serial-discovery_0.0.42_Windows_32bit/. Directories can not be uploaded to a release.
Warning: Artifact is a directory:dist/serial-discovery_0.0.42_Windows_64bit/. Directories can not be uploaded to a release.
```

There is no problem because these subfolders are not intended to be added as release assets and the archives in the root of the `dist` folder are uploaded, but I think these warnings might cause someone confusion far in the future when nobody remembers exactly how these workflows work and wonders if these warnings indicate something is wrong.

I didn't find a clean solution for adjusting the artifacts input glob to exclude the subfolders so I settled on adding an explanatory comment to the workflow.

---
Previous discussion and approval for this change: https://github.com/arduino/serial-discovery/pull/18#pullrequestreview-724994318