### PR TITLE
Bump "Check Python" template's `pep8-naming` dependency

### DIFF
--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -31,14 +31,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="black@^21.7b0" --dev-dependency="flake8@^3.9.2" --dev-dependency="pep8-naming@^0.12.0"
+poetry init --python="^3.9" --dev-dependency="black@^21.7b0" --dev-dependency="flake8@^3.9.2" --dev-dependency="pep8-naming@^0.12.1"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "black@^21.7b0" "flake8@^3.9.2" "pep8-naming@^0.12.0"
+poetry add --dev "black@^21.7b0" "flake8@^3.9.2" "pep8-naming@^0.12.1"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
I have evaluated the changes since 0.12.0 and found nothing to be concerned about. We have already updated to this version in several projects, including in this repository's own infrastructure (https://github.com/arduino/tooling-project-assets/pull/129).