### PR TITLE
Fix typo in template workflow documentation

### DIFF
--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -43,7 +43,7 @@ Commit the resulting `pyproject.toml` and `poetry.lock` files.
 
 #### Workflow
 
-The workflow is configured for repositories that host the website source content in a branch named `main`. If the project uses a different branch, adjust the `on.push.branches[]` value in `check-workflows-task.yml`.
+The workflow is configured for repositories that host the website source content in a branch named `main`. If the project uses a different branch, adjust the `on.push.branches[]` value in `deploy-mkdocs-poetry.yml`.
 
 #### MkDocs
 


### PR DESCRIPTION
A copy/paste error resulted in the wrong workflow filename being referenced in the configuration instructions.