### PR TITLE
Bump `mkdocs-material` website dependency to ^7.2.4

### DIFF
--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -27,14 +27,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="mkdocs@^1.2.1" --dev-dependency="mkdocs-material@^7.1.8" --dev-dependency="mdx_truly_sane_lists@^1.2"
+poetry init --python="^3.9" --dev-dependency="mkdocs@^1.2.1" --dev-dependency="mkdocs-material@^7.2.4" --dev-dependency="mdx_truly_sane_lists@^1.2"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "mkdocs@^1.2.1" "mkdocs-material@^7.1.8" "mdx_truly_sane_lists@^1.2"
+poetry add --dev "mkdocs@^1.2.1" "mkdocs-material@^7.2.4" "mdx_truly_sane_lists@^1.2"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
I have reviewed the changes and found nothing of concern.

This is the version now in use for the Arduino Lint website without problems: https://github.com/arduino/arduino-lint/pull/256

"dev" deployment using `mkdocs-material@7.2.4`:
- https://github.com/arduino/arduino-lint/actions/runs/1123035833
- https://arduino.github.io/arduino-lint/dev/

Test release deployment in my fork using  `mkdocs-material@7.2.4`:
- https://github.com/per1234/arduino-lint/actions/runs/1123028041
- https://per1234.github.io/arduino-lint/1.3/