### PR TITLE
Add multi-module support to Go "templates"

### DIFF
--- a/workflow-templates/assets/check-go-task/Taskfile.yml
+++ b/workflow-templates/assets/check-go-task/Taskfile.yml
@@ -12,18 +12,21 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:vet:
     desc: Check for errors in Go code
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - go vet {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:fix:
     desc: Modernize usages of outdated APIs
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - go fix {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:lint:
     desc: Lint Go code
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - |
         if ! which golint &>/dev/null; then
@@ -38,5 +41,6 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:format:
     desc: Format Go code
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - go fmt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}

--- a/workflow-templates/assets/check-go-task/Taskfile.yml
+++ b/workflow-templates/assets/check-go-task/Taskfile.yml
@@ -1,10 +1,6 @@
 # See: https://taskfile.dev/#/usage
 version: "3"
 
-vars:
-  DEFAULT_GO_PACKAGES:
-    sh: echo $(go list ./... | tr '\n' ' ')
-
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:check:

--- a/workflow-templates/assets/go-task/Taskfile.yml
+++ b/workflow-templates/assets/go-task/Taskfile.yml
@@ -3,7 +3,8 @@ version: "3"
 
 vars:
   DEFAULT_GO_PACKAGES:
-    sh: echo $(go list ./... | tr '\n' ' ')
+    sh: |
+      echo $(cd {{default "./" .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
   LDFLAGS:
 
 tasks:

--- a/workflow-templates/assets/test-go-task/Taskfile.yml
+++ b/workflow-templates/assets/test-go-task/Taskfile.yml
@@ -5,6 +5,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
   go:test:
     desc: Run unit tests
+    dir: '{{default "./" .GO_MODULE_PATH}}'
     cmds:
       - |
         go test \

--- a/workflow-templates/check-go-task.md
+++ b/workflow-templates/check-go-task.md
@@ -19,6 +19,14 @@ Install the [`check-go-task.yml`](check-go-task.yml) GitHub Actions workflow to 
 
 Configure the version of Go used for development of the project in the `env.GO_VERSION` field of `check-go-task.yml`.
 
+If the project contains Go modules in paths other than the root of the repository, add their paths to the [job matrices](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) of `check-go-task.yml` at:
+
+- `jobs.check-errors.strategy.matrix.module[].path`
+- `jobs.check-outdated.strategy.matrix.module[].path`
+- `jobs.check-style.strategy.matrix.module[].path`
+- `jobs.check-formatting.strategy.matrix.module[].path`
+- `jobs.check-config.strategy.matrix.module[].path`
+
 ### Readme badge
 
 Markdown badge:

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -11,22 +11,31 @@ on:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
       - "Taskfile.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.go"
   pull_request:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
       - "Taskfile.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.go"
   workflow_dispatch:
   repository_dispatch:
 
 jobs:
   check-errors:
+    name: check-errors (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -44,10 +53,21 @@ jobs:
           version: 3.x
 
       - name: Check for errors
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:vet
 
   check-outdated:
+    name: check-outdated (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -65,13 +85,24 @@ jobs:
           version: 3.x
 
       - name: Modernize usages of outdated APIs
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:fix
 
       - name: Check if any fixes were needed
         run: git diff --color --exit-code
 
   check-style:
+    name: check-style (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -92,10 +123,21 @@ jobs:
         run: go install golang.org/x/lint/golint@latest
 
       - name: Check style
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task --silent go:lint
 
   check-formatting:
+    name: check-formatting (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -113,6 +155,8 @@ jobs:
           version: 3.x
 
       - name: Format code
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:format
 
       - name: Check formatting

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
@@ -11,22 +11,31 @@ on:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
       - "Taskfile.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.go"
   pull_request:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
       - "Taskfile.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "**.go"
   workflow_dispatch:
   repository_dispatch:
 
 jobs:
   check-errors:
+    name: check-errors (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -44,10 +53,21 @@ jobs:
           version: 3.x
 
       - name: Check for errors
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:vet
 
   check-outdated:
+    name: check-outdated (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -65,13 +85,24 @@ jobs:
           version: 3.x
 
       - name: Modernize usages of outdated APIs
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:fix
 
       - name: Check if any fixes were needed
         run: git diff --color --exit-code
 
   check-style:
+    name: check-style (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -92,10 +123,21 @@ jobs:
         run: go install golang.org/x/lint/golint@latest
 
       - name: Check style
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task --silent go:lint
 
   check-formatting:
+    name: check-formatting (${{ matrix.module.path }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
 
     steps:
       - name: Checkout repository
@@ -113,6 +155,8 @@ jobs:
           version: 3.x
 
       - name: Format code
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:format
 
       - name: Check formatting

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -11,8 +11,8 @@ on:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
       - "codecov.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "Taskfile.ya?ml"
       - "**.go"
       - "**/testdata/**"
@@ -20,8 +20,8 @@ on:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
       - "codecov.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "Taskfile.ya?ml"
       - "**.go"
       - "**/testdata/**"
@@ -30,12 +30,20 @@ on:
 
 jobs:
   test:
+    name: test (${{ matrix.module.path }} - ${{ matrix.operating-system }})
+
     strategy:
+      fail-fast: false
+
       matrix:
         operating-system:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
+            codecov-flags: unit
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -55,12 +63,14 @@ jobs:
           version: 3.x
 
       - name: Run tests
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:test
 
       - name: Send unit tests coverage to Codecov
         if: matrix.operating-system == 'ubuntu-latest'
         uses: codecov/codecov-action@v2
         with:
-          file: ./coverage_unit.txt
-          flags: unit
+          file: ${{ matrix.module.path }}coverage_unit.txt
+          flags: ${{ matrix.module.codecov-flags }}
           fail_ci_if_error: true

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -23,6 +23,8 @@ Install the [`test-go-task.yml`](test-go-task.yml) GitHub Actions workflow to `.
 
 Configure the version of Go used for development of the project in the `env.GO_VERSION` field of `test-go-task.yml`.
 
+If the project contains Go modules in paths other than the root of the repository, add their paths to the [job matrix](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) in `check-go-task.yml` at `jobs.test.strategy.matrix.module[].path` and the [Codecov flag](https://docs.codecov.com/docs/flags) to group their data under at `jobs.test.strategy.matrix.module[].codecov-flags`
+
 #### `.gitignore`
 
 Add the following to `.gitignore`:

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -11,8 +11,8 @@ on:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
       - "codecov.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "Taskfile.ya?ml"
       - "**.go"
       - "**/testdata/**"
@@ -20,8 +20,8 @@ on:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
       - "codecov.ya?ml"
-      - "go.mod"
-      - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "Taskfile.ya?ml"
       - "**.go"
       - "**/testdata/**"
@@ -30,12 +30,20 @@ on:
 
 jobs:
   test:
+    name: test (${{ matrix.module.path }} - ${{ matrix.operating-system }})
+
     strategy:
+      fail-fast: false
+
       matrix:
         operating-system:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        module:
+          # TODO: add paths of all Go modules here
+          - path: ./
+            codecov-flags: unit
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -55,12 +63,14 @@ jobs:
           version: 3.x
 
       - name: Run tests
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: task go:test
 
       - name: Send unit tests coverage to Codecov
         if: matrix.operating-system == 'ubuntu-latest'
         uses: codecov/codecov-action@v2
         with:
-          file: ./coverage_unit.txt
-          flags: unit
+          file: ${{ matrix.module.path }}coverage_unit.txt
+          flags: ${{ matrix.module.codecov-flags }}
           fail_ci_if_error: true


### PR DESCRIPTION
The templates for testing, linting, and formatting Go code work from a list of packages of the Go module which is output
from a `go list` command. Previously, it was only possible to get the packages of the module in the root of the repository.

Projects may contain multiple Go modules in subfolders of the repository. In order to support checks on these modules,
it's necessary to configure the commands to run from their path. This is passed to the task via the `GO_MODULE_PATH`
environment variable. If this variable is not defined, the default root module path is used as default, preserving the
previous task behavior.

The workflows use a job matrix to allow easy configuration for any number of module paths and a dedicated parallel job
for each module.

Because it may not be desirable to combine the code coverage data for all modules, a Codecov flag value can be defined for each matrix job in the "Test Go" workflow. This workflow produces a two dimensional "operating system * module" job matrix, running the tests for each module using all operating systems.

---
Demo of "Check Go" template in action: https://github.com/arduino/arduino-cli/actions/runs/1123382544

Demo of "Test Go" template in action: https://github.com/per1234/arduino-lint/actions/runs/1123365635