### PR TITLE
Specify full path to helper script in versioned website docs

### DIFF
--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
@@ -64,7 +64,7 @@ See the ["Deploy Website" workflow (versioned, MkDocs, Poetry) documentation](de
 The system is configured for the repository branch used as the source for the "dev" website version having the name `main`. If the project's development branch has another name, then configure it:
 
 - `on.push.branches[0]` in `deploy-cobra-mkdocs-versioned-poetry.yml`
-- `DEV_BRANCHES` in [`siteversion/siteversion.py`](assets/deploy-mkdocs-versioned/siteversion/siteversion.py)
+- `DEV_BRANCHES` in [`docs/siteversion/siteversion.py`](assets/deploy-mkdocs-versioned/siteversion/siteversion.py)
 
 #### Configure `.gitignore`
 

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -48,7 +48,7 @@ See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs
 The system is configured for the repository branch used as the source for the "dev" website version having the name `main`. If the project's development branch has another name, then configure it:
 
 - `on.push.branches[0]` in `deploy-mkdocs-versioned-poetry.yml`
-- `DEV_BRANCHES` in [`siteversion/siteversion.py`](assets/deploy-mkdocs-versioned/siteversion/siteversion.py)
+- `DEV_BRANCHES` in [`docs/siteversion/siteversion.py`](assets/deploy-mkdocs-versioned/siteversion/siteversion.py)
 
 #### Configure Material theme for versioning
 


### PR DESCRIPTION
The "siteversion" Python script used by the versioned website templates is installed to
`docs/siteversion/siteversion.py`.

The configuration instructions for this script previously omitted the `docs` part of that path, which might cause
confusion.