### PR TITLE
Don't require Codecov upload success for test run in fork

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -73,4 +73,4 @@ jobs:
         with:
           file: ${{ matrix.module.path }}coverage_unit.txt
           flags: ${{ matrix.module.codecov-flags }}
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.repository == 'REPO_OWNER/REPO_NAME' }}

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -25,6 +25,8 @@ Configure the version of Go used for development of the project in the `env.GO_V
 
 If the project contains Go modules in paths other than the root of the repository, add their paths to the [job matrix](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) in `check-go-task.yml` at `jobs.test.strategy.matrix.module[].path` and the [Codecov flag](https://docs.codecov.com/docs/flags) to group their data under at `jobs.test.strategy.matrix.module[].codecov-flags`
 
+Replace `REPO_OWNER/REPO_NAME` with the repository's name (e.g., `arduino/arduino-cli`) in the `codecov/codecov-action` action's `fail_ci_if_error` input in `test-go-task.yml`.
+
 #### `.gitignore`
 
 Add the following to `.gitignore`:

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -73,4 +73,4 @@ jobs:
         with:
           file: ${{ matrix.module.path }}coverage_unit.txt
           flags: ${{ matrix.module.codecov-flags }}
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.repository == 'REPO_OWNER/REPO_NAME' }}


### PR DESCRIPTION
The "Test Go" workflow uploads code coverage data to Codecov. There will occasionally be spurious upload failures caused by transient network outages. These will typically succeed after the workflow is re-run, but the option to re-run is not offered when the workflow run passes.

Because it's important that the data be complete, [the `codecov/codecov-action` action](https://github.com/codecov/codecov-action) is configured to fail the workflow run if the upload does not succeed. However, the upload will never be able to succeed for workflow runs in a fork where the owner has not set up Codecov. For this reason, [the `fail_ci_if_error` input](https://github.com/codecov/codecov-action#arguments) setting is made conditional upon [the repository name](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context).

The result is:

- Coverage data upload success is required for all workflow runs in the parent repository, including those for PRs  submitted from forks (this data is uploaded to the parent repo's Codecov account, so the upload is able to succeed regardless of whether Codecov is enabled for the fork).
- Uploads are attempted for workflow runs in forks (because the fork owner might have Codecov set up and want the data), but they are not required to succeed and will fail silently.