### PR TITLE
Make editorconfig-checker exclude regexes explicit

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,6 +1,6 @@
 {
   "Exclude": [
-    "LICENSE.txt",
-    "poetry.lock"
+    "^LICENSE\\.txt$",
+    "^poetry\\.lock$"
   ]
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -90,6 +90,7 @@ tasks:
     cmds:
       - |
         cp \
+          "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-general-formatting/.ecrc" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/general/.editorconfig" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-python/.flake8" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-markdown/.markdownlint.yml" \

--- a/workflow-templates/assets/check-general-formatting/.ecrc
+++ b/workflow-templates/assets/check-general-formatting/.ecrc
@@ -1,6 +1,6 @@
 {
   "Exclude": [
-    "LICENSE.txt",
-    "poetry.lock"
+    "^LICENSE\\.txt$",
+    "^poetry\\.lock$"
   ]
 }


### PR DESCRIPTION
The `Exclude` array in [the `.ecrc` configuration file](https://github.com/editorconfig-checker/editorconfig-checker#configuration) contains the regular expressions of paths that should be excluded from checking by the editorconfig-checker tool.

Previously, the "template" file contained a list of filenames that should always be ignored. Although it worked, it was not really correct because the `.` in the filename is actually a regex wildcard, which is not what was intended. Although a false match was unlikely, this also might mislead users adding project-specific exclusions to the file regarding the nature of the exclude patterns. Changing to very explicit patterns avoids any chance of false matches and also makes it clear that these are regexes.