### PR TITLE
Use taskfile variable to define primary Go module path

### DIFF
--- a/workflow-templates/assets/check-go-task/Taskfile.yml
+++ b/workflow-templates/assets/check-go-task/Taskfile.yml
@@ -12,21 +12,21 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:vet:
     desc: Check for errors in Go code
-    dir: '{{default "./" .GO_MODULE_PATH}}'
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go vet {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:fix:
     desc: Modernize usages of outdated APIs
-    dir: '{{default "./" .GO_MODULE_PATH}}'
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go fix {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:lint:
     desc: Lint Go code
-    dir: '{{default "./" .GO_MODULE_PATH}}'
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - |
         if ! which golint &>/dev/null; then
@@ -41,6 +41,6 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:format:
     desc: Format Go code
-    dir: '{{default "./" .GO_MODULE_PATH}}'
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - go fmt {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}

--- a/workflow-templates/assets/go-task/Taskfile.yml
+++ b/workflow-templates/assets/go-task/Taskfile.yml
@@ -2,14 +2,17 @@
 version: "3"
 
 vars:
+  # Path of the project's primary Go module:
+  DEFAULT_GO_MODULE_PATH: ./
   DEFAULT_GO_PACKAGES:
     sh: |
-      echo $(cd {{default "./" .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
+      echo $(cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
   LDFLAGS:
 
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   go:build:
     desc: Build the Go code
+    dir: "{{.DEFAULT_GO_MODULE_PATH}}"
     cmds:
       - go build -v {{.LDFLAGS}}

--- a/workflow-templates/assets/test-go-task/Taskfile.yml
+++ b/workflow-templates/assets/test-go-task/Taskfile.yml
@@ -5,7 +5,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
   go:test:
     desc: Run unit tests
-    dir: '{{default "./" .GO_MODULE_PATH}}'
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - |
         go test \

--- a/workflow-templates/check-go-task.md
+++ b/workflow-templates/check-go-task.md
@@ -12,7 +12,7 @@ Install the [`check-go-task.yml`](check-go-task.yml) GitHub Actions workflow to 
 
 - [`Taskfile.yml`](assets/check-go-task/Taskfile.yml) - Linting and formatting [tasks](https://taskfile.dev/).
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
-- [`Taskfile.yml`](assets/go-task/Taskfile.yml) - `DEFAULT_GO_PACKAGES` variable
+- [`Taskfile.yml`](assets/go-task/Taskfile.yml) - `DEFAULT_GO_MODULE_PATH` and `DEFAULT_GO_PACKAGES` variables
   - Merge into `Taskfile.yml`
 
 ### Configuration

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -14,7 +14,7 @@ Install the [`test-go-task.yml`](test-go-task.yml) GitHub Actions workflow to `.
 
 - [`Taskfile.yml`](assets/test-go-task/Taskfile.yml)
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
-- [`Taskfile.yml`](assets/go-task/Taskfile.yml) - `DEFAULT_GO_PACKAGES` variable
+- [`Taskfile.yml`](assets/go-task/Taskfile.yml) - `DEFAULT_GO_MODULE_PATH` and `DEFAULT_GO_PACKAGES` variables
   - Merge into `Taskfile.yml`
 
 ### Configuration


### PR DESCRIPTION
Although support was added to the Go module related "templates" for projects which contain modules at other paths (https://github.com/arduino/tooling-project-assets/pull/136), the assumption remained that there will always be a primary module in the root of the repository, and this path was hardcoded at several locations in the taskfiles.

It might be that a project that is not a Go module contains an accessory Go module in a subfolder ([example](https://github.com/arduino/library-registry/tree/production/.github/workflows/assets/validate-registry)). In this case, the use
of a taskfile variable will allow that path to be defined in one place, avoiding the need to override the hardcoded incorrect location whenever a Go module-related task is run manually.