### PR TITLE
Avoid workflow conditional reliance on specific runner

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -68,7 +68,7 @@ jobs:
         run: task go:test
 
       - name: Send unit tests coverage to Codecov
-        if: matrix.operating-system == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v2
         with:
           file: ${{ matrix.module.path }}coverage_unit.txt

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -68,7 +68,7 @@ jobs:
         run: task go:test
 
       - name: Send unit tests coverage to Codecov
-        if: matrix.operating-system == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v2
         with:
           file: ${{ matrix.module.path }}coverage_unit.txt


### PR DESCRIPTION
In order to catch platform-specific bugs, the "Test Go" workflow uses a job matrix to run the tests on multiple runners. The step that uploads code coverage data to Codecov is intended to run only during the Linux job. The runner name `ubuntu-latest` was used in the conditional to accomplish this. However, I'm observing that sometimes it is necessary or desirable to pin a specific runner version (e.g., `ubuntu-18.04`). The accompanying adjustment to the conditional might be forgotten and there would not be any obvious sign that the coverage upload had stopped, not why.

So I'm thinking the better approach would be to use the general [`runner.os` context item](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#runner-context) to identify the Linux job in the conditional. This will not be ideal in the event multiple Linux runners are added to the workflow's job matrix, but I haven't observed that in practice, and anyway a double upload shouldn't cause any problems.