### PR TITLE
Improve "docsgen" program's usability as a "template"

### DIFF
--- a/workflow-templates/assets/cobra/docsgen/main.go
+++ b/workflow-templates/assets/cobra/docsgen/main.go
@@ -18,8 +18,8 @@ package main
 import (
 	"os"
 
-	// TODO: Replace CLI_PACKAGE_NAME with the project's Cobra CLI package name
-	"CLI_PACKAGE_NAME"
+	// TODO: Replace CLI_PACKAGE_NAME with the project's Cobra CLI package import path
+	cli "CLI_PACKAGE_NAME"
 	"github.com/spf13/cobra/doc"
 )
 

--- a/workflow-templates/assets/cobra/docsgen/main.go
+++ b/workflow-templates/assets/cobra/docsgen/main.go
@@ -31,6 +31,7 @@ func main() {
 
 	os.MkdirAll(os.Args[1], 0755) // Create the output folder if it doesn't already exist
 
+	// TODO: Replace `cli.NewCommand()` with the project's Cobra CLI package function for command root
 	cli := cli.NewCommand()
 	cli.DisableAutoGenTag = true // Disable addition of auto-generated date stamp
 	err := doc.GenMarkdownTree(cli, os.Args[1])

--- a/workflow-templates/assets/cobra/docsgen/main.go
+++ b/workflow-templates/assets/cobra/docsgen/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	os.MkdirAll(os.Args[1], 0755) // Create the output folder if it doesn't already exist
 
-	cli := cli.Root()
+	cli := cli.NewCommand()
 	cli.DisableAutoGenTag = true // Disable addition of auto-generated date stamp
 	err := doc.GenMarkdownTree(cli, os.Args[1])
 	if err != nil {

--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
@@ -45,7 +45,9 @@ If there are any additional documentation generation tasks, add them to the `doc
 #### `docsgen`
 
 - [`go.mod`](assets/cobra/docsgen/go.mod) - replace `MODULE_NAME` with the project's module name.
-- [`main.go`](assets/cobra/docsgen/main.go) - replace `CLI_PACKAGE_NAME` with the project's Cobra CLI package name
+- [`main.go`](assets/cobra/docsgen/main.go)
+  - replace `CLI_PACKAGE_NAME` with the project's Cobra CLI package name
+  - replace `cli.NewCommand()` with the project's Cobra CLI package function for [command root](https://github.com/spf13/cobra/blob/master/user_guide.md#create-rootcmd) generation
 
 Run the following command from the `docsgen/` folder:
 


### PR DESCRIPTION
I identified some project-specific aspects of the template "docsgen" program for generating the website Cobra CLI reference content. These are resolved, mitigated, or documented by this pull request.

See the individual commits for details:
https://github.com/arduino/tooling-project-assets/pull/144/commits