### PR TITLE
Use shallow fetch for Go tester build

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-tester-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-tester-task.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Install Task
         uses: arduino/setup-task@v1

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Install Task
         uses: arduino/setup-task@v1


### PR DESCRIPTION
The default behavior of [the `actions/checkout` action](https://github.com/actions/checkout) is to do a shallow fetch of the repository, which is the most efficient if all that's needed is a copy of the repository files. In cases where the repository history is needed, this behavior is not appropriate, and so it can be configured via the `fetch-depth` input. [Setting this input to 0](https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches) causes the full history to be fetched.

A full fetch is required for workflows that use [the `arduino/create-changelog` action](https://github.com/arduino/create-changelog) to generate a raw changelog from the commit history, and so it is found in the "Release" workflow. However, there is no use of the commit history by the "Publish Tester Build" workflow, which does not need a changelog.

The unnecessary full fetch makes the workflow less efficient and more difficult to understand, so it must be removed.

---
Demo workflow run after this change: https://github.com/per1234/arduino-lint/actions/runs/1133921362