### PR TITLE
Place project-specific settings first in codespell configuration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = licence,ot
+skip = ./.git,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =
-skip = ./.git,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock

--- a/workflow-templates/assets/spell-check/.codespellrc
+++ b/workflow-templates/assets/spell-check/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = ,
+skip = ./.git,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =
-skip = ./.git,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock


### PR DESCRIPTION
The `ignore-words-list` and `skip` settings of [the codespell configuration file](https://github.com/codespell-project/codespell#using-a-config-file) may required project-specific adjustments to fix false positives or avoid positives from externally maintained files. The other settings are universal. It will be convenient to have the settings the user might need to adjust at the place of highest visibility in the configuration file.