### PR TITLE
Remove superfluous `go:check` template task

### DIFF
--- a/workflow-templates/assets/check-go-task/Taskfile.yml
+++ b/workflow-templates/assets/check-go-task/Taskfile.yml
@@ -3,13 +3,6 @@ version: "3"
 
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
-  go:check:
-    desc: Check for problems with Go code
-    deps:
-      - task: go:vet
-      - task: go:lint
-
-  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
   go:fix:
     desc: Modernize usages of outdated APIs
     dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"


### PR DESCRIPTION
There is an established practice of providing the developer with convenience "umbrella" tasks which collect multiple
tasks of a given type of operation. This has a couple of benefits:

- Provides an alternative to manually running multiple tasks
- Provides a standardized interface to the project, independent from its unique underlying details

However, I have come to the conclusion that these benefits lessen as the number of such convenience tasks increases. At
the same time, the maintenance burden increases. In the end, my preference is to have only the "umbrella" convenience
tasks at the highest possible level, which seems to be:

- "build" (build the application)
- "check" (check for problems with the project)
- "fix" (automatically fix problems with the project)

The decision about whether to add mid-level "umbrella" convenience tasks is up to the maintainer of each project, but I
don't feel that it's appropriate to provide one as a "template". This task is not used by anything in this repository.