### PR TITLE
Run relevant workflows on release branch creation

### DIFF
--- a/.github/workflows/test-python-poetry-task.yml
+++ b/.github/workflows/test-python-poetry-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-python-poetry-task.ya?ml"
@@ -27,7 +28,32 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
@@ -25,8 +26,33 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   check-errors:
     name: check-errors (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -59,6 +85,8 @@ jobs:
 
   check-outdated:
     name: check-outdated (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -94,6 +122,8 @@ jobs:
 
   check-style:
     name: check-style (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -129,6 +159,8 @@ jobs:
 
   check-formatting:
     name: check-formatting (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -164,6 +196,8 @@ jobs:
 
   check-config:
     name: check-config (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/check-go-task.ya?ml"
@@ -25,8 +26,33 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   check-errors:
     name: check-errors (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -59,6 +85,8 @@ jobs:
 
   check-outdated:
     name: check-outdated (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -94,6 +122,8 @@ jobs:
 
   check-style:
     name: check-style (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -129,6 +159,8 @@ jobs:
 
   check-formatting:
     name: check-formatting (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -164,6 +196,8 @@ jobs:
 
   check-config:
     name: check-config (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     strategy:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-tester-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-tester-task.yml
@@ -3,6 +3,7 @@ name: Publish Tester Build
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/publish-go-tester-task.ya?ml"
@@ -28,7 +29,32 @@ env:
   BUILDS_ARTIFACT: build-artifacts
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   build:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -9,6 +9,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-go-integration-task.ya?ml"
@@ -33,7 +34,33 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+
     strategy:
       matrix:
         operating-system:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
@@ -29,8 +30,33 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
     name: test (${{ matrix.module.path }} - ${{ matrix.operating-system }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
 
     strategy:
       fail-fast: false

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-python-poetry-task.ya?ml"
@@ -27,7 +28,32 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -3,6 +3,7 @@ name: Publish Tester Build
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/publish-go-tester-task.ya?ml"
@@ -28,7 +29,32 @@ env:
   BUILDS_ARTIFACT: build-artifacts
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   build:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -9,6 +9,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-go-integration-task.ya?ml"
@@ -33,7 +34,33 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+
     strategy:
       matrix:
         operating-system:

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-go-task.ya?ml"
@@ -29,8 +30,33 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
     name: test (${{ matrix.module.path }} - ${{ matrix.operating-system }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
 
     strategy:
       fail-fast: false

--- a/workflow-templates/test-python-poetry-task.yml
+++ b/workflow-templates/test-python-poetry-task.yml
@@ -7,6 +7,7 @@ env:
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/test-python-poetry-task.ya?ml"
@@ -27,7 +28,32 @@ on:
   repository_dispatch:
 
 jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[ \
+            "${{ github.event_name }}" != "create" || \
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX \
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "::set-output name=result::$RESULT"
+
   test:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This is a sync of a downstream improvement which has been reviewed and approved: https://github.com/arduino/arduino-cli/pull/1400

---
The [trunk-based development](https://trunkbaseddevelopment.com/) strategy is used by some tooling projects (e.g., Arduino CLI). Their release branches may contain a subset of the history of the default branch.

The status of the GitHub Actions workflows should be evaluated before making a release. However, this is not so simple as checking the status of the commit at the tip of the release branch. The reason is that, for the sake of efficiency, the [workflows are configured](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on) to run only when the processes are relevant to the trigger event (e.g., no need to run unit tests for a change to the readme).

In the case of the default branch, you can simply set the workflow runs filter to that branch ([example](https://github.com/arduino/arduino-cli/actions?query=branch%3Amaster)) and then check the result of the latest run of each workflow of interest. However, that was not possible to do with the release branch since it might be that the workflow was never run in that branch. The status of the latest run of the workflow in the default branch might not match the status for the release branch if the release branch does not contain the full history.

For this reason, it will be helpful to trigger all relevant workflows on the creation of a release branch. This will ensure that each of those workflows will always have at least one run in the release branch. Subsequent commits pushed to the branch can run based on their usual trigger filters and the status of the latest run of each workflow in the branch will provide an accurate indication of the state of that branch.

Branches are created for purposes other than releases, most notably feature branches to stage work for a pull request. Because the collection of workflows in a Tooling project are often very comprehensive, it would not be convenient or efficient to run them on the creation of every feature branch.

Unfortunately, GitHub Actions does not support filters on [the `create` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#create) generated by branch creation like it does for the `push` and `pull_request` events. There is support for a [`branches` filter](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags) of the `push` event, but that filter is an AND to the `paths` filter and this application requires an OR. For this reason, the workflows must be triggered by the creation of any branch. The unwanted job runs are prevented by adding a `run-determination` job with the branch filter handled by Bash commands. The other jobs of the workflow use this `run-determination` [job as a dependency](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds), only running when it indicates they should via a [job output](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs). Because this minimal `run-determination` job runs very quickly, it is roughly equivalent to the workflow having been skipped entirely for non-release branch creations. This approach has been in use for some time already in the versioned "Deploy Website" workflows.

---
Demo of workflow runs on release branch creation: https://github.com/per1234/arduino-cli/actions?query=branch%3A0.0.x
(note that the workflows were triggered and all jobs ran)

Demo of workflow runs on feature branch creation: https://github.com/per1234/arduino-cli/actions?query=branch%3Asome-feature
(note that the workflows were triggered but all jobs other than `run-determination` were skipped)