### PR TITLE
Add minimal GitHub release creation template workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-tag.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-tag.yml
@@ -1,0 +1,64 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/release-tag.md
+name: Release
+
+on:
+  push:
+    tags:
+      - "v?[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    env:
+      # See: https://github.com/fsaintjacques/semver-tool/releases
+      SEMVER_TOOL_VERSION: 3.2.0
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "CHANGELOG_PATH=${{ runner.temp }}/CHANGELOG.md" >> "$GITHUB_ENV"
+          echo "SEMVER_TOOL_PATH=${{ runner.temp }}/semver" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create changelog
+        uses: arduino/create-changelog@v1
+        with:
+          tag-regex: '^v?[0-9]+\.[0-9]+\.[0-9]+.*$'
+          filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
+          case-insensitive-regex: true
+          changelog-file-path: ${{ env.CHANGELOG_PATH }}
+
+      - name: Download semver tool
+        id: download-semver-tool
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://github.com/fsaintjacques/semver-tool/archive/${{ env.SEMVER_TOOL_VERSION }}.zip
+          location: ${{ runner.temp }}/semver-tool
+
+      - name: Install semver tool
+        run: |
+          unzip \
+            -p \
+            "${{ steps.download-semver-tool.outputs.file-path }}" \
+            semver-tool-${{ env.SEMVER_TOOL_VERSION }}/src/semver > \
+              "${{ env.SEMVER_TOOL_PATH }}"
+          chmod +x "${{ env.SEMVER_TOOL_PATH }}"
+
+      - name: Identify Prerelease
+        id: prerelease
+        run: |
+          if [[ "$("${{ env.SEMVER_TOOL_PATH }}" get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
+
+      - name: Create Github release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bodyFile: ${{ env.CHANGELOG_PATH }}
+          draft: false
+          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}

--- a/workflow-templates/release-tag.md
+++ b/workflow-templates/release-tag.md
@@ -1,0 +1,48 @@
+# "Release" workflow
+
+Make a [GitHub release](https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/about-releases) with changelog on release [tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) push.
+
+## Installation
+
+### Workflow
+
+Install the [`release-tag.yml`](release-tag.yml) GitHub Actions workflow to `.github/workflows/`
+
+### Readme badge
+
+Markdown badge:
+
+```markdown
+[![Release status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/release-tag.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/release-tag.yml)
+```
+
+Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/release-tag.yml/badge.svg["Release status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/release-tag.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```
+Add GitHub Actions workflow to generate releases
+
+On every push of a release tag (e.g., "1.2.3" or "v1.2.3") to the repository, create a GitHub release with a raw
+changelog generated from the commit history since the last release tag.
+
+Tags that contain a pre-release version will cause the GitHub release to be marked as a pre-release.
+```
+
+## PR message
+
+```markdown
+On every push of a release tag (e.g., `1.2.3` or `v1.2.3`) to the repository, create a [GitHub release](https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/about-releases) with a raw [changelog generated](https://github.com/arduino/create-changelog) from the commit history since the last release tag.
+
+Tags that contain a [pre-release version](https://semver.org/#spec-item-9) will cause the GitHub release to be marked as a pre-release.
+```

--- a/workflow-templates/release-tag.yml
+++ b/workflow-templates/release-tag.yml
@@ -1,0 +1,64 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/release-tag.md
+name: Release
+
+on:
+  push:
+    tags:
+      - "v?[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    env:
+      # See: https://github.com/fsaintjacques/semver-tool/releases
+      SEMVER_TOOL_VERSION: 3.2.0
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "CHANGELOG_PATH=${{ runner.temp }}/CHANGELOG.md" >> "$GITHUB_ENV"
+          echo "SEMVER_TOOL_PATH=${{ runner.temp }}/semver" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create changelog
+        uses: arduino/create-changelog@v1
+        with:
+          tag-regex: '^v?[0-9]+\.[0-9]+\.[0-9]+.*$'
+          filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
+          case-insensitive-regex: true
+          changelog-file-path: ${{ env.CHANGELOG_PATH }}
+
+      - name: Download semver tool
+        id: download-semver-tool
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: https://github.com/fsaintjacques/semver-tool/archive/${{ env.SEMVER_TOOL_VERSION }}.zip
+          location: ${{ runner.temp }}/semver-tool
+
+      - name: Install semver tool
+        run: |
+          unzip \
+            -p \
+            "${{ steps.download-semver-tool.outputs.file-path }}" \
+            semver-tool-${{ env.SEMVER_TOOL_VERSION }}/src/semver > \
+              "${{ env.SEMVER_TOOL_PATH }}"
+          chmod +x "${{ env.SEMVER_TOOL_PATH }}"
+
+      - name: Identify Prerelease
+        id: prerelease
+        run: |
+          if [[ "$("${{ env.SEMVER_TOOL_PATH }}" get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
+
+      - name: Create Github release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bodyFile: ${{ env.CHANGELOG_PATH }}
+          draft: false
+          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}


### PR DESCRIPTION
The requirement emerged (https://github.com/arduino/pluggable-discovery-protocol-handler/pull/12) for a release workflow that can be applied to projects that don't have any release assets to build and upload.

On every push of a release tag (e.g., `1.2.3` or `v1.2.3`) to the repository, create a [GitHub release](https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/about-releases) with a raw [changelog generated](https://github.com/arduino/create-changelog) from the commit history since the last release tag.

Tags that contain a [pre-release version](https://semver.org/#spec-item-9) will cause the GitHub release to be marked as a pre-release.

This workflow is especially well suited for use as a "template", since it does not have any project specific configuration or additional assets.