### PR TITLE
Bump "Check YAML" template's `yamllint` dependency

### DIFF
--- a/workflow-templates/check-yaml-task.md
+++ b/workflow-templates/check-yaml-task.md
@@ -33,14 +33,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="yamllint@^1.26.2"
+poetry init --python="^3.9" --dev-dependency="yamllint@^1.26.3"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "yamllint@^1.26.2"
+poetry add --dev "yamllint@^1.26.3"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
There was a new patch release of the tool and we are updating to using this as the standard version for all tooling
projects, including already in use by this project (https://github.com/arduino/tooling-project-assets/pull/150).