### PR TITLE
Bump `mkdocs-material` dependency of website templates

### DIFF
--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -27,14 +27,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="mkdocs@^1.2.1" --dev-dependency="mkdocs-material@^7.2.4" --dev-dependency="mdx_truly_sane_lists@^1.2"
+poetry init --python="^3.9" --dev-dependency="mkdocs@^1.2.1" --dev-dependency="mkdocs-material@^7.2.5" --dev-dependency="mdx_truly_sane_lists@^1.2"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "mkdocs@^1.2.1" "mkdocs-material@^7.2.4" "mdx_truly_sane_lists@^1.2"
+poetry add --dev "mkdocs@^1.2.1" "mkdocs-material@^7.2.5" "mdx_truly_sane_lists@^1.2"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
There was a new patch release of the tool and we are updating to using this as the standard version for all tooling
projects, including already [in use by Arduino Lint](https://github.com/arduino/arduino-lint/actions/runs/1173183835).