### PR TITLE
Bump `pytest` dependency to ^6.2.5 in templates

### DIFF
--- a/workflow-templates/test-go-integration-task.md
+++ b/workflow-templates/test-go-integration-task.md
@@ -35,14 +35,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="pytest@^6.2.4" --dev-dependency="invoke@^1.5.0"
+poetry init --python="^3.9" --dev-dependency="pytest@^6.2.5" --dev-dependency="invoke@^1.5.0"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "pytest@^6.2.4" "invoke@^1.5.0"
+poetry add --dev "pytest@^6.2.5" "invoke@^1.5.0"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.

--- a/workflow-templates/test-python-poetry-task.md
+++ b/workflow-templates/test-python-poetry-task.md
@@ -33,14 +33,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="pytest@^6.2.4"
+poetry init --python="^3.9" --dev-dependency="pytest@^6.2.5"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "pytest@^6.2.4"
+poetry add --dev "pytest@^6.2.5"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
This is now the standard version of the `pytest` Python testing framework for use in Arduino tooling projects.

It is already in use in multiple projects, including this one: https://github.com/arduino/tooling-project-assets/pull/156