### PR TITLE
Align macOS filename with others in checksum file

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -114,7 +114,7 @@ jobs:
           perl \
             -pi \
             -w \
-            -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM} ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" \
+            -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM}  ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" \
             ${{ env.DIST_DIR }}/*-checksums.txt
 
       - name: Upload artifacts

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -114,7 +114,7 @@ jobs:
           perl \
             -pi \
             -w \
-            -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM} ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" \
+            -e "s/.*${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/${CHECKSUM}  ${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz/g;" \
             ${{ env.DIST_DIR }}/*-checksums.txt
 
       - name: Upload artifacts


### PR DESCRIPTION
A file containing a list of checksums for the build archives is generated by the system used by the "Release Go"
template. The macOS build archive is modified later in the process as a result of the repackaging following notarization.
For this reason, the checksum file must be updated. The `sha256sum` command used to generate the original file separates
the checksum from the filename with two spaces. Previously, the command that updates the macOS checksum only added a
single space, which caused the formatting of the file to be inconsistent:

```
d5dccece4253b8c4c7e86b80f77433b3f3363ee89dcf11fd91d4638bbc66b61e  bhy_0.0.1_Linux_32bit.tar.gz
15557602d6aa6fd0a64b88393b7bd06fde35d6855a51c6b6a56a89ebd7d55153  bhy_0.0.1_Linux_64bit.tar.gz
d7564496bfbb471a79365a838ce6c8a2bc41285b1b687d58747308c78c831332 bhy_0.0.1_macOS_64bit.tar.gz
```