### PR TITLE
Bump dependencies for website templates

### DIFF
--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -27,14 +27,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="mkdocs@^1.2.1" --dev-dependency="mkdocs-material@^7.2.5" --dev-dependency="mdx_truly_sane_lists@^1.2"
+poetry init --python="^3.9" --dev-dependency="mkdocs@^1.2.1" --dev-dependency="mkdocs-material@^7.2.6" --dev-dependency="mdx_truly_sane_lists@^1.2"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "mkdocs@^1.2.1" "mkdocs-material@^7.2.5" "mdx_truly_sane_lists@^1.2"
+poetry add --dev "mkdocs@^1.2.1" "mkdocs-material@^7.2.6" "mdx_truly_sane_lists@^1.2"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -33,7 +33,7 @@ See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs
 
 1. Run this command:
    ```
-   poetry add --dev "gitpython@^3.1.20" "mike@^1.0.1"
+   poetry add --dev "gitpython@^3.1.20" "mike@^1.1.0"
    ```
 1. Commit the resulting `pyproject.toml` and `poetry.lock` files.
 


### PR DESCRIPTION
New releases have arrived of the `mkdocs-material` dependency of all our MkDocs-based websites, and the `mike` dependency
of the versioned website. These are already in use by the Arduino Lint website (https://github.com/arduino/arduino-lint/pull/269, https://github.com/arduino/arduino-lint/pull/268).