### PR TITLE
Bump `gitpython` dependency to ^3.1.23 in template

### DIFF
--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -33,7 +33,7 @@ See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs
 
 1. Run this command:
    ```
-   poetry add --dev "gitpython@^3.1.20" "mike@^1.1.0"
+   poetry add --dev "gitpython@^3.1.23" "mike@^1.1.0"
    ```
 1. Commit the resulting `pyproject.toml` and `poetry.lock` files.
 


### PR DESCRIPTION
This is now the standard version of the `gitpython` Python package for use in the website versioning helper script.

It is already in use in Arduino Lint (https://github.com/arduino/arduino-lint/pull/271) and this repository's own CI system (https://github.com/arduino/tooling-project-assets/pull/161).

Release notes: https://github.com/gitpython-developers/GitPython/blob/main/doc/source/changes.rst#3123