### PR TITLE
Bump `mike` dependency to ^1.1.1 in template

### DIFF
--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -33,7 +33,7 @@ See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs
 
 1. Run this command:
    ```
-   poetry add --dev "gitpython@^3.1.23" "mike@^1.1.0"
+   poetry add --dev "gitpython@^3.1.23" "mike@^1.1.1"
    ```
 1. Commit the resulting `pyproject.toml` and `poetry.lock` files.
 


### PR DESCRIPTION
This is now the standard version of the `mike` Python package used for versioning of MkDocs websites, already in use in Arduino Lint (https://github.com/arduino/arduino-lint/pull/273).