### PR TITLE
Bump `black` dependency to ^21.9b0 in template

### DIFF
--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -31,14 +31,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="black@^21.8b0" --dev-dependency="flake8@^3.9.2" --dev-dependency="pep8-naming@^0.12.1"
+poetry init --python="^3.9" --dev-dependency="black@^21.9b0" --dev-dependency="flake8@^3.9.2" --dev-dependency="pep8-naming@^0.12.1"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "black@^21.8b0" "flake8@^3.9.2" "pep8-naming@^0.12.1"
+poetry add --dev "black@^21.9b0" "flake8@^3.9.2" "pep8-naming@^0.12.1"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
This is now the standard version of the `black` Python package used for formatting Python code. This version is already in use in this repository's own infrastructure (https://github.com/arduino/tooling-project-assets/pull/164).