### PR TITLE
Update DistTasks.yml

### DIFF
--- a/workflow-templates/assets/release-go-task/DistTasks.yml
+++ b/workflow-templates/assets/release-go-task/DistTasks.yml
@@ -210,7 +210,7 @@ tasks:
         sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
 
     vars:
-      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
       BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/arm64"
       CONTAINER_TAG: "{{.GO_VERSION}}-arm"


### PR DESCRIPTION
During my investigations I discovered this typo which was causing a problem:
```
mkdir: cannot create directory ‘serial-monitor_linux_arm_6’: File exists
task: Failed to run task "dist:all": task: Failed to run task "dist:Linux_ARM64": exit status 1
```