### PR TITLE
Add shared phase labels for tooling projects

### DIFF
--- a/workflow-templates/assets/sync-labels/tooling.yml
+++ b/workflow-templates/assets/sync-labels/tooling.yml
@@ -10,6 +10,12 @@
 - name: "os: macos"
   color: "800080"
   description: Specific to macOS operating system
+- name: "phase: design"
+  color: d876e3
+  description: Work is in the design phase
+- name: "phase: implementation"
+  color: d876e3
+  description: Work is in the implementation phase
 - name: "architecture: arm"
   color: ff00ff
   description: Specific to ARM host architecture


### PR DESCRIPTION
Two new labels are added to the shared repository label configuration file for tooling projects. These will allow the
current stage in the development work to resolve an issue to be indicated.

At the moment, the phases recognized by the tooling team are design and implementation. Additional labels will be added
if more distinct phases emerge in practice.

These labels will be added to all repositories that use the "Sync Labels" workflow with the tooling.yml shared label configuration on the next run (scheduled daily).