### PR TITLE
Add criticality labels to "universal" shared label configuration file

### DIFF
--- a/workflow-templates/assets/sync-labels/universal.yml
+++ b/workflow-templates/assets/sync-labels/universal.yml
@@ -31,9 +31,23 @@
 - name: "conclusion: resolved"
   color: "00ff00"
   description: Issue was resolved
+- name: "criticality: highest"
+  color: "ff0000"
+  description: Of highest impact
+- name: "criticality: high"
+  color: "ffa200"
+  description: Of high impact
+- name: "criticality: medium"
+  color: "ffff00"
+  description: Of moderate impact
+- name: "criticality: low"
+  color: "c0c0c0"
+  description: Of low impact
 - name: "priority: high"
   color: "ffa200"
   description: Resolution is a high priority
+  notes: |
+    Distinct from the criticality labels in that priority is assigned based on estimated effort in addition to impact.
 - name: "priority: medium"
   color: "ffff00"
   description: Resolution is a medium priority


### PR DESCRIPTION
A set of "criticality" labels allows the assignment of an impact level estimation to issues and pull requests.

The usage of these labels is distinct from the priority labels in that priority is based on multiple factors. In addition to impact, the effort required to resolve must also be considered when assigning priority. I have added a note to this effect.

After merge of this PR, three new labels would be added to all repositories using [the "Sync Labels" template](https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md) workflow:

- "criticality: highest" (color: `#ff0000`)
- "criticality: high" (color: `#ffa200`)
- "criticality: medium" (color: `#ffff00`)
- "criticality: low" (color: `#c0c0c0`)

The brief in line description provided via the GitHub web interface (menu+tooltips) will be "Of highest/high/medium/low impact".