### PR TITLE
Align heading levels in template install docs

### DIFF
--- a/other/installation-script/installation.md
+++ b/other/installation-script/installation.md
@@ -27,14 +27,14 @@ number as a parameter like this:
 curl -fsSL https://raw.githubusercontent.com/arduino/REPO_NAME/main/etc/install.sh | sh -s 0.9.0
 ```
 
-### Download
+## Download
 
 Pre-built binaries for all the supported platforms are available for download from the links below.
 
 If you would like to use the `REPO_NAME` command from any location, extract the downloaded file to a directory
 already in your `PATH` or add the PRODUCT_NAME installation path to your `PATH` environment variable.
 
-#### Latest release
+### Latest release
 
 | Platform  |                      |                      |
 | --------- | -------------------- | -------------------- |
@@ -51,11 +51,11 @@ already in your `PATH` or add the PRODUCT_NAME installation path to your `PATH` 
 [windows32]: https://downloads.arduino.cc/REPO_NAME/REPO_NAME_latest_Windows_32bit.zip
 [macos]: https://downloads.arduino.cc/REPO_NAME/REPO_NAME_latest_macOS_64bit.tar.gz
 
-#### Previous versions
+### Previous versions
 
 These are available from the "Assets" sections on the [releases page](https://github.com/arduino/REPO_NAME/releases).
 
-#### Nightly builds
+### Nightly builds
 
 These builds are generated every day at 01:00 GMT from the `main` branch and should be considered unstable. In order to
 get the latest nightly build available for the supported platform, use the following links:
@@ -81,7 +81,7 @@ get the latest nightly build available for the supported platform, use the follo
 Checksums for the nightly builds are available at
 `https://downloads.arduino.cc/REPO_NAME/nightly/nightly-<DATE>-checksums.txt`
 
-### Build from source
+## Build from source
 
 If you're familiar with Golang or if you want to contribute to the project, you will probably build PRODUCT_NAME locally
 with your Go toolchain. See the ["How to contribute"](CONTRIBUTING.md#building-the-source-code) page for instructions.


### PR DESCRIPTION
This document is intended to provide a list of installation options:

- script
- download
- build

but the heading levels were misaligned, which resulted in this structure:

- script
  - download
  - build

Example of the bug in production:
https://arduino.github.io/arduino-lint/dev/installation/

![image](https://user-images.githubusercontent.com/8572152/140943539-dff6c060-48d6-4deb-b360-15a4bdbb2875.png)
