### PR TITLE
Use placeholder for product in template install docs

### DIFF
--- a/other/installation-script/installation.md
+++ b/other/installation-script/installation.md
@@ -1,6 +1,6 @@
 <!-- Source: https://github.com/arduino/tooling-project-assets/blob/main/other/installation-script/installation.md -->
 
-Several options are available for installation of this tool. Instructions for each are provided below:
+Several options are available for installation of PRODUCT_NAME. Instructions for each are provided below:
 
 ## Use the install script
 


### PR DESCRIPTION
A placeholder "PRODUCT_NAME" is used when referring to the specific software product in the "template" installation
instructions document. As is explained in the associated readme, these placeholders are replaced when the "template" is
applied to a repository to tailor it to that specific project.

The document previously used a more ambiguous "this tool" at one location when referring to the product. That sentence
will be more clear to the reader if the specific product name is used there, and so it is replaced by the placeholder.