### PR TITLE
Add missing reference link re: `PATH` to template install docs

### DIFF
--- a/other/installation-script/installation.md
+++ b/other/installation-script/installation.md
@@ -35,8 +35,9 @@ curl -fsSL https://raw.githubusercontent.com/arduino/REPO_NAME/main/etc/install.
 
 Pre-built binaries for all the supported platforms are available for download from the links below.
 
-If you would like to use the `REPO_NAME` command from any location, extract the downloaded file to a directory
-already in your `PATH` or add the PRODUCT_NAME installation path to your `PATH` environment variable.
+If you would like to use the `REPO_NAME` command from any location, extract the downloaded file to a directory already
+in your [`PATH`](https://en.wikipedia.org/wiki/PATH%5F%28variable%29) or add the PRODUCT_NAME installation path to your
+`PATH` environment variable.
 
 ### Latest release
 


### PR DESCRIPTION
A reference link provides easy access to the relevant information for readers who are not familiar with this concept
while not harming readability for everyone else by increasing verbosity.

This had already been done for the script method installation instructions (https://github.com/arduino/tooling-project-assets/commit/7894fd751127a2d09d46b9f43b950068224c6d05), but not for the direct download method
instructions. Since the user is only intended to read the instructions for the specific installation method they choose,
the reference link must be added to the first mention of `PATH` in each set of instructions.