### PR TITLE
Bump Python code tools used in "templates"

### DIFF
--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -31,14 +31,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="black@^21.9b0" --dev-dependency="flake8@^3.9.2" --dev-dependency="pep8-naming@^0.12.1"
+poetry init --python="^3.9" --dev-dependency="black@^21.9b0" --dev-dependency="flake8@^4.0.1" --dev-dependency="pep8-naming@^0.12.1"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "black@^21.9b0" "flake8@^3.9.2" "pep8-naming@^0.12.1"
+poetry add --dev "black@^21.9b0" "flake8@^4.0.1" "pep8-naming@^0.12.1"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.

--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -31,14 +31,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="black@^21.9b0" --dev-dependency="flake8@^4.0.1" --dev-dependency="pep8-naming@^0.12.1"
+poetry init --python="^3.9" --dev-dependency="black@^21.10b0" --dev-dependency="flake8@^4.0.1" --dev-dependency="pep8-naming@^0.12.1"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "black@^21.9b0" "flake8@^4.0.1" "pep8-naming@^0.12.1"
+poetry add --dev "black@^21.10b0" "flake8@^4.0.1" "pep8-naming@^0.12.1"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
These will now be the standard versions Python code tool for use in Arduino tooling projects:

- [flake8](https://flake8.pycqa.org/en/latest/)@^4.0.1
- [black](https://github.com/psf/black)@^21.10b0