### PR TITLE
Bump `black` dependency to ^21.11b1 in template

### DIFF
--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -31,14 +31,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="black@^21.10b0" --dev-dependency="flake8@^4.0.1" --dev-dependency="pep8-naming@^0.12.1"
+poetry init --python="^3.9" --dev-dependency="black@^21.11b1" --dev-dependency="flake8@^4.0.1" --dev-dependency="pep8-naming@^0.12.1"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "black@^21.10b0" "flake8@^4.0.1" "pep8-naming@^0.12.1"
+poetry add --dev "black@^21.11b1" "flake8@^4.0.1" "pep8-naming@^0.12.1"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.


### PR DESCRIPTION
This is now the standard version of the `black` Python code formatting tool for use in Arduino tooling projects.