### PR TITLE
Pin Windows-compatible version of Task where necessary

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -91,7 +91,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
       - name: Run integration tests
         run: task go:test-integration

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -86,7 +86,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
       - name: Run tests
         env:

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -91,7 +91,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
       - name: Run integration tests
         run: task go:test-integration

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -86,7 +86,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
       - name: Run tests
         env:


### PR DESCRIPTION
The recent 3.9.1 release of [the Task task runner](https://taskfile.dev/#/) does not correctly handle the `PATH` environment variable on Windows.
Since the "template" workflows were configured to always use the latest version of Task within the 3.x major version
series, this bug caused spurious failure of workflows under the following conditions:

- Used a Windows runner
- Ran a task that contained a command reliant on a file from PATH

([example](https://github.com/arduino/arduino-cli/runs/4355349975?check_suite_focus=true#step:6:546))

The workaround is to pin the version of Task used in these workflows to the last working version: 3.9.0.