### PR TITLE
Revert "Pin Windows-compatible version of Task where necessary"

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -91,7 +91,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
       - name: Run integration tests
         run: task go:test-integration

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -86,7 +86,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
       - name: Run tests
         env:

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -91,7 +91,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
       - name: Run integration tests
         run: task go:test-integration

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -86,7 +86,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
       - name: Run tests
         env:


### PR DESCRIPTION
This reverts commit 8d6e59fa716b8800e1fe3b99d606c2ab8f72bce0.

A new 3.9.2 release of Task is out with a fix for the the Windows PATH handling bug that affected 3.9.1 (https://github.com/mvdan/sh/issues/768). So it is no longer necessary to do a full pin of Task in the "Template" workflows.

Pinning only the major version series allows the workflows to use the latest version of Task until such time as a breaking change necessitates a major version bump. This provides the right balance of access to beneficial developments, while requiring manual review in the event that development might break something.