### PR TITLE
Fix install script's check for previous installation

### DIFF
--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -191,3 +191,78 @@ jobs:
         shell: bash
         run: |
           "${PWD}/bin/${{ env.TOOL_NAME }}" --version | grep "^nightly-"
+
+  path-suggestions:
+    needs: configure
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Set install path environment variables
+        shell: bash
+        run: |
+          # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          FIRST_INSTALLATION_FOLDER="first-installation-folder"
+          echo "FIRST_INSTALLATION_FOLDER=${FIRST_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
+          echo "FIRST_BINDIR=${{ runner.temp }}/${FIRST_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
+          SECOND_INSTALLATION_FOLDER="second-installation-folder"
+          echo "SECOND_INSTALLATION_FOLDER=${SECOND_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
+          echo "SECOND_BINDIR=${{ runner.temp }}/${SECOND_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
+
+      - name: Download script artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.SCRIPT_ARTIFACT_NAME }}
+
+      - name: Make script executable
+        run: chmod u+x "${{ github.workspace }}/${{ env.SCRIPT_NAME }}"
+
+      - name: Check script output without previous installation in PATH
+        shell: sh
+        env:
+          BINDIR: ${{ env.FIRST_BINDIR }}
+        run: |
+          mkdir -p "${{ env.BINDIR }}"
+          "${{ github.workspace }}/${{ env.SCRIPT_NAME }}" | \
+            grep \
+              -F \
+              '${{ env.TOOL_NAME }} not found. You might want to add "${{ env.FIRST_BINDIR }}" to your $PATH'
+
+      - name: Add first installation to PATH
+        shell: bash
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.FIRST_BINDIR }}" >> "$GITHUB_PATH"
+
+      - name: Check script output with previous installation in PATH (non-Windows)
+        if: runner.os != 'Windows'
+        shell: sh
+        env:
+          BINDIR: ${{ env.SECOND_BINDIR }}
+        run: |
+          mkdir -p "${{ env.BINDIR }}"
+          "${{ github.workspace }}/${{ env.SCRIPT_NAME }}" | \
+            grep \
+              -F \
+              '${{ env.TOOL_NAME }} was found at ${{ env.FIRST_BINDIR }}/${{ env.TOOL_NAME }}. Please prepend "${{ env.BINDIR }}" to your $PATH'
+
+      # ${{ runner.temp }} is a Windows style path on the windows runner, but the script output uses the equivalent POSIX style path.
+      # So a regex is used for the output check on Windows.
+      - name: Check script output with previous installation in PATH (Windows)
+        if: runner.os == 'Windows'
+        shell: sh
+        env:
+          BINDIR: ${{ env.SECOND_BINDIR }}
+        run: |
+          mkdir -p "${{ env.BINDIR }}"
+          "${{ github.workspace }}/${{ env.SCRIPT_NAME }}" | \
+            grep \
+              '${{ env.TOOL_NAME }} was found at .*/${{ env.FIRST_INSTALLATION_FOLDER }}/${{ env.TOOL_NAME }}\. Please prepend ".*/${{ env.SECOND_INSTALLATION_FOLDER }}" to your \$PATH'

--- a/other/installation-script/install.sh
+++ b/other/installation-script/install.sh
@@ -186,8 +186,7 @@ bye() {
 
 testVersion() {
   set +e
-  EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"
-  if [ "$?" = "0" ]; then
+  if EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"; then
     # Convert to resolved, absolute paths before comparison
     EXECUTABLE_REALPATH="$(cd -- "$(dirname -- "$EXECUTABLE_PATH")" && pwd -P)"
     EFFECTIVE_BINDIR_REALPATH="$(cd -- "$EFFECTIVE_BINDIR" && pwd -P)"

--- a/other/installation-script/install.sh
+++ b/other/installation-script/install.sh
@@ -187,18 +187,19 @@ bye() {
 testVersion() {
   set +e
   EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"
-  if [ "$?" = "1" ]; then
-    # $PATH is intentionally a literal in this message.
-    # shellcheck disable=SC2016
-    echo "$PROJECT_NAME not found. You might want to add \"$EFFECTIVE_BINDIR\" to your "'$PATH'
-  else
+  if [ "$?" = "0" ]; then
     # Convert to resolved, absolute paths before comparison
     EXECUTABLE_REALPATH="$(cd -- "$(dirname -- "$EXECUTABLE_PATH")" && pwd -P)"
     EFFECTIVE_BINDIR_REALPATH="$(cd -- "$EFFECTIVE_BINDIR" && pwd -P)"
     if [ "$EXECUTABLE_REALPATH" != "$EFFECTIVE_BINDIR_REALPATH" ]; then
+      # $PATH is intentionally a literal in this message.
       # shellcheck disable=SC2016
       echo "An existing $PROJECT_NAME was found at $EXECUTABLE_PATH. Please prepend \"$EFFECTIVE_BINDIR\" to your "'$PATH'" or remove the existing one."
     fi
+  else
+    # $PATH is intentionally a literal in this message.
+    # shellcheck disable=SC2016
+    echo "$PROJECT_NAME not found. You might want to add \"$EFFECTIVE_BINDIR\" to your "'$PATH'
   fi
 
   set -e


### PR DESCRIPTION
The "template" installation script stored in this repository checks for an existing installation in the `PATH` in order to provide appropriate advice to the user about adding the installation to their their `PATH` environment variable.

This check is done using `command -v`. It turns out that the exit status is shell dependent in the event the command is not found, so that it might be either `1` or `127` depending on the user's system. The script previously assumed that the exit status would be `1` when the command was not found in `PATH`, which resulted in spurious advice under these conditions:

https://github.com/arduino/tooling-project-assets/runs/4556007479?check_suite_focus=true#step:4:13

```
An existing arduino-lint was found at . Please prepend "/home/runner/work/tooling-project-assets/tooling-project-assets/bin" to your $PATH or remove the existing one.
```

It seems safest to fix this by inverting the logic so that the advice about an existing installation in `PATH` is only printed when one was found.

---

Originally reported at https://forum.arduino.cc/t/failing-to-instlal-arduino-cli-on-raspberry/936871