### PR TITLE
Bump dependencies in templates

### DIFF
--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -31,14 +31,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="black@^21.11b1" --dev-dependency="flake8@^4.0.1" --dev-dependency="pep8-naming@^0.12.1"
+poetry init --python="^3.9" --dev-dependency="black@^21.12b0" --dev-dependency="flake8@^4.0.1" --dev-dependency="pep8-naming@^0.12.1"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "black@^21.11b1" "flake8@^4.0.1" "pep8-naming@^0.12.1"
+poetry add --dev "black@^21.12b0" "flake8@^4.0.1" "pep8-naming@^0.12.1"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.

--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -27,14 +27,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="mkdocs@^1.2.1" --dev-dependency="mkdocs-material@^7.2.8" --dev-dependency="mdx_truly_sane_lists@^1.2"
+poetry init --python="^3.9" --dev-dependency="mkdocs@^1.2.3" --dev-dependency="mkdocs-material@^8.1.5" --dev-dependency="mdx_truly_sane_lists@^1.2"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "mkdocs@^1.2.1" "mkdocs-material@^7.2.8" "mdx_truly_sane_lists@^1.2"
+poetry add --dev "mkdocs@^1.2.3" "mkdocs-material@^8.1.5" "mdx_truly_sane_lists@^1.2"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -33,7 +33,7 @@ See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs
 
 1. Run this command:
    ```
-   poetry add --dev "gitpython@^3.1.24" "mike@^1.1.1"
+   poetry add --dev "gitpython@^3.1.25" "mike@^1.1.2"
    ```
 1. Commit the resulting `pyproject.toml` and `poetry.lock` files.
 


### PR DESCRIPTION
These dependencies of the "templates" are now the standard versions for use in Arduino tooling projects.

They are already in use in Arduino Lint and in this repository's own CI system:

- https://github.com/arduino/tooling-project-assets/pull/187
- https://github.com/arduino/tooling-project-assets/pull/193
- https://github.com/arduino/arduino-lint/pull/319