### PR TITLE
Bump `gitpython` dependency to ^3.1.26 in template

### DIFF
--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -33,7 +33,7 @@ See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs
 
 1. Run this command:
    ```
-   poetry add --dev "gitpython@^3.1.25" "mike@^1.1.2"
+   poetry add --dev "gitpython@^3.1.26" "mike@^1.1.2"
    ```
 1. Commit the resulting `pyproject.toml` and `poetry.lock` files.
 


### PR DESCRIPTION
This is now the standard version of the `gitpython` Python module for use in Arduino tooling projects.

It is already in use in this repository's CI system as well as other Tooling projects:

- https://github.com/arduino/tooling-project-assets/pull/195
- https://github.com/arduino/arduino-lint/pull/320
- https://github.com/arduino/compile-sketches/pull/44