### PR TITLE
Remove aliases from shared label configurations

### DIFF
--- a/workflow-templates/assets/sync-labels/universal.yml
+++ b/workflow-templates/assets/sync-labels/universal.yml
@@ -7,18 +7,12 @@
 - name: "conclusion: declined"
   color: "940404"
   description: Will not be worked on
-  aliases:
-    - wontfix
 - name: "conclusion: duplicate"
   color: "ff0000"
   description: Has already been submitted
-  aliases:
-    - duplicate
 - name: "conclusion: invalid"
   color: "ff0000"
   description: Issue/PR not valid
-  aliases:
-    - invalid
 - name: "conclusion: off topic"
   color: "ff0000"
   description: Off topic for this repository
@@ -65,9 +59,6 @@
   description: Do not proceed at this time
 - name: "status: waiting for information"
   color: "ffff00"
-  aliases:
-    - Waiting for feedback
-    - waiting for feedback
   description: More information must be provided before work can proceed
 - name: "status: blocked"
   color: "940404"
@@ -87,24 +78,16 @@
 - name: "topic: documentation"
   color: "00ffff"
   description: Related to documentation for the project
-  aliases:
-    - documentation
 - name: "type: imperfection"
   color: "ff0000"
   description: Perceived defect in any part of project
-  aliases:
-    - bug
   notes: This includes bugs, but avoids confusion for use in non-code contexts.
 - name: "type: enhancement"
   color: "008000"
   description: Proposed improvement
-  aliases:
-    - enhancement
 - name: "type: support"
   color: "ff0000"
   description: "OT: Request for help using the project"
-  aliases:
-    - question
   notes: |
     All support request issues must be closed as "conclusion: invalid", redirecting the user to the Arduino forum, but
     it's still useful to label the closed issues and this type doesn't fit into the imperfection/enhancement dichotomy.


### PR DESCRIPTION
[The "**GitHub Label Sync**" tool](https://github.com/Financial-Times/github-label-sync) used by [the "**Manage Labels**" template workflow](https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md) has a bug that can cause unwanted label deletion when multiple labels in the repository match an element in [the configuration file](https://github.com/Financial-Times/github-label-sync#label-config-file).

For example, the configuration for the universally shared "**`type: enhancement`**" label defines the "**`enhancement`**" label as an alias, so if a repository has both a "**`type: enhancement`**" and an "**`enhancement`**" label (which might happen through a maintainer who isn't aware of the label management system adding the label manually), both labels will match that configuration element. The bug would cause the deletion of the "**`type: enhancement`**" label from the repository, and with it the irreversible loss of labeling in all issues and pull requests it had been applied to.

This multiple match condition can only occur when aliases have been configured in the element. So the mitigation for the bug is to remove all alias configurations.

Because these aliases are very useful for automatically migrating a repository from the existing use of GitHub's inadequate stock labels to our standardized labels after the initial installation of the "**Manage Labels**" workflow in a repository (or even when running the tool directly in case a maintainer prefers to manage their labels manually), this provisional change will be reverted as soon as the bug has been fixed in "**GitHub Label Sync**" and released.

There is a proposal for a fix here: https://github.com/Financial-Times/github-label-sync/pull/165