### PR TITLE
Remove `notes` from allowed properties in label configuration schema

### DIFF
--- a/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
+++ b/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
@@ -9,16 +9,21 @@
     "type": "object",
     "properties": {
       "name": {
-        "type": "string",
-        "maxLength": 50,
-        "anyOf": [
+        "allOf": [
           {
-            "$comment": "Standardized label format",
-            "pattern": "^.+: .+$"
+            "$ref": "#/$defs/name_base"
           },
           {
-            "$comment": "Allowed exceptions to the standardized format",
-            "enum": ["help wanted"]
+            "anyOf": [
+              {
+                "$comment": "Standardized label format",
+                "pattern": "^.+: .+$"
+              },
+              {
+                "$comment": "Allowed exceptions to the standardized format",
+                "enum": ["help wanted"]
+              }
+            ]
           }
         ]
       },
@@ -45,10 +50,20 @@
         "maxLength": 100
       },
       "aliases": {
-        "type": "array"
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/name_base"
+        }
       }
     },
     "additionalProperties": false,
     "required": ["name", "color", "description"]
+  },
+  "$defs": {
+    "name_base": {
+      "$comment": "Fundamental requirements",
+      "type": "string",
+      "maxLength": 50
+    }
   }
 }

--- a/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
+++ b/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
@@ -46,10 +46,6 @@
       },
       "aliases": {
         "type": "array"
-      },
-      "notes": {
-        "type": "string",
-        "minLength": 1
       }
     },
     "additionalProperties": false,

--- a/workflow-templates/assets/sync-labels/tooling.yml
+++ b/workflow-templates/assets/sync-labels/tooling.yml
@@ -19,9 +19,8 @@
 - name: "architecture: arm"
   color: ff00ff
   description: Specific to ARM host architecture
+# Vulnerability disclosures are made following the procedure at:
+# https://github.com/arduino/.github/blob/master/SECURITY.md
 - name: "topic: security"
   color: ff0000
   description: Related to the protection of user data
-  notes: |
-    Vulnerability disclosures are made following the procedure at:
-    https://github.com/arduino/.github/blob/master/SECURITY.md

--- a/workflow-templates/assets/sync-labels/universal.yml
+++ b/workflow-templates/assets/sync-labels/universal.yml
@@ -22,12 +22,11 @@
 - name: "conclusion: off topic"
   color: "ff0000"
   description: Off topic for this repository
+# For use when it's not possible to do a true transfer
+# (PRs, different organizations, or maintainer doesn't have write permissions in target repo).
 - name: "conclusion: moved"
   color: "940404"
   description: Issue/PR moved to another repository
-  notes: |
-    For use when it's not possible to do a true transfer
-    (PRs, different organizations, or maintainer doesn't have write permissions in target repo).
 - name: "conclusion: resolved"
   color: "00ff00"
   description: Issue was resolved
@@ -43,11 +42,10 @@
 - name: "criticality: low"
   color: "c0c0c0"
   description: Of low impact
+# Distinct from the criticality labels in that priority is assigned based on estimated effort in addition to impact.
 - name: "priority: high"
   color: "ffa200"
   description: Resolution is a high priority
-  notes: |
-    Distinct from the criticality labels in that priority is assigned based on estimated effort in addition to impact.
 - name: "priority: medium"
   color: "ffff00"
   description: Resolution is a medium priority
@@ -72,12 +70,11 @@
 - name: "status: blocked"
   color: "940404"
   description: Progress on this prevented by an external cause
+# Ideally this would be "status: help wanted", but GitHub gives this label special treatment so it's best to leave it
+# stock.
 - name: help wanted
   color: "ffa200"
   description: Assistance from the community is especially welcome
-  notes: |
-    Ideally this would be "status: help wanted", but GitHub gives this label special treatment so it's best to leave it
-    stock.
 - name: "topic: infrastructure"
   color: "00ffff"
   description: Related to repository infrastructure
@@ -89,22 +86,21 @@
   description: Related to documentation for the project
   aliases:
     - documentation
+# This includes bugs, but avoids confusion for use in non-code contexts.
 - name: "type: imperfection"
   color: "ff0000"
   description: Perceived defect in any part of project
   aliases:
     - bug
-  notes: This includes bugs, but avoids confusion for use in non-code contexts.
 - name: "type: enhancement"
   color: "008000"
   description: Proposed improvement
   aliases:
     - enhancement
+# All support request issues must be closed as "conclusion: invalid", redirecting the user to the Arduino forum, but
+# it's still useful to label the closed issues and this type doesn't fit into the imperfection/enhancement dichotomy.
 - name: "type: support"
   color: "ff0000"
   description: "OT: Request for help using the project"
   aliases:
     - question
-  notes: |
-    All support request issues must be closed as "conclusion: invalid", redirecting the user to the Arduino forum, but
-    it's still useful to label the closed issues and this type doesn't fit into the imperfection/enhancement dichotomy.


### PR DESCRIPTION
At the time the original configuration file was developed, it was in JSON, which does not support comments. I found the need to add some internal explanatory commentary to some of the labels, so I added an arbitrary `notes` key as a container for this information, and our JSON schema was also configured to accept this field.

I later decided to convert the files to YAML, since that is the language used by the majority of the asset configuration files. At this point it became possible to use comments, but the `notes` field was already in place so it seemed pointless to change it.

Validation of the configuration file [was added](https://github.com/Financial-Times/github-label-sync/pull/158) to the "**GitHub Label Sync**" tool in [the recent 2.1.0 release](https://github.com/Financial-Times/github-label-sync/releases/tag/v2.1.0). Before 2.1.0, the tool ignored any additional properties in the label configuration objects. It now errors if there are any unexpected properties.

This `notes` field now causes the label configuration files that contain it to be considered invalid by the tool:

https://github.com/arduino/tooling-project-assets/runs/5754102563?check_suite_focus=true#step:9:13

```text
Syncing labels for "arduino/tooling-project-assets"
Validating provided labels
Invalid label:
  {"name":"conclusion: moved","color":"940404","description":"Issue/PR moved to another repository","notes":"For use when it's not possible to do a true transfer\n(PRs, different organizations, or maintainer doesn't have write permissions in target repo).\n"}
  - must NOT have additional properties

[...]
```

So the `notes` field is hereby removed, with the contents moved to comments.

---

I have also updated the [JSON schema](https://json-schema.org/) used by this repository's CI system to validate the "shared" label configuration files hosted here, and by [the "Sync Labels" template workflow](https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md) to validate the local label configuration files. It is now aligned with the internal JSON schema of the "**GitHub Label Sync**" tool.
