### PR TITLE
Improve configuration for "topic: infrastructure" shared label

### DIFF
--- a/workflow-templates/assets/sync-labels/universal.yml
+++ b/workflow-templates/assets/sync-labels/universal.yml
@@ -77,7 +77,7 @@
   description: Assistance from the community is especially welcome
 - name: "topic: infrastructure"
   color: "00ffff"
-  description: Related to repository infrastructure
+  description: Related to project infrastructure
   aliases:
     - dependencies
 - name: "topic: code"

--- a/workflow-templates/assets/sync-labels/universal.yml
+++ b/workflow-templates/assets/sync-labels/universal.yml
@@ -78,6 +78,8 @@
 - name: "topic: infrastructure"
   color: "00ffff"
   description: Related to repository infrastructure
+  aliases:
+    - dependencies
 - name: "topic: code"
   color: "00ffff"
   description: Related to content of the project itself


### PR DESCRIPTION
The "Sync Labels" template workflow uses a "universal" label configuration file hosted in this repository, which defines the GitHub labels that are used in all Arduino tooling project repositories.

The "**topic: infrastructure**" label is applied to all issues and PRs related to the project infrastructure (as opposed to the content of the project itself or its documentation). This "infrastructure" includes the dependencies, which are normally managed by Dependabot.

By default, Dependabot applies a label named "**dependencies**" to its PRs. This is configurable, but experience shows that is often forgotten. With the previous configuration, the "**topic: infrastructure**" label must be manually applied to the Dependabot PRs. The "**dependencies**" label is added here as an "alias" for "**topic: infrastructure**" label, which will automate this labeling task.