### PR TITLE
Detect unused dependency license metadata files

### DIFF
--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Check for outdated cache
         id: diff
         run: |
-          git add --intent-to-add .
-          if ! git diff --color --exit-code; then
+          git add .
+          if ! git diff --cached --color --exit-code; then
             echo
             echo "::error::Dependency license metadata out of sync. See: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md#metadata-cache"
             exit 1

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Check for outdated cache
         id: diff
         run: |
-          git add --intent-to-add .
-          if ! git diff --color --exit-code; then
+          git add .
+          if ! git diff --cached --color --exit-code; then
             echo
             echo "::error::Dependency license metadata out of sync. See: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-dependencies-task.md#metadata-cache"
             exit 1


### PR DESCRIPTION
## Background

The "**Check Go Dependencies**" GitHub Actions workflow checks for dependencies with incompatible or unapproved license types.

The dependency license metadata consumed by [the "**Licensed**" tool](https://github.com/github/licensed) is cached in the project repository, in a dedicated file for each dependency.

The `check-cache` job of the workflow checks whether that cache is in sync with the project's current dependencies. It does this by using the "Licensed" tool to update the cache and then a [`git diff`](https://git-scm.com/docs/git-diff) command to check whether that resulted in any changes (which would indicate it is out of sync).

Out of sync states could result from any of three distinct conditions:

- Missing metadata file
- Incorrect metadata file contents
- Superfluous metadata file

## Problem

🐛 An incorrectly configured `git diff` command previously caused the last of these to be missed.

My first take at this system was simply using `git diff --exit-code` alone. That detects the last two, but misses the first. I added a preceding [`git add --intent-to-add .`](https://git-scm.com/docs/git-add#Documentation/git-add.txt---intent-to-add) command to detect added files, but didn't realize that it also caused the last condition to be missed.

Superfluous files in the dependency license metadata cache won't interfere with its intended functionality, but it is still important to avoid an accumulation of unused files.

## Solution

The new commands will catch all three of the possible out of sync conditions by staging all changes that result from the metadata cache update to the repository and then comparing those against the `HEAD` commit.

## Additional Context

I considered an alternative approach which works just as well as the chosen one (explanation of the two approaches [here](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-Variouswaystocheckyourworkingtree)):

```text
git add .
git diff --exit-code HEAD
```

However, I feel that the `git diff` command with [the `--cached` flag](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgt--cached--merge-baseltcommitgt--ltpathgt82308203) is more self-explanatory.