### PR TITLE
Add schedule triggers to workflows whenever possible

### DIFF
--- a/.github/workflows/check-ci-sync.yml
+++ b/.github/workflows/check-ci-sync.yml
@@ -18,6 +18,9 @@ on:
       - ".github/workflows/*.ya?ml"
       - "Taskfile.ya?ml"
       - "workflow-templates/*.ya?ml"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 13 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-community-health-sync.yml
+++ b/.github/workflows/check-community-health-sync.yml
@@ -20,6 +20,9 @@ on:
       - "Taskfile.ya?ml"
       - ".github/ISSUE_TEMPLATE/**"
       - "issue-templates/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 14 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-config-sync.yml
+++ b/.github/workflows/check-config-sync.yml
@@ -10,6 +10,9 @@ name: Check Configuration Files Sync
 on:
   push:
   pull_request:
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 15 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-dependabot-sync.yml
+++ b/.github/workflows/check-dependabot-sync.yml
@@ -19,6 +19,9 @@ on:
       - "Taskfile.yml"
       - "workflow-templates/*.ya?ml"
       - "workflow-templates/dependabot/workflow-template-copies/.github/workflows/*"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 16 * * WED"
 
 jobs:
   check-sync:

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -26,6 +26,9 @@ on:
       - "[lL][iI][cC][eE][nN][cCsS][eE]*"
       - "[oO][fF][lL]*"
       - "[pP][aA][tT][eE][nN][tT][sS]*"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 6 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -195,6 +195,9 @@ on:
       - "**.rviz"
       - "**.sublime-syntax"
       - "**.syntax"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 4 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -27,6 +27,9 @@ on:
       - "Taskfile.ya?ml"
       - "**/tox.ini"
       - "**.py"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -39,6 +39,9 @@ on:
       - "**.rviz"
       - "**.sublime-syntax"
       - "**.syntax"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 9 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/.github/workflows/test-python-poetry-task.yml
+++ b/.github/workflows/test-python-poetry-task.yml
@@ -24,6 +24,9 @@ on:
       - "pyproject.toml"
       - "tests/**"
       - "**.py"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 12 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -27,6 +27,9 @@ on:
       - "**/.gitmodules"
       - "**/go.mod"
       - "**/go.sum"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -22,6 +22,9 @@ on:
       - "**/go.mod"
       - "**/go.sum"
       - "**.go"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 7 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -27,6 +27,9 @@ on:
       - "[lL][iI][cC][eE][nN][cCsS][eE]*"
       - "[oO][fF][lL]*"
       - "[pP][aA][tT][eE][nN][tT][sS]*"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 6 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/check-mkdocs-task.yml
+++ b/workflow-templates/check-mkdocs-task.yml
@@ -23,6 +23,9 @@ on:
       - "poetry.lock"
       - "pyproject.toml"
       - "docs/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 5 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/check-prettier-formatting-task.yml
+++ b/workflow-templates/check-prettier-formatting-task.yml
@@ -195,6 +195,9 @@ on:
       - "**.rviz"
       - "**.sublime-syntax"
       - "**.syntax"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 4 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/check-python-task.yml
+++ b/workflow-templates/check-python-task.yml
@@ -27,6 +27,9 @@ on:
       - "Taskfile.ya?ml"
       - "**/tox.ini"
       - "**.py"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/check-toc-task.yml
+++ b/workflow-templates/check-toc-task.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/check-toc-task.ya?ml"
       # TODO: Update this if ToC of any other files should be checked.
       - "README.md"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 3 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/check-yaml-task.yml
+++ b/workflow-templates/check-yaml-task.yml
@@ -39,6 +39,9 @@ on:
       - "**.rviz"
       - "**.sublime-syntax"
       - "**.syntax"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 9 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
@@ -27,6 +27,9 @@ on:
       - "**/.gitmodules"
       - "**/go.mod"
       - "**/go.sum"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
@@ -22,6 +22,9 @@ on:
       - "**/go.mod"
       - "**/go.sum"
       - "**.go"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 7 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-license.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-license.yml
@@ -27,6 +27,9 @@ on:
       - "[lL][iI][cC][eE][nN][cCsS][eE]*"
       - "[oO][fF][lL]*"
       - "[pP][aA][tT][eE][nN][tT][sS]*"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 6 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-mkdocs-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-mkdocs-task.yml
@@ -23,6 +23,9 @@ on:
       - "poetry.lock"
       - "pyproject.toml"
       - "docs/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 5 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-prettier-formatting-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-prettier-formatting-task.yml
@@ -195,6 +195,9 @@ on:
       - "**.rviz"
       - "**.sublime-syntax"
       - "**.syntax"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 4 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
@@ -27,6 +27,9 @@ on:
       - "Taskfile.ya?ml"
       - "**/tox.ini"
       - "**.py"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 8 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-toc-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-toc-task.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/check-toc-task.ya?ml"
       # TODO: Update this if ToC of any other files should be checked.
       - "README.md"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 3 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-yaml-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-yaml-task.yml
@@ -39,6 +39,9 @@ on:
       - "**.rviz"
       - "**.sublime-syntax"
       - "**.syntax"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 9 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -30,6 +30,9 @@ on:
       - "poetry.lock"
       - "pyproject.toml"
       - "tests/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 10 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -26,6 +26,9 @@ on:
       - "Taskfile.ya?ml"
       - "**.go"
       - "**/testdata/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 11 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
@@ -24,6 +24,9 @@ on:
       - "pyproject.toml"
       - "tests/**"
       - "**.py"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 12 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -30,6 +30,9 @@ on:
       - "poetry.lock"
       - "pyproject.toml"
       - "tests/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 10 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -26,6 +26,9 @@ on:
       - "Taskfile.ya?ml"
       - "**.go"
       - "**/testdata/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 11 * * WED"
   workflow_dispatch:
   repository_dispatch:
 

--- a/workflow-templates/test-python-poetry-task.yml
+++ b/workflow-templates/test-python-poetry-task.yml
@@ -24,6 +24,9 @@ on:
       - "pyproject.toml"
       - "tests/**"
       - "**.py"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 12 * * WED"
   workflow_dispatch:
   repository_dispatch:
 


### PR DESCRIPTION
This repository contains several GitHub Actions workflows, both hosted in this repository as reusable assets for use in other projects, or to facilitate the development and maintenance of the `arduino/tooling-project-assets` repo itself.

The workflows are typically [configured to run whenever any relevant file in the repository is changed](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore). However, the results of the workflow run are also dependent on the external environment it runs in, which include:

- The software running on the [GitHub hosted GitHub Actions runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) machines
- The [GitHub Actions actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#actions) used by the workflow
- The dependencies that are installed by the workflow directly or via the GitHub Actions actions it uses

The workflows often do not fully pin to a specific version of given external tool. This was done in the interest on reducing the maintenance burden of keeping the systems up to date. However, it also means that a new release can cause the workflow runs to start failing (which might happen through an enhancement to that resource resolving a false negative, or a defect causing a false negative).

When the repository [file path trigger](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) is used by itself, this sort of external breakage is only revealed when an unrelated change triggers the workflow. That can be distracting even to a dedicated member of the project development team, as well as confusing and discouraging to any contributor.

This type of change can be caught by adding [a `schedule` event trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) that causes the workflow to run periodically in addition to the other on-demand triggers. This allows the problem to be identified and resolved at the maintainer's convenience, separate from the unrelated development work.

---

I have spread out the times of the newly added `schedule` triggers. The previous approach of copy/pasting the same optimal schedule configuration to all the workflows results in somewhat of an unintentional "DDoS" attempt by Arduino on the GitHub Actions infrastructure every Tuesday.