### PR TITLE
Bump all dependencies to current versions

### DIFF
--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -2,7 +2,7 @@
 name: Check Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -2,7 +2,7 @@
 name: Check YAML
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -2,7 +2,7 @@
 name: Spell Check
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/.github/workflows/test-python-poetry-task.yml
+++ b/.github/workflows/test-python-poetry-task.yml
@@ -2,7 +2,7 @@
 name: Test Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/assets/cobra/docsgen/go.mod
+++ b/workflow-templates/assets/cobra/docsgen/go.mod
@@ -8,5 +8,5 @@ replace MODULE_NAME => ../
 
 require (
 	MODULE_NAME v0.0.0
-	github.com/spf13/cobra v1.2.1
+	github.com/spf13/cobra v1.4.0
 )

--- a/workflow-templates/assets/cobra/docsgen/go.mod
+++ b/workflow-templates/assets/cobra/docsgen/go.mod
@@ -2,7 +2,7 @@
 // TODO: replace MODULE_NAME with the project's module name
 module MODULE_NAME/docsgen
 
-go 1.16
+go 1.17
 
 replace MODULE_NAME => ../
 

--- a/workflow-templates/assets/release-go-task/DistTasks.yml
+++ b/workflow-templates/assets/release-go-task/DistTasks.yml
@@ -19,7 +19,7 @@ version: "3"
 
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
-  GO_VERSION: "1.16.4"
+  GO_VERSION: "1.17.8"
   CHECKSUM_FILE: "{{.VERSION}}-checksums.txt"
 
 tasks:

--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -3,7 +3,7 @@ name: Check Go Dependencies
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:

--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -2,7 +2,7 @@
 name: Check Go Dependencies
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
@@ -76,7 +76,7 @@ jobs:
           version: 3.x
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -126,7 +126,7 @@ jobs:
           version: 3.x
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -3,7 +3,7 @@ name: Check Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -2,7 +2,7 @@
 name: Check Go
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -179,7 +179,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -216,7 +216,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/check-mkdocs-task.yml
+++ b/workflow-templates/check-mkdocs-task.yml
@@ -2,7 +2,7 @@
 name: Check Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -31,14 +31,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="black@^21.12b0" --dev-dependency="flake8@^4.0.1" --dev-dependency="pep8-naming@^0.12.1"
+poetry init --python="^3.9" --dev-dependency="black@^22.3" --dev-dependency="flake8@^4.0.1" --dev-dependency="pep8-naming@^0.12.1"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "black@^21.12b0" "flake8@^4.0.1" "pep8-naming@^0.12.1"
+poetry add --dev "black@^22.3" "flake8@^4.0.1" "pep8-naming@^0.12.1"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.

--- a/workflow-templates/check-python-task.yml
+++ b/workflow-templates/check-python-task.yml
@@ -2,7 +2,7 @@
 name: Check Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/check-yaml-task.yml
+++ b/workflow-templates/check-yaml-task.yml
@@ -2,7 +2,7 @@
 name: Check YAML
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
@@ -3,7 +3,7 @@ name: Check Go Dependencies
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
@@ -2,7 +2,7 @@
 name: Check Go Dependencies
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
@@ -76,7 +76,7 @@ jobs:
           version: 3.x
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -126,7 +126,7 @@ jobs:
           version: 3.x
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
@@ -3,7 +3,7 @@ name: Check Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
@@ -2,7 +2,7 @@
 name: Check Go
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -179,7 +179,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -216,7 +216,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-mkdocs-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-mkdocs-task.yml
@@ -2,7 +2,7 @@
 name: Check Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
@@ -2,7 +2,7 @@
 name: Check Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-yaml-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-yaml-task.yml
@@ -2,7 +2,7 @@
 name: Check YAML
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-poetry.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-versioned-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
@@ -10,7 +10,7 @@ env:
   AWS_PLUGIN_TARGET: TODO
   ARTIFACT_NAME: dist
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: 1.16
+  GO_VERSION: "1.17"
 
 on:
   push:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
@@ -9,7 +9,7 @@ env:
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: TODO
   ARTIFACT_NAME: dist
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
 
 on:
@@ -36,7 +36,7 @@ jobs:
           changelog-file-path: "${{ env.DIST_DIR }}/CHANGELOG.md"
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
@@ -147,7 +147,7 @@ jobs:
         # to implement auto pre-release based on tag
         id: prerelease
         run: |
-          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
+          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -140,7 +140,7 @@ jobs:
         # to implement auto pre-release based on tag
         id: prerelease
         run: |
-          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
+          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/spell-check-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/spell-check-task.yml
@@ -2,7 +2,7 @@
 name: Spell Check
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -3,7 +3,7 @@ name: Test Integration
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9"
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -2,7 +2,7 @@
 name: Test Integration
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
   # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -4,7 +4,7 @@ name: Test Integration
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
   GO_VERSION: "1.17"
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Send unit tests coverage to Codecov
         if: runner.os == 'Linux'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: ${{ matrix.module.path }}coverage_unit.txt
           flags: ${{ matrix.module.codecov-flags }}

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -2,7 +2,7 @@
 name: Test Go
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -3,7 +3,7 @@ name: Test Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
@@ -2,7 +2,7 @@
 name: Test Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 on:

--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -27,14 +27,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="mkdocs@^1.2.3" --dev-dependency="mkdocs-material@^8.1.5" --dev-dependency="mdx_truly_sane_lists@^1.2"
+poetry init --python="^3.9" --dev-dependency="mkdocs@^1.3.0" --dev-dependency="mkdocs-material@^8.2.11" --dev-dependency="mdx_truly_sane_lists@^1.2"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "mkdocs@^1.2.3" "mkdocs-material@^8.1.5" "mdx_truly_sane_lists@^1.2"
+poetry add --dev "mkdocs@^1.3.0" "mkdocs-material@^8.2.11" "mdx_truly_sane_lists@^1.2"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.

--- a/workflow-templates/deploy-mkdocs-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -33,7 +33,7 @@ See the ["Deploy Website" workflow (MkDocs, Poetry) documentation](deploy-mkdocs
 
 1. Run this command:
    ```
-   poetry add --dev "gitpython@^3.1.26" "mike@^1.1.2"
+   poetry add --dev "gitpython@^3.1.27" "mike@^1.1.2"
    ```
 1. Commit the resulting `pyproject.toml` and `poetry.lock` files.
 

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 on:

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -10,7 +10,7 @@ env:
   AWS_PLUGIN_TARGET: TODO
   ARTIFACT_NAME: dist
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: 1.16
+  GO_VERSION: "1.17"
 
 on:
   push:

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -9,7 +9,7 @@ env:
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: TODO
   ARTIFACT_NAME: dist
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
 
 on:
@@ -36,7 +36,7 @@ jobs:
           changelog-file-path: "${{ env.DIST_DIR }}/CHANGELOG.md"
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -147,7 +147,7 @@ jobs:
         # to implement auto pre-release based on tag
         id: prerelease
         run: |
-          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
+          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -140,7 +140,7 @@ jobs:
         # to implement auto pre-release based on tag
         id: prerelease
         run: |
-          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
+          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 

--- a/workflow-templates/spell-check-task.yml
+++ b/workflow-templates/spell-check-task.yml
@@ -2,7 +2,7 @@
 name: Spell Check
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/test-go-integration-task.md
+++ b/workflow-templates/test-go-integration-task.md
@@ -35,14 +35,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="pytest@^6.2.5" --dev-dependency="invoke@^1.5.0"
+poetry init --python="^3.9" --dev-dependency="pytest@^7.1.2" --dev-dependency="invoke@^1.7.0"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "pytest@^6.2.5" "invoke@^1.5.0"
+poetry add --dev "pytest@^7.1.2" "invoke@^1.7.0"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -3,7 +3,7 @@ name: Test Integration
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9"
 

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -2,7 +2,7 @@
 name: Test Integration
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
   # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -4,7 +4,7 @@ name: Test Integration
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
   GO_VERSION: "1.17"
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Send unit tests coverage to Codecov
         if: runner.os == 'Linux'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: ${{ matrix.module.path }}coverage_unit.txt
           flags: ${{ matrix.module.codecov-flags }}

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -2,7 +2,7 @@
 name: Test Go
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v2#readme
+  # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -3,7 +3,7 @@ name: Test Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:

--- a/workflow-templates/test-python-poetry-task.md
+++ b/workflow-templates/test-python-poetry-task.md
@@ -33,14 +33,14 @@ https://python-poetry.org/docs/#installation
 If your project does not already use Poetry, you can initialize the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) file using these commands:
 
 ```
-poetry init --python="^3.9" --dev-dependency="pytest@^6.2.5"
+poetry init --python="^3.9" --dev-dependency="pytest@^7.1.2"
 poetry install
 ```
 
 If already using Poetry, add the tool using this command:
 
 ```
-poetry add --dev "pytest@^6.2.5"
+poetry add --dev "pytest@^7.1.2"
 ```
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.

--- a/workflow-templates/test-python-poetry-task.yml
+++ b/workflow-templates/test-python-poetry-task.yml
@@ -2,7 +2,7 @@
 name: Test Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows


### PR DESCRIPTION
I have not been very good about keeping the dependencies versions in the assets updated lately.

These have been in use for some time in the downstream projects I maintain, where the task is easier with Dependabot's help. We usually at least get assistance from Dependabot here for the action dependencies in addition to the repo infrastructure, but that has not been working recently (https://github.com/arduino/tooling-project-assets/issues/224).