### PR TITLE
Remove unnecessary use of `eval` from install script

### DIFF
--- a/other/installation-script/install.sh
+++ b/other/installation-script/install.sh
@@ -70,6 +70,7 @@ initDownloadTool() {
   echo "Using $DOWNLOAD_TOOL as download tool"
 }
 
+# checkLatestVersion() sets the CHECKLATESTVERSION_TAG variable to the latest version
 checkLatestVersion() {
   # Use the GitHub releases webpage to find the latest version for this project
   # so we don't get rate-limited.
@@ -84,7 +85,6 @@ checkLatestVersion() {
     echo "Cannot determine latest tag."
     exit 1
   fi
-  eval "$1='$CHECKLATESTVERSION_TAG'"
 }
 
 getFile() {
@@ -101,7 +101,8 @@ getFile() {
 
 downloadFile() {
   if [ -z "$1" ]; then
-    checkLatestVersion TAG
+    checkLatestVersion
+    TAG="$CHECKLATESTVERSION_TAG"
   else
     TAG=$1
   fi


### PR DESCRIPTION
The "template" installation script hosted in this repository contains a `checkLatestVersion()` function which is used to determine the latest version of the project when the user does not specify a version to install.

The version number is required by the caller, but shell functions do not support returning such content.

As a workaround, the script author set up a system where the caller passed an arbitrary variable name to the function. The function then sets a global variable of that name with the release name. So it resembles a "pass by reference" approach, but isn't.

This was done using [the `eval` builtin](https://man7.org/linux/man-pages/man1/eval.1p.html). This tool must be used with caution and best practices is to avoid it unless absolutely necessary. The system used by the script has some value for a reusable function. However, in this case the function is only intended for internal use by the script, and is called only once. So the unintuitive nature of this system and potential for bugs (e.g., https://github.com/arduino/arduino-cli/issues/1714) don't bring any benefits when compared with the much more straightforward approach of simply using a fixed name for the global variable used to store the release name.

---

Related: https://github.com/arduino/tooling-project-assets/pull/222