### PR TITLE
Standardize format of placeholders in templates

### DIFF
--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       PROJECT_OWNER_PLACEHOLDER: arduino # Placeholder value of the PROJECT_OWNER variable in the template script
       PROJECT_OWNER: arduino # Replacement value used for the tests
-      PROJECT_NAME_PLACEHOLDER: TODO # Placeholder value of the PROJECT_NAME variable in the template script
+      PROJECT_NAME_PLACEHOLDER: TODO_PROJECT_NAME # Placeholder value of the PROJECT_NAME variable in the template script
       PROJECT_NAME: arduino-lint # Replacement value used for the tests
       SCRIPT_FOLDER: other/installation-script
 

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -7,7 +7,7 @@
       "pattern": "^CONTRIBUTING\\.md#building-the-source-code$"
     },
     {
-      "pattern": "/REPO_NAME/"
+      "pattern": "/TODO_REPO_NAME/"
     }
   ]
 }

--- a/issue-templates/minimal/README.md
+++ b/issue-templates/minimal/README.md
@@ -21,7 +21,7 @@ This is the minimal issue template, applicable to any Arduino tooling project, i
 
 ### Configuration
 
-Replace `REPO_OWNER/REPO_NAME` in the `contact_links[0].url` field of `config.yml`.
+Replace `TODO_REPO_OWNER/TODO_REPO_NAME` in the `contact_links[0].url` field of `config.yml`.
 
 Add links for any additional relevant resources to the `contact_links[]` field of `config.yml`.
 

--- a/issue-templates/template-choosers/general/config.yml
+++ b/issue-templates/template-choosers/general/config.yml
@@ -2,8 +2,8 @@
 # https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/general/config.yml
 contact_links:
   - name: Learn about using this project
-    # TODO: Replace REPO_OWNER/REPO_NAME with the repository owner and name
-    url: https://github.com/REPO_OWNER/REPO_NAME#readme
+    # TODO: Replace TODO_REPO_OWNER/TODO_REPO_NAME with the repository owner and name
+    url: https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME#readme
     about: Detailed usage documentation is available here.
   - name: Support request
     url: https://forum.arduino.cc/

--- a/issue-templates/template-choosers/github-actions/config.yml
+++ b/issue-templates/template-choosers/github-actions/config.yml
@@ -2,8 +2,8 @@
 # https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/github-actions/config.yml
 contact_links:
   - name: Learn about using this project
-    # TODO: Replace REPO_OWNER/REPO_NAME with the repository owner and name
-    url: https://github.com/REPO_OWNER/REPO_NAME#readme
+    # TODO: Replace TODO_REPO_OWNER/TODO_REPO_NAME with the repository owner and name
+    url: https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME#readme
     about: Detailed usage documentation is available here.
   - name: Learn about GitHub Actions
     url: https://docs.github.com/actions

--- a/other/installation-script/README.md
+++ b/other/installation-script/README.md
@@ -26,9 +26,9 @@ This shell script does the following:
 
 Set the `PROJECT_NAME` variable in `install.sh` to the project's repository name (e.g., "arduino-cli").
 
-Replace all occurrences of `PRODUCT_NAME` in `installation.md` with the project's product name (e.g., "Arduino CLI").
+Replace all occurrences of `TODO_PRODUCT_NAME` in `installation.md` with the project's product name (e.g., "Arduino CLI").
 
-Replace all occurrences of `REPO_NAME` in `installation.md` with the project's repository name (e.g., "arduino-cli").
+Replace all occurrences of `TODO_REPO_NAME` in `installation.md` with the project's repository name (e.g., "arduino-cli").
 
 ## Commit message
 

--- a/other/installation-script/install.sh
+++ b/other/installation-script/install.sh
@@ -5,7 +5,7 @@
 # MIT license. See https://github.com/Masterminds/glide/blob/master/LICENSE for more details and copyright notice.
 
 PROJECT_OWNER="arduino"
-PROJECT_NAME="TODO"
+PROJECT_NAME="TODO_PROJECT_NAME"
 
 # BINDIR represents the local bin location, defaults to ./bin.
 EFFECTIVE_BINDIR=""

--- a/other/installation-script/installation.md
+++ b/other/installation-script/installation.md
@@ -1,6 +1,6 @@
 <!-- Source: https://github.com/arduino/tooling-project-assets/blob/main/other/installation-script/installation.md -->
 
-Several options are available for installation of PRODUCT_NAME. Instructions for each are provided below:
+Several options are available for installation of TODO_PRODUCT_NAME. Instructions for each are provided below:
 
 ## Use the install script
 
@@ -8,35 +8,35 @@ The script requires `sh`, which is always available on Linux and macOS. `sh` is 
 though it is available as part of [Git for Windows](https://gitforwindows.org/) (Git Bash). If you don't have `sh`
 available, use the ["Download" installation option](#download).
 
-This script will install the latest version of PRODUCT_NAME to `$PWD/bin`:
+This script will install the latest version of TODO_PRODUCT_NAME to `$PWD/bin`:
 
 ```
-curl -fsSL https://raw.githubusercontent.com/arduino/REPO_NAME/main/etc/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/arduino/TODO_REPO_NAME/main/etc/install.sh | sh
 ```
 
 If you want to target a different directory, for example `~/local/bin`, set the `BINDIR` environment variable like this:
 
 ```
-curl -fsSL https://raw.githubusercontent.com/arduino/REPO_NAME/main/etc/install.sh | BINDIR=~/local/bin sh
+curl -fsSL https://raw.githubusercontent.com/arduino/TODO_REPO_NAME/main/etc/install.sh | BINDIR=~/local/bin sh
 ```
 
-If you would like to use the `REPO_NAME` command from any location, install PRODUCT_NAME to a directory already in
-your [`PATH`](https://wikipedia.org/wiki/PATH%5F%28variable%29) or add the PRODUCT_NAME installation path to your
+If you would like to use the `TODO_REPO_NAME` command from any location, install TODO_PRODUCT_NAME to a directory already in
+your [`PATH`](https://wikipedia.org/wiki/PATH%5F%28variable%29) or add the TODO_PRODUCT_NAME installation path to your
 `PATH` environment variable.
 
-If you want to download a specific PRODUCT_NAME version, for example `0.9.0` or `nightly-latest`, pass the version
+If you want to download a specific TODO_PRODUCT_NAME version, for example `0.9.0` or `nightly-latest`, pass the version
 number as a parameter like this:
 
 ```
-curl -fsSL https://raw.githubusercontent.com/arduino/REPO_NAME/main/etc/install.sh | sh -s 0.9.0
+curl -fsSL https://raw.githubusercontent.com/arduino/TODO_REPO_NAME/main/etc/install.sh | sh -s 0.9.0
 ```
 
 ## Download
 
 Pre-built binaries for all the supported platforms are available for download from the links below.
 
-If you would like to use the `REPO_NAME` command from any location, extract the downloaded file to a directory already
-in your [`PATH`](https://wikipedia.org/wiki/PATH%5F%28variable%29) or add the PRODUCT_NAME installation path to your
+If you would like to use the `TODO_REPO_NAME` command from any location, extract the downloaded file to a directory already
+in your [`PATH`](https://wikipedia.org/wiki/PATH%5F%28variable%29) or add the TODO_PRODUCT_NAME installation path to your
 `PATH` environment variable.
 
 ### Latest release
@@ -48,17 +48,17 @@ in your [`PATH`](https://wikipedia.org/wiki/PATH%5F%28variable%29) or add the PR
 | Windows   | [32 bit][windows32]  | [64 bit][windows64]  |
 | macOS     |                      | [64 bit][macos]      |
 
-[linux64]: https://downloads.arduino.cc/REPO_NAME/REPO_NAME_latest_Linux_64bit.tar.gz
-[linux32]: https://downloads.arduino.cc/REPO_NAME/REPO_NAME_latest_Linux_32bit.tar.gz
-[linuxarm64]: https://downloads.arduino.cc/REPO_NAME/REPO_NAME_latest_Linux_ARM64.tar.gz
-[linuxarm32]: https://downloads.arduino.cc/REPO_NAME/REPO_NAME_latest_Linux_ARMv7.tar.gz
-[windows64]: https://downloads.arduino.cc/REPO_NAME/REPO_NAME_latest_Windows_64bit.zip
-[windows32]: https://downloads.arduino.cc/REPO_NAME/REPO_NAME_latest_Windows_32bit.zip
-[macos]: https://downloads.arduino.cc/REPO_NAME/REPO_NAME_latest_macOS_64bit.tar.gz
+[linux64]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Linux_64bit.tar.gz
+[linux32]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Linux_32bit.tar.gz
+[linuxarm64]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Linux_ARM64.tar.gz
+[linuxarm32]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Linux_ARMv7.tar.gz
+[windows64]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Windows_64bit.zip
+[windows32]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Windows_32bit.zip
+[macos]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_macOS_64bit.tar.gz
 
 ### Previous versions
 
-These are available from the "Assets" sections on the [releases page](https://github.com/arduino/REPO_NAME/releases).
+These are available from the "Assets" sections on the [releases page](https://github.com/arduino/TODO_REPO_NAME/releases).
 
 ### Nightly builds
 
@@ -72,21 +72,21 @@ get the latest nightly build available for the supported platform, use the follo
 | Windows   | [32 bit][windows32-nightly]  | [64 bit][windows64-nightly]  |
 | macOS     |                              | [64 bit][macos-nightly]      |
 
-[linux64-nightly]: https://downloads.arduino.cc/REPO_NAME/nightly/REPO_NAME_nightly-latest_Linux_64bit.tar.gz
-[linux32-nightly]: https://downloads.arduino.cc/REPO_NAME/nightly/REPO_NAME_nightly-latest_Linux_32bit.tar.gz
-[linuxarm64-nightly]: https://downloads.arduino.cc/REPO_NAME/nightly/REPO_NAME_nightly-latest_Linux_ARM64.tar.gz
-[linuxarm32-nightly]: https://downloads.arduino.cc/REPO_NAME/nightly/REPO_NAME_nightly-latest_Linux_ARMv7.tar.gz
-[windows64-nightly]: https://downloads.arduino.cc/REPO_NAME/nightly/REPO_NAME_nightly-latest_Windows_64bit.zip
-[windows32-nightly]: https://downloads.arduino.cc/REPO_NAME/nightly/REPO_NAME_nightly-latest_Windows_32bit.zip
-[macos-nightly]: https://downloads.arduino.cc/REPO_NAME/nightly/REPO_NAME_nightly-latest_macOS_64bit.tar.gz
+[linux64-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Linux_64bit.tar.gz
+[linux32-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Linux_32bit.tar.gz
+[linuxarm64-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Linux_ARM64.tar.gz
+[linuxarm32-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Linux_ARMv7.tar.gz
+[windows64-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Windows_64bit.zip
+[windows32-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Windows_32bit.zip
+[macos-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_macOS_64bit.tar.gz
 
 > These links return a `302: Found` response, redirecting to latest generated builds by replacing `latest` with the
 > latest available build date, using the format YYYYMMDD (i.e for 2019-08-06 `latest` is replaced with `20190806` )
 
 Checksums for the nightly builds are available at
-`https://downloads.arduino.cc/REPO_NAME/nightly/nightly-<DATE>-checksums.txt`
+`https://downloads.arduino.cc/TODO_REPO_NAME/nightly/nightly-<DATE>-checksums.txt`
 
 ## Build from source
 
-If you're familiar with Golang or if you want to contribute to the project, you will probably build PRODUCT_NAME locally
+If you're familiar with Golang or if you want to contribute to the project, you will probably build TODO_PRODUCT_NAME locally
 with your Go toolchain. See the ["How to contribute"](CONTRIBUTING.md#building-the-source-code) page for instructions.

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -4,7 +4,7 @@ A collection of reusable [GitHub Actions workflows](https://docs.github.com/acti
 
 ## Documentation
 
-While some workflows can be added to any repository without any modification, others need to be configured for each project. "TODO" comments in the workflow explain what needs to be done. Documentation for each workflow is provided by the .md file of the same name, including:
+While some workflows can be added to any repository without any modification, others need to be configured for each project. "TODO" comments in the workflow explain what needs to be done and `TODO_*` placeholders indicate where project-specific information needs to be filled in. Documentation for each workflow is provided by the .md file of the same name, including:
 
 - Instructions
 - List of asset files which must be added to the repository along with the workflow

--- a/workflow-templates/assets/cobra/docsgen/go.mod
+++ b/workflow-templates/assets/cobra/docsgen/go.mod
@@ -1,12 +1,12 @@
 // Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/cobra/docsgen/go.mod
-// TODO: replace MODULE_NAME with the project's module name
-module MODULE_NAME/docsgen
+// TODO: replace TODO_MODULE_NAME with the project's module name
+module TODO_MODULE_NAME/docsgen
 
 go 1.17
 
-replace MODULE_NAME => ../
+replace TODO_MODULE_NAME => ../
 
 require (
-	MODULE_NAME v0.0.0
+	TODO_MODULE_NAME v0.0.0
 	github.com/spf13/cobra v1.4.0
 )

--- a/workflow-templates/assets/cobra/docsgen/main.go
+++ b/workflow-templates/assets/cobra/docsgen/main.go
@@ -18,8 +18,9 @@ package main
 import (
 	"os"
 
-	// TODO: Replace CLI_PACKAGE_NAME with the project's Cobra CLI package import path
-	cli "CLI_PACKAGE_NAME"
+	// TODO: Replace TODO_CLI_PACKAGE_NAME with the project's Cobra CLI package import path
+	cli "TODO_CLI_PACKAGE_NAME"
+
 	"github.com/spf13/cobra/doc"
 )
 

--- a/workflow-templates/assets/general/gon.config.hcl
+++ b/workflow-templates/assets/general/gon.config.hcl
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/general/gon.config.hcl
 # See: https://github.com/mitchellh/gon#configuration-file
-source = [TODO]
-bundle_id = TODO
+source = [TODO_SOURCE_PATH]
+bundle_id = TODO_BUNDLE_ID
 
 sign {
   application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"

--- a/workflow-templates/assets/mkdocs/mkdocs.yml
+++ b/workflow-templates/assets/mkdocs/mkdocs.yml
@@ -1,13 +1,13 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/mkdocs/mkdocs.yml
 # See: https://www.mkdocs.org/user-guide/configuration/
 
-# TODO: Fill in all blank fields below.
-site_name:
-site_description:
-site_url:
+# TODO: Replace all "TODO_*" placeholders with the project information.
+site_name: TODO_SITE_NAME
+site_description: TODO_SITE_DESCRIPTION
+site_url: TODO_SITE_URL
 
-repo_name:
-repo_url:
+repo_name: TODO_REPO_NAME
+repo_url: TODO_REPO_URL
 edit_uri: blob/main/docs/
 
 copyright: Copyright 2021 ARDUINO SA (http://www.arduino.cc/)
@@ -34,7 +34,7 @@ markdown_extensions:
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
       emoji_index: !!python/name:pymdownx.emoji.twemoji
   - pymdownx.magiclink:
-      repo:
+      repo: TODO_REPO_NAME
       repo_url_shorthand: true
       user: arduino
   - pymdownx.superfences

--- a/workflow-templates/assets/test-integration/test_all.py
+++ b/workflow-templates/assets/test-integration/test_all.py
@@ -32,7 +32,7 @@ def run_command(pytestconfig, working_dir) -> typing.Callable[..., invoke.runner
     """
 
     # TODO: define project's executable name here:
-    executable_path = pathlib.Path(pytestconfig.rootdir).parent / "TODO"
+    executable_path = pathlib.Path(pytestconfig.rootdir).parent / "TODO_EXECUTABLE_NAME"
 
     def _run(
         cmd: list,

--- a/workflow-templates/check-certificates.md
+++ b/workflow-templates/check-certificates.md
@@ -10,7 +10,7 @@ Install the [`check-certificates.yml`](check-certificates.yml) GitHub Actions wo
 
 ### Configuration
 
-Replace `REPO_OWNER/REPO_NAME` with the repository's name in the `jobs.check-certificates.if` field of `check-certificates.yml`.
+Replace `TODO_REPO_OWNER/TODO_REPO_NAME` with the repository's name in the `jobs.check-certificates.if` field of `check-certificates.yml`.
 
 #### Set up Slack webhook
 
@@ -30,10 +30,10 @@ Replace `REPO_OWNER/REPO_NAME` with the repository's name in the `jobs.check-cer
 Markdown badge:
 
 ```markdown
-[![Check Certificates status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-certificates.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-certificates.yml)
+[![Check Certificates status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-certificates.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-certificates.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-certificates.yml
+++ b/workflow-templates/check-certificates.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
           # TODO: Update repository name.
-          REPO_SLUG="REPO_OWNER/REPO_NAME"
+          REPO_SLUG="TODO_REPO_OWNER/TODO_REPO_NAME"
           if [[
             (
               # Only run on branch creation when it is a release branch.

--- a/workflow-templates/check-general-formatting-task.md
+++ b/workflow-templates/check-general-formatting-task.md
@@ -31,10 +31,10 @@ https://github.com/editorconfig-checker/editorconfig-checker#configuration
 Markdown badge:
 
 ```markdown
-[![Check General Formatting status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-general-formatting-task.yml)
+[![Check General Formatting status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-general-formatting-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-go-dependencies-task.md
+++ b/workflow-templates/check-go-dependencies-task.md
@@ -70,10 +70,10 @@ In this case, the dependency's identifier must be added to the `reviewed.<source
 Markdown badge:
 
 ```markdown
-[![Check Go Dependencies status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-go-dependencies-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-go-dependencies-task.yml)
+[![Check Go Dependencies status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-go-dependencies-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-go-dependencies-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-go-task.md
+++ b/workflow-templates/check-go-task.md
@@ -32,10 +32,10 @@ If the project contains Go modules in paths other than the root of the repositor
 Markdown badge:
 
 ```markdown
-[![Check Go status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-go-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-go-task.yml)
+[![Check Go status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-go-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-go-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-license.md
+++ b/workflow-templates/check-license.md
@@ -20,10 +20,10 @@ Install the [`check-license.yml`](check-license.yml) GitHub Actions workflow to 
 Markdown badge:
 
 ```markdown
-[![Check License status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-license.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-license.yml)
+[![Check License status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-license.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-license.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-markdown-task.md
+++ b/workflow-templates/check-markdown-task.md
@@ -49,10 +49,10 @@ https://github.com/tcort/markdown-link-check#config-file-format
 Markdown badge:
 
 ```markdown
-[![Check Markdown status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-markdown-task.yml)
+[![Check Markdown status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-markdown-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-mkdocs-task.md
+++ b/workflow-templates/check-mkdocs-task.md
@@ -39,10 +39,10 @@ See [the "Deploy Website" (MkDocs, Poetry) workflow documentation](deploy-mkdocs
 Markdown badge:
 
 ```markdown
-[![Check Website status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-mkdocs-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-mkdocs-task.yml)
+[![Check Website status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-mkdocs-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-mkdocs-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-prettier-formatting-task.md
+++ b/workflow-templates/check-prettier-formatting-task.md
@@ -43,10 +43,10 @@ The default Prettier code style is the official standardized style to be used in
 Markdown badge:
 
 ```markdown
-[![Check Prettier Formatting status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-prettier-formatting-task.yml)
+[![Check Prettier Formatting status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-prettier-formatting-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-prettier-formatting-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -65,10 +65,10 @@ The `black` configuration is the official standardized style to be used in all A
 Markdown badge:
 
 ```markdown
-[![Check Python status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-python-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-python-task.yml)
+[![Check Python status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-python-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-python-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-shell-task.md
+++ b/workflow-templates/check-shell-task.md
@@ -28,10 +28,10 @@ The formatting style defined in `.editorconfig` is the official standardized sty
 Markdown badge:
 
 ```markdown
-[![Check Shell Scripts status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-shell-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-shell-task.yml)
+[![Check Shell Scripts status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-shell-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-shell-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-taskfiles.md
+++ b/workflow-templates/check-taskfiles.md
@@ -21,10 +21,10 @@ The workflow is configured to check all files named `Taskfile.yml` in the reposi
 Markdown badge:
 
 ```markdown
-[![Check Taskfiles status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-taskfiles.yml)
+[![Check Taskfiles status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-taskfiles.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-toc-task.md
+++ b/workflow-templates/check-toc-task.md
@@ -30,10 +30,10 @@ The workflow is configured to check a table of contents in `README.md`. If other
 Markdown badge:
 
 ```markdown
-[![Check ToC status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-toc-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-toc-task.yml)
+[![Check ToC status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-toc-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-toc-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-workflows-task.md
+++ b/workflow-templates/check-workflows-task.md
@@ -20,10 +20,10 @@ Install the [`check-workflows-task.yml`](check-workflows-task.yml) GitHub Action
 Markdown badge:
 
 ```markdown
-[![Check Workflows status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-workflows-task.yml)
+[![Check Workflows status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-workflows-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/check-yaml-task.md
+++ b/workflow-templates/check-yaml-task.md
@@ -57,10 +57,10 @@ https://yamllint.readthedocs.io/en/stable/configuration.html
 Markdown badge:
 
 ```markdown
-[![Check YAML status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-yaml-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/check-yaml-task.yml)
+[![Check YAML status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-yaml-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-yaml-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-certificates.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-certificates.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
           # TODO: Update repository name.
-          REPO_SLUG="REPO_OWNER/REPO_NAME"
+          REPO_SLUG="TODO_REPO_OWNER/TODO_REPO_NAME"
           if [[
             (
               # Only run on branch creation when it is a release branch.

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -3,11 +3,11 @@ name: Publish Nightly Build
 
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
-  PROJECT_NAME: TODO
+  PROJECT_NAME: TODO_PROJECT_NAME
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
-  AWS_PLUGIN_TARGET: TODO
+  AWS_PLUGIN_TARGET: TODO_AWS_PLUGIN_TARGET
   ARTIFACT_NAME: dist
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
@@ -3,11 +3,11 @@ name: Release
 
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
-  PROJECT_NAME: TODO
+  PROJECT_NAME: TODO_PROJECT_NAME
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
-  AWS_PLUGIN_TARGET: TODO
+  AWS_PLUGIN_TARGET: TODO_AWS_PLUGIN_TARGET
   ARTIFACT_NAME: dist
   # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -3,11 +3,11 @@ name: Release
 
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
-  PROJECT_NAME: TODO
+  PROJECT_NAME: TODO_PROJECT_NAME
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
-  AWS_PLUGIN_TARGET: TODO
+  AWS_PLUGIN_TARGET: TODO_AWS_PLUGIN_TARGET
   ARTIFACT_NAME: dist
 
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -102,4 +102,4 @@ jobs:
         with:
           file: ${{ matrix.module.path }}coverage_unit.txt
           flags: ${{ matrix.module.codecov-flags }}
-          fail_ci_if_error: ${{ github.repository == 'REPO_OWNER/REPO_NAME' }}
+          fail_ci_if_error: ${{ github.repository == 'TODO_REPO_OWNER/TODO_REPO_NAME' }}

--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
@@ -94,10 +94,10 @@ Add the following to `.gitignore`:
 Markdown badge:
 
 ```markdown
-[![Deploy Website status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-cobra-mkdocs-versioned-poetry.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-cobra-mkdocs-versioned-poetry.yml)
+[![Deploy Website status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/deploy-cobra-mkdocs-versioned-poetry.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/deploy-cobra-mkdocs-versioned-poetry.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -47,7 +47,7 @@ The workflow is configured for repositories that host the website source content
 
 #### MkDocs
 
-Fill in all blank field in `mkdocs.yml` with the project-specific information.
+Replace all `TODO_*` placeholders in `mkdocs.yml` with the project-specific information.
 
 Add entries for each website source file to the `nav` array in `mkdocs.yml`, or remove `nav` to have MkDocs auto-generate the navigation panel.
 
@@ -58,10 +58,10 @@ Reference: https://www.mkdocs.org/user-guide/configuration/
 Markdown badge:
 
 ```markdown
-[![Deploy Website status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-mkdocs-poetry.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-mkdocs-poetry.yml)
+[![Deploy Website status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/deploy-mkdocs-poetry.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/deploy-mkdocs-poetry.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.md
@@ -94,10 +94,10 @@ After this initial deployment, all further website updates will be handled autom
 Markdown badge:
 
 ```markdown
-[![Deploy Website status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-mkdocs-versioned-poetry.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/deploy-mkdocs-versioned-poetry.yml)
+[![Deploy Website status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/deploy-mkdocs-versioned-poetry.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/deploy-mkdocs-versioned-poetry.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/publish-go-nightly-task.md
+++ b/workflow-templates/publish-go-nightly-task.md
@@ -27,10 +27,10 @@ In addition, the following [repository secret](https://docs.github.com/actions/s
 Markdown badge:
 
 ```markdown
-[![Publish Nightly Build status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/publish-go-nightly-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/publish-go-nightly-task.yml)
+[![Publish Nightly Build status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/publish-go-nightly-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/publish-go-nightly-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -3,11 +3,11 @@ name: Publish Nightly Build
 
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
-  PROJECT_NAME: TODO
+  PROJECT_NAME: TODO_PROJECT_NAME
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
-  AWS_PLUGIN_TARGET: TODO
+  AWS_PLUGIN_TARGET: TODO_AWS_PLUGIN_TARGET
   ARTIFACT_NAME: dist
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/publish-go-tester-task.md
+++ b/workflow-templates/publish-go-tester-task.md
@@ -24,10 +24,10 @@ Install the [`publish-go-tester-task.yml`](publish-go-tester-task.yml) GitHub Ac
 Markdown badge:
 
 ```markdown
-[![Publish Tester Build status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/publish-go-tester-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/publish-go-tester-task.yml)
+[![Publish Tester Build status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/publish-go-tester-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/publish-go-tester-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/release-go-crosscompile-task.md
+++ b/workflow-templates/release-go-crosscompile-task.md
@@ -64,10 +64,10 @@ The following [repository secrets](https://docs.github.com/actions/security-guid
 Markdown badge:
 
 ```markdown
-[![Release status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/release-go-crosscompile-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/release-go-crosscompile-task.yml)
+[![Release status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/release-go-crosscompile-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/release-go-crosscompile-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -3,11 +3,11 @@ name: Release
 
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
-  PROJECT_NAME: TODO
+  PROJECT_NAME: TODO_PROJECT_NAME
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
-  AWS_PLUGIN_TARGET: TODO
+  AWS_PLUGIN_TARGET: TODO_AWS_PLUGIN_TARGET
   ARTIFACT_NAME: dist
   # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.17"

--- a/workflow-templates/release-go-task.md
+++ b/workflow-templates/release-go-task.md
@@ -63,10 +63,10 @@ The following [repository secrets](https://docs.github.com/actions/security-guid
 Markdown badge:
 
 ```markdown
-[![Release status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/release-go-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/release-go-task.yml)
+[![Release status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/release-go-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/release-go-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -3,11 +3,11 @@ name: Release
 
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
-  PROJECT_NAME: TODO
+  PROJECT_NAME: TODO_PROJECT_NAME
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
-  AWS_PLUGIN_TARGET: TODO
+  AWS_PLUGIN_TARGET: TODO_AWS_PLUGIN_TARGET
   ARTIFACT_NAME: dist
 
 on:

--- a/workflow-templates/release-tag.md
+++ b/workflow-templates/release-tag.md
@@ -13,10 +13,10 @@ Install the [`release-tag.yml`](release-tag.yml) GitHub Actions workflow to `.gi
 Markdown badge:
 
 ```markdown
-[![Release status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/release-tag.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/release-tag.yml)
+[![Release status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/release-tag.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/release-tag.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/spell-check-task.md
+++ b/workflow-templates/spell-check-task.md
@@ -55,10 +55,10 @@ https://github.com/codespell-project/codespell#using-a-config-file
 Markdown badge:
 
 ```markdown
-[![Spell Check status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/spell-check-task.yml)
+[![Spell Check status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/spell-check-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/sync-labels.md
+++ b/workflow-templates/sync-labels.md
@@ -65,10 +65,10 @@ The configuration file for labels that only apply to the specific project should
 Markdown badge:
 
 ```markdown
-[![Sync Labels status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/sync-labels.yml)
+[![Sync Labels status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/sync-labels.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/test-go-integration-task.md
+++ b/workflow-templates/test-go-integration-task.md
@@ -76,10 +76,10 @@ __pycache__/
 Markdown badge:
 
 ```markdown
-[![Test Integration status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-go-integration-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-go-integration-task.yml)
+[![Test Integration status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/test-go-integration-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/test-go-integration-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -25,7 +25,7 @@ Configure the version of Go used for development of the project in the `env.GO_V
 
 If the project contains Go modules in paths other than the root of the repository, add their paths to the [job matrix](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) in `check-go-task.yml` at `jobs.test.strategy.matrix.module[].path` and the [Codecov flag](https://docs.codecov.com/docs/flags) to group their data under at `jobs.test.strategy.matrix.module[].codecov-flags`
 
-Replace `REPO_OWNER/REPO_NAME` with the repository's name (e.g., `arduino/arduino-cli`) in the `codecov/codecov-action` action's `fail_ci_if_error` input in `test-go-task.yml`.
+Replace `TODO_REPO_OWNER/TODO_REPO_NAME` with the repository's name (e.g., `arduino/arduino-cli`) in the `codecov/codecov-action` action's `fail_ci_if_error` input in `test-go-task.yml`.
 
 #### `.gitignore`
 
@@ -43,11 +43,11 @@ Add the following to `.gitignore`:
 Markdown badge:
 
 ```markdown
-[![Test Go status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-go-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-go-task.yml)
-[![Codecov](https://codecov.io/gh/REPO_OWNER/REPO_NAME/branch/main/graph/badge.svg)](https://codecov.io/gh/REPO_OWNER/REPO_NAME)
+[![Test Go status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/test-go-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/test-go-task.yml)
+[![Codecov](https://codecov.io/gh/TODO_REPO_OWNER/TODO_REPO_NAME/branch/main/graph/badge.svg)](https://codecov.io/gh/TODO_REPO_OWNER/TODO_REPO_NAME)
 ```
 
-- Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+- Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 - If the coverage badge should reflect the coverage for a branch named something other than `main`, adjust the badge URL accordingly.
 
 ---

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -102,4 +102,4 @@ jobs:
         with:
           file: ${{ matrix.module.path }}coverage_unit.txt
           flags: ${{ matrix.module.codecov-flags }}
-          fail_ci_if_error: ${{ github.repository == 'REPO_OWNER/REPO_NAME' }}
+          fail_ci_if_error: ${{ github.repository == 'TODO_REPO_OWNER/TODO_REPO_NAME' }}

--- a/workflow-templates/test-python-poetry-task.md
+++ b/workflow-templates/test-python-poetry-task.md
@@ -54,10 +54,10 @@ Configure the version of Python used for development of the project in the `env.
 Markdown badge:
 
 ```markdown
-[![Test Python status](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-python-poetry-task.yml/badge.svg)](https://github.com/REPO_OWNER/REPO_NAME/actions/workflows/test-python-poetry-task.yml)
+[![Test Python status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/test-python-poetry-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/test-python-poetry-task.yml)
 ```
 
-Replace the `REPO_OWNER` and `REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
 
 ---
 


### PR DESCRIPTION
The assets collected in this repository are designed to be as universally applicable as is practical.

However, in some cases it is necessary to make some project-specific configurations within the asset files during the installation. These locations are indicated by ["TODO"-prefixed comments](https://en.wikipedia.org/wiki/Comment_(computer_programming)#Tags) where possible and the location where the configuration value is to be filled is indicated by placeholder text. I have found that it is sometimes easy to miss placeholders among a sea of visually similar variable names both while installing and while reviewing installations made by others.

Adding a `TODO_` prefix to the descriptive suffix of the placeholder text will make it easy for the installer to find all places where configuration is needed by a quick text search for "TODO" (which will now find both the comments and placeholders) and also make it easy for the reviewer to spot placeholders the installer missed.