### PR TITLE
Split configuration file validation infrastructure by type

### DIFF
--- a/.github/workflows/check-dependabot.yml
+++ b/.github/workflows/check-dependabot.yml
@@ -1,0 +1,36 @@
+name: Check Dependabot Configuration
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-dependabot.yml"
+      - "Taskfile.ya?ml"
+      - "**/dependabot.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-dependabot.yml"
+      - "Taskfile.ya?ml"
+      - "**/dependabot.ya?ml"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 17 * * WED"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate Dependabot configuration files
+        run: task dependabot:validate

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,24 +1,22 @@
-name: Check Configuration Files
+name: Check Label Configuration
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
     paths:
-      - ".github/workflows/check-configs.yml"
-      - "Taskfile.ya?ml"
-      - "**/dependabot.ya?ml"
+      - ".github/workflows/check-labels.yml"
       - "workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json"
       - "workflow-templates/assets/sync-labels/*.ya?ml"
+      - "Taskfile.ya?ml"
   pull_request:
     paths:
-      - ".github/workflows/check-configs.yml"
-      - "Taskfile.ya?ml"
-      - "**/dependabot.ya?ml"
+      - ".github/workflows/check-labels.yml"
       - "workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json"
       - "workflow-templates/assets/sync-labels/*.ya?ml"
+      - "Taskfile.ya?ml"
   schedule:
-    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
-    - cron: "0 8 * * TUE"
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 18 * * WED"
   workflow_dispatch:
   repository_dispatch:
 
@@ -36,5 +34,5 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
-      - name: Validate configuration files
-        run: task config:validate
+      - name: Validate repository label configuration files
+        run: task labels:validate

--- a/.github/workflows/check-markdownlint.yml
+++ b/.github/workflows/check-markdownlint.yml
@@ -1,0 +1,36 @@
+name: Check markdownlint Configuration
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-markdownlint.yml"
+      - "Taskfile.ya?ml"
+      - "**/.markdownlint*"
+  pull_request:
+    paths:
+      - ".github/workflows/check-markdownlint.yml"
+      - "Taskfile.ya?ml"
+      - "**/.markdownlint*"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 19 * * WED"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate markdownlint configuration files
+        run: task markdownlint:validate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Tooling Project Assets
 
-[![Check Configuration Files status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-configs.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-configs.yml)
+[![Check Dependabot Configuration status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot.yml)
+[![Check Label Configuration status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-labels.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-labels.yml)
+[![Check markdownlint Configuration status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdownlint.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdownlint.yml)
 [![Check General Formatting status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-general-formatting-task.yml)
 [![Check License status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-license.yml)
 [![Check Workflow Duplicates Sync status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot-sync.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot-sync.yml)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,11 +5,13 @@ tasks:
     desc: Check for problems with the project
     deps:
       - task: ci:validate
-      - task: config:validate
+      - task: dependabot:validate
       - task: general:check-formatting
       - task: general:check-spelling
+      - task: labels:validate
       - task: markdown:check-links
       - task: markdown:lint
+      - task: markdownlint:validate
       - task: python:lint
       - task: python:test
       - task: shell:check
@@ -101,54 +103,23 @@ tasks:
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-yaml/.yamllint.yml" \
           "{{.REPOSITORY_ROOT_PATH}}"
 
-  config:validate:
-    desc: Validate configuration files against their JSON schema
+  dependabot:validate:
+    desc: Validate Dependabot configuration files against their JSON schema
     vars:
       # Last version with support for draft-04, used by Dependabot schema
       AJV_CLI_VERSION: 3.3.0
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/dependabot-2.0.json
-      DEPENDABOT_SCHEMA_URL: https://json.schemastore.org/dependabot-2.0
-      DEPENDABOT_SCHEMA_PATH:
+      SCHEMA_URL: https://json.schemastore.org/dependabot-2.0
+      SCHEMA_PATH:
         sh: mktemp -t dependabot-schema-XXXXXXXXXX.json
-      DEPENDABOT_DATA_PATH: "**/dependabot.yml"
-      LABEL_CONFIG_SCHEMA_PATH: workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
-      LABEL_CONFIG_DATA_PATH: "workflow-templates/assets/sync-labels/*.{yml,yaml}"
-      # Source: https://github.com/DavidAnson/markdownlint/blob/main/schema/markdownlint-config-schema.json
-      # Note: temporarily using schema from `next` branch due to bug in the one on `main`.
-      # (https://github.com/DavidAnson/markdownlint/pull/406).
-      MARKDOWNLINT_SCHEMA_URL: https://raw.githubusercontent.com/DavidAnson/markdownlint/next/schema/markdownlint-config-schema.json
-      MARKDOWNLINT_SCHEMA_PATH:
-        sh: mktemp -t markdownlint-schema-XXXXXXXXXX.json
-      MARKDOWNLINT_DATA_PATH: "**/.markdownlint.{yml,yaml}"
+      DATA_PATH: "**/dependabot.yml"
     cmds:
-      - wget --quiet --output-document="{{.DEPENDABOT_SCHEMA_PATH}}" {{.DEPENDABOT_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - |
         npx ajv-cli@{{.AJV_CLI_VERSION}} validate \
           --all-errors \
-          -s "{{.DEPENDABOT_SCHEMA_PATH}}" \
-          -d "{{.DEPENDABOT_DATA_PATH}}"
-      - |
-        npx \
-          --package=ajv-cli \
-          --package=ajv-formats \
-          ajv validate \
-            --all-errors \
-            --strict=false \
-            -c ajv-formats \
-            -s "{{.LABEL_CONFIG_SCHEMA_PATH}}" \
-            -d "{{.LABEL_CONFIG_DATA_PATH}}"
-      - wget --quiet --output-document="{{.MARKDOWNLINT_SCHEMA_PATH}}" {{.MARKDOWNLINT_SCHEMA_URL}}
-      - |
-        npx \
-          --package=ajv-cli \
-          --package=ajv-formats \
-          ajv validate \
-            --all-errors \
-            --strict=false \
-            --allow-union-types \
-            -c ajv-formats \
-            -s "{{.MARKDOWNLINT_SCHEMA_PATH}}" \
-            -d "{{.MARKDOWNLINT_DATA_PATH}}"
+          -s "{{.SCHEMA_PATH}}" \
+          -d "{{.DATA_PATH}}"
 
   dependabot:sync:
     desc: Sync workflow duplicates for dependabot checks
@@ -215,6 +186,23 @@ tasks:
           "{{.ISSUE_TEMPLATES_PATH}}/minimal/bug-report.md" \
           "{{.ISSUE_TEMPLATES_PATH}}/minimal/feature-request.md" \
           "{{.ISSUE_TEMPLATES_INSTALLATION_PATH}}"
+
+  labels:validate:
+    desc: Validate GitHub repository label configuration files against their JSON schema
+    vars:
+      SCHEMA_PATH: workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
+      DATA_PATH: "workflow-templates/assets/sync-labels/*.{yml,yaml}"
+    cmds:
+      - |
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -c ajv-formats \
+            -s "{{.SCHEMA_PATH}}" \
+            -d "{{.DATA_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
   markdown:check-links:
@@ -284,6 +272,30 @@ tasks:
     desc: Check for problems in Markdown files
     cmds:
       - npx markdownlint-cli "**/*.md"
+
+  markdownlint:validate:
+    desc: Validate markdownlint configuration files against their JSON schema
+    vars:
+      # Source: https://github.com/DavidAnson/markdownlint/blob/main/schema/markdownlint-config-schema.json
+      # Note: temporarily using schema from `next` branch due to bug in the one on `main`.
+      # (https://github.com/DavidAnson/markdownlint/pull/406).
+      SCHEMA_URL: https://raw.githubusercontent.com/DavidAnson/markdownlint/next/schema/markdownlint-config-schema.json
+      SCHEMA_PATH:
+        sh: mktemp -t markdownlint-schema-XXXXXXXXXX.json
+      DATA_PATH: "**/.markdownlint.{yml,yaml}"
+    cmds:
+      - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
+      - |
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            --allow-union-types \
+            -c ajv-formats \
+            -s "{{.SCHEMA_PATH}}" \
+            -d "{{.DATA_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:


### PR DESCRIPTION
Previously, the validation of various configuration files stored and/or used in the repository was done by a single monolithic task and workflow. Due to the different characteristics of the files and their JSON schemas, there was no real benefit from this approach in terms of efficiency or maintainability.

As validation of additional configuration file types became necessary, the previous system grew more unwieldy. Splitting it up into separate tasks and workflows offers several primary benefits:

- Tasks are more maintainable
- CI workflows are more efficient due to only running validations relevant to the specific configuration files that were modified