### PR TITLE
Move docs for issue template chooser configs alongside assets

### DIFF
--- a/issue-templates/minimal/README.md
+++ b/issue-templates/minimal/README.md
@@ -16,16 +16,7 @@ This is the minimal issue template, applicable to any Arduino tooling project, i
   - Install to: `.github/ISSUE_TEMPLATE/`
 - [`feature-request.md`](feature-request.md) - feature request issue template
   - Install to: `.github/ISSUE_TEMPLATE/`
-- Template chooser - select the appropriate `config.yml` template chooser configuration file for the project type from the [`template-choosers` folder](../template-choosers).
-  - Install to: `.github/ISSUE_TEMPLATE/`
-
-### Configuration
-
-Replace `TODO_REPO_OWNER/TODO_REPO_NAME` in the `contact_links[0].url` field of `config.yml`.
-
-Add links for any additional relevant resources to the `contact_links[]` field of `config.yml`.
-
-Reference: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+- Template chooser - select the appropriate template chooser configuration for the project type from the [`template-choosers` folder](../template-choosers) and follow the installation instructions provided there.
 
 ## Commit message
 

--- a/issue-templates/template-choosers/README.md
+++ b/issue-templates/template-choosers/README.md
@@ -1,0 +1,14 @@
+# Issue template chooser configurations
+
+The template chooser is presented to the contributor when creating an issue in a repository that uses [issue templates](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).
+
+This chooser can be customized by adding a [configuration file](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser). This allows redirecting support requests via "Contact Links".
+
+Each subfolder contains an issue template chooser configuration for a specific application. Documentation is provided in each, which includes:
+
+- Installation instructions
+- Stock commit and pull request messages
+
+## References
+
+- https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

--- a/issue-templates/template-choosers/general/README.md
+++ b/issue-templates/template-choosers/general/README.md
@@ -1,0 +1,21 @@
+# General purpose issue template chooser configuration
+
+This is the general purpose issue template chooser configuration suitable for use in any Arduino tooling project.
+
+The template chooser is presented to the contributor when creating an issue in a repository that uses [issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).
+
+This chooser can be customized by adding a [configuration file](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser). This allows redirecting support requests via "Contact Links".
+
+## Installation
+
+### Assets
+
+- [`config.yml`](config.yml) - template chooser configuration file
+  - Install to: `.github/ISSUE_TEMPLATE/`
+- Issue templates - the chooser must be used in combination with issue templates or issue form configuration files. See the information about that [here](../../README.md).
+
+### Configuration
+
+Replace `TODO_REPO_OWNER/TODO_REPO_NAME` in the `contact_links[0].url` field of `config.yml`.
+
+Add links for any additional relevant resources to the `contact_links[]` field of `config.yml`.

--- a/issue-templates/template-choosers/general/config.yml
+++ b/issue-templates/template-choosers/general/config.yml
@@ -1,5 +1,8 @@
 # Source:
 # https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/general/config.yml
+# See:
+# https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
 contact_links:
   - name: Learn about using this project
     # TODO: Replace TODO_REPO_OWNER/TODO_REPO_NAME with the repository owner and name

--- a/issue-templates/template-choosers/github-actions/README.md
+++ b/issue-templates/template-choosers/github-actions/README.md
@@ -1,0 +1,17 @@
+# Issue template chooser configuration for GitHub Actions actions
+
+This is the issue template chooser configuration for use in [GitHub Actions action](https://docs.github.com/actions/creating-actions/about-custom-actions) repositories.
+
+## Installation
+
+### Assets
+
+- [`config.yml`](config.yml) - template chooser configuration file
+  - Install to: `.github/ISSUE_TEMPLATE/`
+- Issue templates - the chooser must be used in combination with issue templates or issue form configuration files. See the information about that [here](../../README.md).
+
+### Configuration
+
+Replace `TODO_REPO_OWNER/TODO_REPO_NAME` in the `contact_links[0].url` field of `config.yml`.
+
+Add links for any additional relevant resources to the `contact_links[]` field of `config.yml`.

--- a/issue-templates/template-choosers/github-actions/config.yml
+++ b/issue-templates/template-choosers/github-actions/config.yml
@@ -1,5 +1,8 @@
 # Source:
 # https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/template-choosers/github-actions/config.yml
+# See:
+# https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
 contact_links:
   - name: Learn about using this project
     # TODO: Replace TODO_REPO_OWNER/TODO_REPO_NAME with the repository owner and name


### PR DESCRIPTION
A collection of reusable [GitHub issue template chooser configuration files](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) are stored in this repository.

Previously, their documentation was located in the documentation for the [issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository). The reasoning for that approach was that the template chooser feature is exclusive to repositories that have issue templates. However, it does not scale well as additional issue templates are added, and also makes it difficult to find information about these template chooser configuration files.

A better approach is to place the documentation alongside the assets and then reference that from associated assets.