### PR TITLE
Add a collection of reusable issue form configuration files

### DIFF
--- a/.github/workflows/check-issue-templates.yml
+++ b/.github/workflows/check-issue-templates.yml
@@ -1,0 +1,36 @@
+name: Check Issue Templates
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-issue-templates.yml"
+      - "issue-templates/forms/**.ya?ml"
+      - "Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-issue-templates.yml"
+      - "issue-templates/forms/**.ya?ml"
+      - "Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate GitHub issue form configuration files
+        run: task issue-form:validate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Tooling Project Assets
 
 [![Check Dependabot Configuration status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-dependabot.yml)
+[![Check Issue Templates status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-issue-templates.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-issue-templates.yml)
 [![Check Label Configuration status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-labels.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-labels.yml)
 [![Check markdownlint Configuration status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdownlint.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-markdownlint.yml)
 [![Check General Formatting status](https://github.com/arduino/tooling-project-assets/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/arduino/tooling-project-assets/actions/workflows/check-general-formatting-task.yml)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,7 @@ tasks:
       - task: dependabot:validate
       - task: general:check-formatting
       - task: general:check-spelling
+      - task: issue-form:validate
       - task: labels:validate
       - task: markdown:check-links
       - task: markdown:lint
@@ -186,6 +187,26 @@ tasks:
           "{{.ISSUE_TEMPLATES_PATH}}/minimal/bug-report.md" \
           "{{.ISSUE_TEMPLATES_PATH}}/minimal/feature-request.md" \
           "{{.ISSUE_TEMPLATES_INSTALLATION_PATH}}"
+
+  issue-form:validate:
+    desc: Validate GitHub issue form configuration files against their JSON schema
+    vars:
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-issue-forms.json
+      SCHEMA_URL: https://json.schemastore.org/github-issue-forms.json
+      SCHEMA_PATH:
+        sh: mktemp -t github-issue-forms-schema-XXXXXXXXXX.json
+      DATA_PATH: "issue-templates/forms/**/*.{yml,yaml}"
+    cmds:
+      - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
+      - |
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            -c ajv-formats \
+            -s "{{.SCHEMA_PATH}}" \
+            -d "{{.DATA_PATH}}"
 
   labels:validate:
     desc: Validate GitHub repository label configuration files against their JSON schema

--- a/issue-templates/forms/README.md
+++ b/issue-templates/forms/README.md
@@ -1,0 +1,11 @@
+# GitHub issue form configuration files
+
+GitHub's issue form system offers the option of presenting the contributor with a web form when creating an issue.
+
+These forms can consist of several input field types including multi-line fields with the same formatting and attachment capabilities as the standard GitHub Issue composer, in addition to menus and checkboxes where appropriate.
+
+The form is configured via a YAML file. Reusable issue form configuration files designed for each project type are stored under the folders. See their individual readmes for instructions.
+
+More information:
+
+https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms

--- a/issue-templates/forms/general/README.md
+++ b/issue-templates/forms/general/README.md
@@ -1,0 +1,61 @@
+# General purpose issue forms
+
+These are the general purpose [GitHub issue form](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) configuration files suitable for use in any Arduino tooling project.
+
+## Installation
+
+### Assets
+
+- [`bug-report.md`](bug-report.yml) - issue form configuration for bug reports
+  - Install to: `.github/ISSUE_TEMPLATE/`
+- [`feature-request.md`](feature-request.yml) - issue form configuration for feature requests
+  - Install to: `.github/ISSUE_TEMPLATE/`
+- Template chooser - select the appropriate template chooser configuration for the project type from the [`template-choosers` folder](../../template-choosers) and follow the installation instructions provided there.
+
+### Configuration
+
+Replace the `TODO_*` placeholder text in the configuration files with the project-specific information.
+
+## Commit message
+
+```
+Use form-based issue templates
+
+High quality feedback via GitHub issues is a very valuable contribution to the project. It is important to make the
+issue creation and management process as efficient as possible for the contributors, maintainers, and developers.
+
+Issue templates are helpful to the maintainers and developers because it establishes a standardized framework for the
+issues and encourages the contributors to provide the essential information.
+
+The contributor is now presented with a web form when creating an issue. This consists of multi-line input fields that
+have the same formatting, preview, and attachment capabilities as the standard GitHub Issue composer, in addition to
+menus and checkboxes where appropriate.
+
+The use of this form-based system should provide a much better experience for the contributors and also result in higher
+quality issues by establishing a standardized framework for the issues and encouraging contributors to provide the
+essential information.
+
+A template chooser allows the contributor to select the appropriate template type, redirects support requests to the
+appropriate communication channels via "Contact Links", and provides a prominent link to security policy to guide any
+vulnerability disclosures.
+
+The clear separation of the types of issues encourages the reporter to fit their report into a specific issue category,
+resulting in more clarity. Automatic labeling according to template choice allows the reporter to do the initial
+classification.
+```
+
+## PR message
+
+```markdown
+High quality feedback via GitHub issues is a very valuable contribution to the project. It is important to make the issue creation and management process as efficient as possible for the contributors, maintainers, and developers.
+
+Issue templates are helpful to the maintainers and developers because it establishes a standardized framework for the issues and encourages the contributors to provide the essential information.
+
+The contributor is now presented with [a web form](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) when creating an issue. This consists of multi-line input fields that have the same formatting, preview, and attachment capabilities as the standard GitHub Issue composer, in addition to menus and checkboxes where appropriate.
+
+The use of this form-based system should provide a better issue creation experience and result in higher quality issues by establishing a standardized framework for the issues and encouraging contributors to provide the essential information.
+
+A [template chooser](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) allows the contributor to select the appropriate template type, redirects support requests to the appropriate communication channels via "Contact Links", and provides a prominent link to the security policy in order to guide any vulnerability disclosures.
+
+The clear separation of the types of issues encourages the reporter to fit their report into a specific issue category, resulting in more clarity. Automatic labeling according to template choice allows the reporter to do the initial classification.
+```

--- a/issue-templates/forms/general/bug-report.yml
+++ b/issue-templates/forms/general/bug-report.yml
@@ -1,0 +1,58 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/bug-report.md
+# See: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Bug report
+description: Report a problem with the code or documentation in this repository.
+labels:
+  - "type: imperfection"
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To reproduce
+      description: Provide the specific set of steps we can follow to reproduce the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What would you expect to happen after following those instructions?
+    validations:
+      required: true
+  - type: input
+    id: project-version
+    attributes:
+      # TODO: Replace TODO_PRODUCT_NAME with the product name of the project.
+      label: TODO_PRODUCT_NAME version
+      description: |
+        Which version of TODO_PRODUCT_NAME are you using?
+        _This should be the most recent version available._
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any additional information here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Issue checklist
+      description: Please double-check that you have done each of the following things before submitting the issue.
+      options:
+        # TODO: Replace TODO_REPO_OWNER/TODO_REPO_NAME with the repository owner and name.
+        - label: I searched for previous reports in [the issue tracker](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/issues?q=)
+          required: true
+        - label: I verified the problem still occurs when using the latest version
+          required: true
+        - label: My report contains all necessary details
+          required: true

--- a/issue-templates/forms/general/feature-request.yml
+++ b/issue-templates/forms/general/feature-request.yml
@@ -1,0 +1,54 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/bug-report.md
+# See: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Feature request
+description: Suggest an enhancement to this project.
+labels:
+  - "type: enhancement"
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the request
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Describe the current behavior
+      # TODO: Replace TODO_PRODUCT_NAME with the product name of the project.
+      description: |
+        What is the current behavior of TODO_PRODUCT_NAME in relation to your request?
+        How can we reproduce that behavior?
+    validations:
+      required: true
+  - type: input
+    id: project-version
+    attributes:
+      # TODO: Replace TODO_PRODUCT_NAME with the product name of the project.
+      label: TODO_PRODUCT_NAME version
+      description: |
+        Which version of TODO_PRODUCT_NAME are you using?
+        _This should be the most recent version available._
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any additional information here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Issue checklist
+      description: Please double-check that you have done each of the following things before submitting the issue.
+      options:
+        # TODO: Replace TODO_REPO_OWNER/TODO_REPO_NAME with the repository owner and name.
+        - label: I searched for previous requests in [the issue tracker](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/issues?q=)
+          required: true
+        - label: I verified the feature was still missing when using the latest version
+          required: true
+        - label: My request contains all necessary details
+          required: true

--- a/issue-templates/forms/platform-dependent/README.md
+++ b/issue-templates/forms/platform-dependent/README.md
@@ -1,0 +1,61 @@
+# Platform-dependent issue forms
+
+These are the [GitHub issue form](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) configuration files for platform-dependent projects.
+
+## Installation
+
+### Assets
+
+- [`bug-report.md`](bug-report.yml) - issue form configuration for bug reports
+  - Install to: `.github/ISSUE_TEMPLATE/`
+- [`feature-request.md`](feature-request.yml) - issue form configuration for feature requests
+  - Install to: `.github/ISSUE_TEMPLATE/`
+- Template chooser - select the appropriate template chooser configuration for the project type from the [`template-choosers` folder](../../template-choosers) and follow the installation instructions provided there.
+
+### Configuration
+
+Replace the `TODO_*` placeholder text in the configuration files with the project-specific information.
+
+## Commit message
+
+```
+Use form-based issue templates
+
+High quality feedback via GitHub issues is a very valuable contribution to the project. It is important to make the
+issue creation and management process as efficient as possible for the contributors, maintainers, and developers.
+
+Issue templates are helpful to the maintainers and developers because it establishes a standardized framework for the
+issues and encourages the contributors to provide the essential information.
+
+The contributor is now presented with a web form when creating an issue. This consists of multi-line input fields that
+have the same formatting, preview, and attachment capabilities as the standard GitHub Issue composer, in addition to
+menus and checkboxes where appropriate.
+
+The use of this form-based system should provide a much better experience for the contributors and also result in higher
+quality issues by establishing a standardized framework for the issues and encouraging contributors to provide the
+essential information.
+
+A template chooser allows the contributor to select the appropriate template type, redirects support requests to the
+appropriate communication channels via "Contact Links", and provides a prominent link to security policy to guide any
+vulnerability disclosures.
+
+The clear separation of the types of issues encourages the reporter to fit their report into a specific issue category,
+resulting in more clarity. Automatic labeling according to template choice allows the reporter to do the initial
+classification.
+```
+
+## PR message
+
+```markdown
+High quality feedback via GitHub issues is a very valuable contribution to the project. It is important to make the issue creation and management process as efficient as possible for the contributors, maintainers, and developers.
+
+Issue templates are helpful to the maintainers and developers because it establishes a standardized framework for the issues and encourages the contributors to provide the essential information.
+
+The contributor is now presented with [a web form](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) when creating an issue. This consists of multi-line input fields that have the same formatting, preview, and attachment capabilities as the standard GitHub Issue composer, in addition to menus and checkboxes where appropriate.
+
+The use of this form-based system should provide a better issue creation experience and result in higher quality issues by establishing a standardized framework for the issues and encouraging contributors to provide the essential information.
+
+A [template chooser](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) allows the contributor to select the appropriate template type, redirects support requests to the appropriate communication channels via "Contact Links", and provides a prominent link to the security policy in order to guide any vulnerability disclosures.
+
+The clear separation of the types of issues encourages the reporter to fit their report into a specific issue category, resulting in more clarity. Automatic labeling according to template choice allows the reporter to do the initial classification.
+```

--- a/issue-templates/forms/platform-dependent/bug-report.yml
+++ b/issue-templates/forms/platform-dependent/bug-report.yml
@@ -1,0 +1,78 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/bug-report.md
+# See: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Bug report
+description: Report a problem with the code or documentation in this repository.
+labels:
+  - "type: imperfection"
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To reproduce
+      description: Provide the specific set of steps we can follow to reproduce the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What would you expect to happen after following those instructions?
+    validations:
+      required: true
+  - type: input
+    id: project-version
+    attributes:
+      # TODO: Replace TODO_PRODUCT_NAME with the product name of the project.
+      label: TODO_PRODUCT_NAME version
+      description: |
+        Which version of TODO_PRODUCT_NAME are you using?
+        _This should be the most recent version available._
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      description: Which operating system(s) are you using on your computer?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - macOS
+        - N/A
+    validations:
+      required: true
+  - type: input
+    id: os-version
+    attributes:
+      label: Operating system version
+      description: Which version of the operating system are you using on your computer?
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any additional information here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Issue checklist
+      description: Please double-check that you have done each of the following things before submitting the issue.
+      options:
+        # TODO: Replace TODO_REPO_OWNER/TODO_REPO_NAME with the repository owner and name.
+        - label: I searched for previous reports in [the issue tracker](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/issues?q=)
+          required: true
+        - label: I verified the problem still occurs when using the latest version
+          required: true
+        - label: My report contains all necessary details
+          required: true

--- a/issue-templates/forms/platform-dependent/feature-request.yml
+++ b/issue-templates/forms/platform-dependent/feature-request.yml
@@ -1,0 +1,74 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/issue-templates/forms/platform-dependent/bug-report.md
+# See: https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Feature request
+description: Suggest an enhancement to this project.
+labels:
+  - "type: enhancement"
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the request
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Describe the current behavior
+      # TODO: Replace TODO_PRODUCT_NAME with the product name of the project.
+      description: |
+        What is the current behavior of TODO_PRODUCT_NAME in relation to your request?
+        How can we reproduce that behavior?
+    validations:
+      required: true
+  - type: input
+    id: project-version
+    attributes:
+      # TODO: Replace TODO_PRODUCT_NAME with the product name of the project.
+      label: TODO_PRODUCT_NAME version
+      description: |
+        Which version of TODO_PRODUCT_NAME are you using?
+        _This should be the most recent version available._
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      description: Which operating system(s) are you using on your computer?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - macOS
+        - N/A
+    validations:
+      required: true
+  - type: input
+    id: os-version
+    attributes:
+      label: Operating system version
+      description: Which version of the operating system are you using on your computer?
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any additional information here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Issue checklist
+      description: Please double-check that you have done each of the following things before submitting the issue.
+      options:
+        # TODO: Replace TODO_REPO_OWNER/TODO_REPO_NAME with the repository owner and name.
+        - label: I searched for previous requests in [the issue tracker](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/issues?q=)
+          required: true
+        - label: I verified the feature was still missing when using the latest version
+          required: true
+        - label: My request contains all necessary details
+          required: true


### PR DESCRIPTION
High quality feedback via GitHub issues is a very valuable contribution to the project. It is important to make the issue creation and management process as efficient as possible for the contributors, maintainers, and developers.

Issue templates are helpful to the maintainers and developers because it establishes a standardized framework for the issues and encourages the contributors to provide the essential information.

When a repository is configured to use the GitHub issue forms system, the contributor is now presented with a [a web form](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) when creating an issue. This consists of multi-line input fields that have the same formatting, preview, and attachment capabilities as the standard GitHub Issue composer, in addition to menus and checkboxes where appropriate.

The use of this form-based system should provide a much better experience for the contributors and also result in higher quality issues by establishing a standardized framework for the issues and encouraging contributors to provide the essential information.

The forms are [configured via a YAML file](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema). A collection of reusable issue form configuration files designed for each project type accompanied by documentation for their use are now stored in this repository. These will enable easily setting up issue forms in any project repository and efficiently maintaining the shared files in a centralized location.

On every push and pull request which modifies relevant files, and periodically, the issue form configuration files will be validated against [their JSON schema](https://json.schemastore.org/github-issue-forms.json) to catch any problems with the data.