### PR TITLE
fix semver-tool version. 3.2.0 is downloaded but 3.0.0 is still used.

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
@@ -148,7 +148,7 @@ jobs:
         id: prerelease
         run: |
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
-          unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
+          unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
       - name: Create Github Release and upload artifacts

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -141,7 +141,7 @@ jobs:
         id: prerelease
         run: |
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
-          unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
+          unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
       - name: Create Github Release and upload artifacts

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -148,7 +148,7 @@ jobs:
         id: prerelease
         run: |
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
-          unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
+          unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
       - name: Create Github Release and upload artifacts

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -141,7 +141,7 @@ jobs:
         id: prerelease
         run: |
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
-          unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
+          unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
           if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
       - name: Create Github Release and upload artifacts


### PR DESCRIPTION
Followup of f3291c6e4c706be12cc0ad5096b88f85298ee282
This problem causes the "Identify Prerelease" step to not correctly detect a prerelease:
`/home/runner/work/_temp/86a34b5f-71b2-4554-ba4c-b3d565415455.sh: line 3: /tmp/semver: Permission denied`
Example run: https://github.com/arduino/imgtool-packing/runs/6455908108?check_suite_focus=true#step:5:14