### PR TITLE
Remove outdated action version specification from comments

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/publish-go-nightly-task.yml
@@ -98,7 +98,7 @@ jobs:
         # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         # 2. Recalculate package checksum and replace it in the nnnnnn-checksums.txt file
         run: |
-          # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
+          # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}"
           PACKAGE_FILENAME="$(basename ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_nightly-*_macOS_64bit.tar.gz)"

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
@@ -110,7 +110,7 @@ jobs:
         # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         # 2. Recalculate package checksum and replace it in the nnnnnn-checksums.txt file
         run: |
-          # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
+          # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}
           TAG="${GITHUB_REF/refs\/tags\//}"

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -103,7 +103,7 @@ jobs:
         # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         # 2. Recalculate package checksum and replace it in the nnnnnn-checksums.txt file
         run: |
-          # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
+          # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}
           TAG="${GITHUB_REF/refs\/tags\//}"

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -98,7 +98,7 @@ jobs:
         # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         # 2. Recalculate package checksum and replace it in the nnnnnn-checksums.txt file
         run: |
-          # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
+          # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}"
           PACKAGE_FILENAME="$(basename ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_nightly-*_macOS_64bit.tar.gz)"

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -110,7 +110,7 @@ jobs:
         # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         # 2. Recalculate package checksum and replace it in the nnnnnn-checksums.txt file
         run: |
-          # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
+          # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}
           TAG="${GITHUB_REF/refs\/tags\//}"

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -103,7 +103,7 @@ jobs:
         # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         # 2. Recalculate package checksum and replace it in the nnnnnn-checksums.txt file
         run: |
-          # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
+          # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x ${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_darwin_amd64/${{ env.PROJECT_NAME }}
           TAG="${GITHUB_REF/refs\/tags\//}"


### PR DESCRIPTION
The workflow is using v3 now, and there has not been any on the permissions situation documented by this comment:

https://github.com/actions/upload-artifact/tree/v3#permission-loss

Since we have gotten behind on this comment at each bump and there is no sign that they will ever change the behavior (and also no reason to believe that it would align with a major version bump even if they did), I think it is best to just remove the version specification from the comment altogether.