### PR TITLE
Use non-version specific reference URLs for tool version workflow variables

### DIFF
--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -2,7 +2,7 @@
 name: Check Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -2,7 +2,7 @@
 name: Check YAML
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -2,7 +2,7 @@
 name: Spell Check
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/.github/workflows/test-python-poetry-task.yml
+++ b/.github/workflows/test-python-poetry-task.yml
@@ -2,7 +2,7 @@
 name: Test Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -2,7 +2,7 @@
 name: Check Go Dependencies
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -2,7 +2,7 @@
 name: Check Go
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/check-mkdocs-task.yml
+++ b/workflow-templates/check-mkdocs-task.yml
@@ -2,7 +2,7 @@
 name: Check Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/check-python-task.yml
+++ b/workflow-templates/check-python-task.yml
@@ -2,7 +2,7 @@
 name: Check Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/check-yaml-task.yml
+++ b/workflow-templates/check-yaml-task.yml
@@ -2,7 +2,7 @@
 name: Check YAML
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-dependencies-task.yml
@@ -2,7 +2,7 @@
 name: Check Go Dependencies
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-go-task.yml
@@ -2,7 +2,7 @@
 name: Check Go
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-mkdocs-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-mkdocs-task.yml
@@ -2,7 +2,7 @@
 name: Check Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-python-task.yml
@@ -2,7 +2,7 @@
 name: Check Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-yaml-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-yaml-task.yml
@@ -2,7 +2,7 @@
 name: Check YAML
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-poetry.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/deploy-mkdocs-versioned-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-crosscompile-task.yml
@@ -9,7 +9,7 @@ env:
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: TODO_AWS_PLUGIN_TARGET
   ARTIFACT_NAME: dist
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
 on:

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/spell-check-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/spell-check-task.yml
@@ -2,7 +2,7 @@
 name: Spell Check
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-integration-task.yml
@@ -2,9 +2,9 @@
 name: Test Integration
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-go-task.yml
@@ -2,7 +2,7 @@
 name: Test Go
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/test-python-poetry-task.yml
@@ -2,7 +2,7 @@
 name: Test Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 on:

--- a/workflow-templates/deploy-mkdocs-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.yml
@@ -2,7 +2,7 @@
 name: Deploy Website
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 on:

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -9,7 +9,7 @@ env:
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: TODO_AWS_PLUGIN_TARGET
   ARTIFACT_NAME: dist
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
 on:

--- a/workflow-templates/spell-check-task.yml
+++ b/workflow-templates/spell-check-task.yml
@@ -2,7 +2,7 @@
 name: Spell Check
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -2,9 +2,9 @@
 name: Test Integration
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -2,7 +2,7 @@
 name: Test Go
 
 env:
-  # See: https://github.com/actions/setup-go/tree/v3#readme
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/test-python-poetry-task.yml
+++ b/workflow-templates/test-python-poetry-task.yml
@@ -2,7 +2,7 @@
 name: Test Python
 
 env:
-  # See: https://github.com/actions/setup-python/tree/v3#available-versions-of-python
+  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows


### PR DESCRIPTION


GitHub Actions actions are used by the workflows to set up development tools in the runner workspace.

In order to facilitate updates to new versions of these tools, we specify the tool version to be set up via [environment variables](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#env) at the top of the workflow.

Since this variable definition is separate from the step using the action, it might not be immediately apparent to the maintainer which version syntaxes are supported. For this reason, comments were added with the URL to the relevant section of the consuming action's documentation. Previously, these URLs were made to point to the version of the documentation that matched the version of the action in use by the workflow. Since we only use a major version ref, the expectation was that this would only need to be updated rarely. However, it turned out that the major version bump cycle of these actions is significantly shorter than expected. In addition, it is easy to forget to update the URLs because action version update PRs are provided by Dependabot, which obviously won't update the comments for us.

So it will be best to use a URL that points to the documentation at the tip of the default branch of the action repository. The likelihood of the documentation provided by this URL not matching the behavior of the release version of the action in use is likely less than it is for the inevitably outdated URLs resulting from the previous approach.