### PR TITLE
Convert absolute paths used in tasks to Windows format

### DIFF
--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -48,7 +48,7 @@ jobs:
           version: 3.x
 
       - name: Validate package.json
-        run: task npm:validate
+        run: task --silent npm:validate
 
   check-sync:
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,7 +60,7 @@ tasks:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
       WORKFLOW_SCHEMA_URL: https://json.schemastore.org/github-workflow
       WORKFLOW_SCHEMA_PATH:
-        sh: mktemp -t workflow-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="workflow-schema-XXXXXXXXXX.json"
       WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
       TEMPLATE_WORKFLOWS_DATA_PATH: "./workflow-templates/*.{yml,yaml}"
     deps:
@@ -115,7 +115,7 @@ tasks:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/dependabot-2.0.json
       SCHEMA_URL: https://json.schemastore.org/dependabot-2.0
       SCHEMA_PATH:
-        sh: mktemp -t dependabot-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="dependabot-schema-XXXXXXXXXX.json"
       DATA_PATH: "**/dependabot.yml"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
@@ -199,7 +199,7 @@ tasks:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-issue-forms.json
       SCHEMA_URL: https://json.schemastore.org/github-issue-forms.json
       SCHEMA_PATH:
-        sh: mktemp -t github-issue-forms-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="github-issue-forms-schema-XXXXXXXXXX.json"
       DATA_PATH: "issue-templates/forms/**/*.{yml,yaml}"
     deps:
       - task: npm:install-deps
@@ -314,7 +314,7 @@ tasks:
       # Source: https://github.com/DavidAnson/markdownlint/blob/main/schema/markdownlint-config-schema.json
       SCHEMA_URL: https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json
       SCHEMA_PATH:
-        sh: mktemp -t markdownlint-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="markdownlint-schema-XXXXXXXXXX.json"
       DATA_PATH: "**/.markdownlint.{yml,yaml}"
     deps:
       - task: npm:install-deps
@@ -347,31 +347,31 @@ tasks:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json
       SCHEMA_URL: https://json.schemastore.org/package.json
       SCHEMA_PATH:
-        sh: mktemp -t package-json-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="package-json-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/ava.json
       AVA_SCHEMA_URL: https://json.schemastore.org/ava.json
       AVA_SCHEMA_PATH:
-        sh: mktemp -t ava-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="ava-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/eslintrc.json
       ESLINTRC_SCHEMA_URL: https://json.schemastore.org/eslintrc.json
       ESLINTRC_SCHEMA_PATH:
-        sh: mktemp -t eslintrc-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="eslintrc-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/jscpd.json
       JSCPD_SCHEMA_URL: https://json.schemastore.org/jscpd.json
       JSCPD_SCHEMA_PATH:
-        sh: mktemp -t jscpd-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="jscpd-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/prettierrc.json
       PRETTIERRC_SCHEMA_URL: https://json.schemastore.org/prettierrc.json
       PRETTIERRC_SCHEMA_PATH:
-        sh: mktemp -t prettierrc-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="prettierrc-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_URL: https://json.schemastore.org/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_PATH:
-        sh: mktemp -t semantic-release-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="semantic-release-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/stylelintrc.json
       STYLELINTRC_SCHEMA_URL: https://json.schemastore.org/stylelintrc.json
       STYLELINTRC_SCHEMA_PATH:
-        sh: mktemp -t stylelintrc-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
       INSTANCE_PATH: "**/package.json"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
@@ -502,6 +502,30 @@ tasks:
           exit 1
         fi
       - shfmt -w .
+
+  # Make a temporary file named according to the passed TEMPLATE variable and print the path passed to stdout
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
+  utility:mktemp-file:
+    vars:
+      RAW_PATH:
+        sh: mktemp --tmpdir "{{.TEMPLATE}}"
+    cmds:
+      - task: utility:normalize-path
+        vars:
+          RAW_PATH: "{{.RAW_PATH}}"
+
+  # Print a normalized version of the path passed via the RAW_PATH variable to stdout
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
+  utility:normalize-path:
+    cmds:
+      - |
+        if [[ "{{.OS}}" == "Windows_NT" ]] && which cygpath &>/dev/null; then
+            # Even though the shell handles POSIX format absolute paths as expected, external applications do not.
+            # So paths passed to such applications must first be converted to Windows format.
+            cygpath -w "{{.RAW_PATH}}"
+        else
+          echo "{{.RAW_PATH}}"
+        fi
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-yaml-task/Taskfile.yml
   yaml:lint:

--- a/workflow-templates/assets/check-npm-task/Taskfile.yml
+++ b/workflow-templates/assets/check-npm-task/Taskfile.yml
@@ -11,31 +11,31 @@ tasks:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json
       SCHEMA_URL: https://json.schemastore.org/package.json
       SCHEMA_PATH:
-        sh: mktemp -t package-json-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="package-json-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/ava.json
       AVA_SCHEMA_URL: https://json.schemastore.org/ava.json
       AVA_SCHEMA_PATH:
-        sh: mktemp -t ava-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="ava-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/eslintrc.json
       ESLINTRC_SCHEMA_URL: https://json.schemastore.org/eslintrc.json
       ESLINTRC_SCHEMA_PATH:
-        sh: mktemp -t eslintrc-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="eslintrc-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/jscpd.json
       JSCPD_SCHEMA_URL: https://json.schemastore.org/jscpd.json
       JSCPD_SCHEMA_PATH:
-        sh: mktemp -t jscpd-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="jscpd-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/prettierrc.json
       PRETTIERRC_SCHEMA_URL: https://json.schemastore.org/prettierrc.json
       PRETTIERRC_SCHEMA_PATH:
-        sh: mktemp -t prettierrc-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="prettierrc-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_URL: https://json.schemastore.org/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_PATH:
-        sh: mktemp -t semantic-release-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="semantic-release-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/stylelintrc.json
       STYLELINTRC_SCHEMA_URL: https://json.schemastore.org/stylelintrc.json
       STYLELINTRC_SCHEMA_PATH:
-        sh: mktemp -t stylelintrc-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
       INSTANCE_PATH: "**/package.json"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}

--- a/workflow-templates/assets/check-workflows-task/Taskfile.yml
+++ b/workflow-templates/assets/check-workflows-task/Taskfile.yml
@@ -9,7 +9,7 @@ tasks:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
       WORKFLOW_SCHEMA_URL: https://json.schemastore.org/github-workflow
       WORKFLOW_SCHEMA_PATH:
-        sh: mktemp -t workflow-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="workflow-schema-XXXXXXXXXX.json"
       WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
     deps:
       - task: npm:install-deps

--- a/workflow-templates/assets/windows-task/Taskfile.yml
+++ b/workflow-templates/assets/windows-task/Taskfile.yml
@@ -1,0 +1,27 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Make a temporary file named according to the passed TEMPLATE variable and print the path passed to stdout
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
+  utility:mktemp-file:
+    vars:
+      RAW_PATH:
+        sh: mktemp --tmpdir "{{.TEMPLATE}}"
+    cmds:
+      - task: utility:normalize-path
+        vars:
+          RAW_PATH: "{{.RAW_PATH}}"
+
+  # Print a normalized version of the path passed via the RAW_PATH variable to stdout
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
+  utility:normalize-path:
+    cmds:
+      - |
+        if [[ "{{.OS}}" == "Windows_NT" ]] && which cygpath &>/dev/null; then
+            # Even though the shell handles POSIX format absolute paths as expected, external applications do not.
+            # So paths passed to such applications must first be converted to Windows format.
+            cygpath -w "{{.RAW_PATH}}"
+        else
+          echo "{{.RAW_PATH}}"
+        fi

--- a/workflow-templates/check-npm-task.md
+++ b/workflow-templates/check-npm-task.md
@@ -16,6 +16,8 @@ Install the [check-npm-task.yml](check-npm-task.yml) GitHub Actions workflow to 
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/check-npm-task/Taskfile.yml) - Validation task.
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
+- [`Taskfile.yml`](assets/windows-task/Taskfile.yml) - Utility tasks.
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 
 ### Configuration
 

--- a/workflow-templates/check-npm-task.yml
+++ b/workflow-templates/check-npm-task.yml
@@ -48,7 +48,7 @@ jobs:
           version: 3.x
 
       - name: Validate package.json
-        run: task npm:validate
+        run: task --silent npm:validate
 
   check-sync:
     runs-on: ubuntu-latest

--- a/workflow-templates/check-workflows-task.md
+++ b/workflow-templates/check-workflows-task.md
@@ -16,6 +16,8 @@ Install the [`check-workflows-task.yml`](check-workflows-task.yml) GitHub Action
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/npm-task/Taskfile.yml) - npm tasks.
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
+- [`Taskfile.yml`](assets/windows-task/Taskfile.yml) - Utility tasks.
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 
 ### Dependencies
 

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-npm-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-npm-task.yml
@@ -48,7 +48,7 @@ jobs:
           version: 3.x
 
       - name: Validate package.json
-        run: task npm:validate
+        run: task --silent npm:validate
 
   check-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The [Task task runner tool](https://taskfile.dev/) uses [an integrated Bash shell interpreter](https://github.com/mvdan/sh) to allow the use of standard POSIX/Bash syntax and built-in utilities while providing cross-platform support for users who have made the poor choice of the non-standard Windows cmd or PowerShell shells.

While this is a nice feature of Task, distinguishing it from other alternatives, it is still often necessary to use non-built-in utilities.So use of a Bash shell is a requirement to run our tasks even the developers using Windows.

Although high quality Bash shells for Windows such as the Git Bash included as part of the [Git for Windows](https://git-scm.com/download/win) installation generally provide a seamless experience, there is the occasional "gotcha".

Relative paths work the same for POSIX and Windows, but absolute POSIX format paths may not. These paths are handled as expected by Task's integrated shell interpreter and by Bash, but when these paths are used outside that context they may no longer be correct.

For example:

```yaml
  foo:
    cmds:
      - mkdir "/tmp/posix-path-test-dir"
      - touch "/tmp/posix-path-test-dir/posix-path-test-file"
      - ls "/tmp/posix-path-test-dir"
      - cd "/tmp/posix-path-test-dir"
```

The first three commands work as expected, but the `cd` command fails:

```text
$ task foo
task: [foo] mkdir "/tmp/posix-path-test-dir"
task: [foo] touch "/tmp/posix-path-test-dir/posix-path-test-file"
task: [foo] ls "/tmp/posix-path-test-dir"
posix-path-test-file
task: [foo] cd "/tmp/posix-path-test-dir"
task: Failed to run task "foo": exit status 1
```

The POSIX format `/tmp` is actually set to the system temporary directory:

```text
$ cygpath -w "/tmp/posix-path-test-dir"
C:\Users\per\AppData\Local\Temp\posix-path-test-dir
```

But if treated as a Windows format path, this would be the `tmp` subfolder of the root of the current drive (e.g., `C:\tmp`). Even though the command was run from Git Bash, which provides a `cd` that handles this absolute path perfectly, when run from Task the Windows native `cd` is used instead.

This resulted in several of the data file validation tasks, which download the JSON schema to the temporary folder, to fail when ran on Windows.

The solution is to convert these absolute paths, the occurrence of which are relatively rare in our tasks, to Windows format (which is handled fine by both the integrated, Bash, and external applications) when the task is ran on a Windows machine. [The `cygpath` utility](https://cygwin.com/cygwin-ug-net/cygpath.html) provides this capability:

```text
$ task foo
task: [foo] mkdir "C:\Users\per\AppData\Local\Temp/posix-path-test-dir"
task: [foo] touch "C:\Users\per\AppData\Local\Temp/posix-path-test-dir/posix-path-test-file"
task: [foo] ls "C:\Users\per\AppData\Local\Temp/posix-path-test-dir"
posix-path-test-file
task: [foo] cd "C:\Users\per\AppData\Local\Temp/posix-path-test-dir"
```