### PR TITLE
Force use of unmanaged ajv-cli version as required

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -119,13 +119,18 @@ tasks:
       SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="dependabot-schema-XXXXXXXXXX.json"
       DATA_PATH: "**/dependabot.yml"
+      PROJECT_FOLDER:
+        sh: pwd
+      WORKING_FOLDER:
+        sh: task utility:mktemp-folder TEMPLATE="dependabot-validate-XXXXXXXXXX"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - |
+        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
         npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
           --all-errors \
           -s "{{.SCHEMA_PATH}}" \
-          -d "{{.DATA_PATH}}"
+          -d "{{.PROJECT_FOLDER}}/{{.DATA_PATH}}"
 
   dependabot:sync:
     desc: Sync workflow duplicates for dependabot checks
@@ -373,6 +378,10 @@ tasks:
       STYLELINTRC_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
       INSTANCE_PATH: "**/package.json"
+      PROJECT_FOLDER:
+        sh: pwd
+      WORKING_FOLDER:
+        sh: task utility:mktemp-folder TEMPLATE="dependabot-validate-XXXXXXXXXX"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}
@@ -382,6 +391,7 @@ tasks:
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
+        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
         npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
           --all-errors \
           -s "{{.SCHEMA_PATH}}" \
@@ -391,7 +401,7 @@ tasks:
           -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
           -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
           -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
-          -d "{{.INSTANCE_PATH}}"
+          -d "{{.PROJECT_FOLDER}}/{{.INSTANCE_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:
@@ -509,6 +519,17 @@ tasks:
     vars:
       RAW_PATH:
         sh: mktemp --tmpdir "{{.TEMPLATE}}"
+    cmds:
+      - task: utility:normalize-path
+        vars:
+          RAW_PATH: "{{.RAW_PATH}}"
+
+  # Make a temporary folder named according to the passed TEMPLATE variable and print the path passed to stdout
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
+  utility:mktemp-folder:
+    vars:
+      RAW_PATH:
+        sh: mktemp --directory --tmpdir "{{.TEMPLATE}}"
     cmds:
       - task: utility:normalize-path
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,9 @@
 version: "3"
 
+vars:
+  # Last version of ajv-cli with support for the JSON schema "Draft 4" specification
+  SCHEMA_DRAFT_4_AJV_CLI_VERSION: 3.3.0
+
 tasks:
   check:
     desc: Check for problems with the project
@@ -110,8 +114,6 @@ tasks:
   dependabot:validate:
     desc: Validate Dependabot configuration files against their JSON schema
     vars:
-      # Last version with support for draft-04, used by Dependabot schema
-      AJV_CLI_VERSION: 3.3.0
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/dependabot-2.0.json
       SCHEMA_URL: https://json.schemastore.org/dependabot-2.0
       SCHEMA_PATH:
@@ -120,7 +122,7 @@ tasks:
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - |
-        npx ajv-cli@{{.AJV_CLI_VERSION}} validate \
+        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
           --all-errors \
           -s "{{.SCHEMA_PATH}}" \
           -d "{{.DATA_PATH}}"
@@ -342,8 +344,6 @@ tasks:
   npm:validate:
     desc: Validate npm configuration files against their JSON schema
     vars:
-      # Last version with support for draft-04, used by the `package.json` schema
-      AJV_CLI_VERSION: 3.3.0
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json
       SCHEMA_URL: https://json.schemastore.org/package.json
       SCHEMA_PATH:
@@ -382,7 +382,7 @@ tasks:
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
-        npx ajv-cli@{{.AJV_CLI_VERSION}} validate \
+        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
           --all-errors \
           -s "{{.SCHEMA_PATH}}" \
           -r "{{.AVA_SCHEMA_PATH}}" \

--- a/workflow-templates/assets/check-npm-task/Taskfile.yml
+++ b/workflow-templates/assets/check-npm-task/Taskfile.yml
@@ -1,13 +1,15 @@
 # See: https://taskfile.dev/#/usage
 version: "3"
 
+vars:
+  # Last version of ajv-cli with support for the JSON schema "Draft 4" specification
+  SCHEMA_DRAFT_4_AJV_CLI_VERSION: 3.3.0
+
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-npm-task/Taskfile.yml
   npm:validate:
     desc: Validate npm configuration files against their JSON schema
     vars:
-      # Last version with support for draft-04, used by the `package.json` schema
-      AJV_CLI_VERSION: 3.3.0
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json
       SCHEMA_URL: https://json.schemastore.org/package.json
       SCHEMA_PATH:
@@ -46,7 +48,7 @@ tasks:
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
-        npx ajv-cli@{{.AJV_CLI_VERSION}} validate \
+        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
           --all-errors \
           -s "{{.SCHEMA_PATH}}" \
           -r "{{.AVA_SCHEMA_PATH}}" \

--- a/workflow-templates/assets/check-npm-task/Taskfile.yml
+++ b/workflow-templates/assets/check-npm-task/Taskfile.yml
@@ -39,6 +39,10 @@ tasks:
       STYLELINTRC_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
       INSTANCE_PATH: "**/package.json"
+      PROJECT_FOLDER:
+        sh: pwd
+      WORKING_FOLDER:
+        sh: task utility:mktemp-folder TEMPLATE="dependabot-validate-XXXXXXXXXX"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}
@@ -48,6 +52,7 @@ tasks:
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
+        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
         npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
           --all-errors \
           -s "{{.SCHEMA_PATH}}" \
@@ -57,4 +62,4 @@ tasks:
           -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
           -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
           -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
-          -d "{{.INSTANCE_PATH}}"
+          -d "{{.PROJECT_FOLDER}}/{{.INSTANCE_PATH}}"

--- a/workflow-templates/assets/windows-task/Taskfile.yml
+++ b/workflow-templates/assets/windows-task/Taskfile.yml
@@ -13,6 +13,17 @@ tasks:
         vars:
           RAW_PATH: "{{.RAW_PATH}}"
 
+  # Make a temporary folder named according to the passed TEMPLATE variable and print the path passed to stdout
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
+  utility:mktemp-folder:
+    vars:
+      RAW_PATH:
+        sh: mktemp --directory --tmpdir "{{.TEMPLATE}}"
+    cmds:
+      - task: utility:normalize-path
+        vars:
+          RAW_PATH: "{{.RAW_PATH}}"
+
   # Print a normalized version of the path passed via the RAW_PATH variable to stdout
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
   utility:normalize-path:


### PR DESCRIPTION
## Background

The [**ajv-cli** command line tool](https://github.com/ajv-validator/ajv-cli) is used for validating data files against their [JSON schema](https://json-schema.org/).

In general, it is preferable (for some schemas even mandatory) to use the modern versions of **ajv-cli**. However, support for the ["Draft 4" schema specification](https://json-schema.org/specification-links.html#draft-4) was dropped in [**avj** version 7.0.0](https://github.com/ajv-validator/ajv/releases/tag/v7.0.0), [introduced into **ajv-cli**](https://github.com/ajv-validator/ajv-cli/commit/5d2939ece4273b4306f43d4efef59f3033768168) at version 4.0.0. So when working with JSON schemas that specify that draft, it is necessary to use **ajv-cli** 3.3.0, the last compatible version.

This means that some projects may have dependencies on multiple versions of **ajv-cli**.

## Overview

The **ajv-cli** package is distributed via the **npm** registry. We are now using **npm** for management of such dependencies (https://github.com/arduino/tooling-project-assets/pull/240). Unfortunately, **npm** does not have support for managing multiple versions of a binary dependency.

**npm**'s "alias" feature seems ideal:

https://docs.npmjs.com/cli/v8/commands/npm-install#:~:text=npm%20install%20%3Calias%3E%40npm%3A%3Cname%3E

> - `npm install <alias>@npm:<name>`:
>
> Install a package under a custom alias. Allows multiple versions of a same-name package side-by-side

However, this is only suitable for code dependencies. There is no special handling of providing access via [`npx`](https://docs.npmjs.com/cli/v8/commands/npx/) to the binary of the aliased package:

```text
$ npm install --save-dev prettier1@npm:prettier@^1.0.0 prettier@^2.0.0
[...]

$ npx prettier1 --version
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/prettier1 - Not found
npm ERR! 404
npm ERR! 404  'prettier1@latest' is not in this registry.
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\per\AppData\Local\npm-cache\_logs\2022-07-04T19_20_39_998Z-debug-0.log

$ npx prettier1@npm:prettier --version
2.7.1
```

(**Prettier** is used for the demos because **ajv-cli** doesn't have a version command)

So the only reasonable option is to manage only one of the two tool versions. Since the "Draft 4" compatible version of the tool (3.3.0) will never have an available update, managing only the modern **ajv-cli** dependency is no hardship.

## Problem

Selectively running commands with the unmanaged version of the tool should be a simple matter of specifying the version of the package: `npx ajv-cli@3.3.0`:

https://docs.npmjs.com/cli/v8/commands/npx#description

> Package names with a specifier will only be considered a match if they have the exact same name and version as the local dependency.

Unfortunately, a bug in `npx` (https://github.com/npm/cli/issues/3210) causes the version specifier to be ignored when the managed version is already installed:

```text
$ npm install --save-dev prettier@^2.0.0
[...]

$ npx prettier@^1.0.0 --version
2.7.1
```

This bug is reportedly fixed, but that fix is not in a **Node.js** release yet, and even after that it may take us quite some time to upgrade to the version of **Node.js** which contains the fix (our current approach is to use [the **Node.js** "LTS" version](https://nodejs.org/en/about/releases/), which is currently at 16.x, while the fix will only be available from >18.4.0).

## Solution

The workaround implemented here is to run the unmanaged tool command from outside the project folder:

```text
$ npm install --save-dev prettier@^2.0.0
[...]

$ cd "$(mktemp --directory --tmpdir npx-bug-XXXXXXXX)"

$ npx prettier@^1.0.0 --version
1.19.1
```