### PR TITLE
Update ClangFormat configuration file for ClangFormat 14.0.0

### DIFF
--- a/.github/workflows/check-clang-format.yml
+++ b/.github/workflows/check-clang-format.yml
@@ -80,10 +80,11 @@ jobs:
             echo "CLANG_FORMAT_VERSION=${{ github.event.inputs.clang-format-version }}" >> "$GITHUB_ENV"
           fi
           echo "CLANG_FORMAT_INSTALL_PATH=${{ runner.temp }}/clang-format" >> "$GITHUB_ENV"
+          echo "YQ_INSTALL_PATH=${{ runner.temp }}/yq" >> "$GITHUB_ENV"
           echo "WORKING_FOLDER=${{ runner.temp }}" >> "$GITHUB_ENV"
 
       - name: Download ClangFormat
-        id: download
+        id: download-clang-format
         uses: MrOctopus/download-asset-action@1.0
         with:
           repository: arduino/clang-static-binaries
@@ -94,10 +95,26 @@ jobs:
       - name: Install ClangFormat
         run: |
           cd "${{ env.CLANG_FORMAT_INSTALL_PATH }}"
-          tar --extract --file="${{ steps.download.outputs.name }}"
+          tar --extract --file="${{ steps.download-clang-format.outputs.name }}"
           # Add installation to PATH:
           # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.CLANG_FORMAT_INSTALL_PATH }}/clang_Linux_64bit" >> "$GITHUB_PATH"
+
+      - name: Download yq
+        id: download-yq
+        uses: MrOctopus/download-asset-action@1.0
+        with:
+          repository: mikefarah/yq
+          asset: yq_linux_amd64.tar.gz
+          target: ${{ env.YQ_INSTALL_PATH }}
+
+      - name: Install yq
+        run: |
+          cd "${{ env.YQ_INSTALL_PATH }}"
+          tar --extract --file="${{ steps.download-yq.outputs.name }}"
+          # Add installation to PATH:
+          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          echo "${{ env.YQ_INSTALL_PATH }}/yq" >> "$GITHUB_PATH"
 
       - name: Check ClangFormat configuration file
         id: check

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -249,6 +249,13 @@ tasks:
             "{{.TARGET_PATH}}"
 
       - |
+        # Correct invalid `BasedOnStyle` key value
+        # The existing key is deleted before assigning it to a valid value in order to achieve consistent quoting style
+        # (updating the empty string value in place causes the assigned value to be wrapped in quotes)
+        yq --inplace 'del(.BasedOnStyle)' "{{.TARGET_PATH}}"
+        yq --inplace '.BasedOnStyle = "LLVM"' "{{.TARGET_PATH}}"
+
+      - |
         # Fix the inconsistent key order
         yq --inplace 'sort_keys(.)' "{{.TARGET_PATH}}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -231,6 +231,12 @@ tasks:
       - task: clang-format:check-installed
     cmds:
       - |
+        if ! which yq &>/dev/null; then
+          echo "ec not found or not in PATH. Please install: https://github.com/mikefarah/yq/#install"
+          exit 1
+        fi
+
+      - |
         # Add source comment
         echo \
           "# Source: https://github.com/arduino/tooling-project-assets/tree/main/other/clang-format-configuration" > \
@@ -241,6 +247,10 @@ tasks:
           --dump-config \
           --style=file:"{{.CLANG_FORMAT_CONFIGURATION_PATH}}" >> \
             "{{.TARGET_PATH}}"
+
+      - |
+        # Fix the inconsistent key order
+        yq --inplace 'sort_keys(.)' "{{.TARGET_PATH}}"
 
   # Use ClangFormat to format the files under the path specified by TARGET_FOLDER recursively
   clang-format:format:
@@ -272,10 +282,14 @@ tasks:
 
   clang-format:update-config:
     desc: Update ClangFormat configuration file to match effective tool configuration
+    vars:
+      WORKING_PATH:
+        sh: task utility:mktemp-file TEMPLATE="clang-format-update-config-XXXXXXXXXX.json"
     cmds:
       - task: clang-format:dump-config
         vars:
-          TARGET_PATH: "{{.CLANG_FORMAT_CONFIGURATION_PATH}}"
+          TARGET_PATH: "{{.WORKING_PATH}}"
+      - mv --force "{{.WORKING_PATH}}" "{{.CLANG_FORMAT_CONFIGURATION_PATH}}"
 
   clang-format:update-golden:
     desc: Update golden master test data for current configuration

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -26,6 +26,7 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: No
 AttributeMacros:
   - __capability
+BasedOnStyle: ''
 BinPackArguments: true
 BinPackParameters: true
 BitFieldColonSpacing: Both

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -135,6 +135,7 @@ QualifierAlignment: Leave
 ReferenceAlignment: Pointer
 ReflowComments: false
 RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
 SortIncludes: Never
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -51,6 +51,7 @@ BraceWrapping:
 BreakAfterJavaFieldAnnotations: false
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Attach
+BreakBeforeConceptDeclarations: false
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -28,6 +28,7 @@ AttributeMacros:
   - __capability
 BinPackArguments: true
 BinPackParameters: true
+BitFieldColonSpacing: Both
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -150,6 +150,14 @@ SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -61,7 +61,7 @@ BreakStringLiterals: false
 ColumnLimit: 0
 CommentPragmas: ''
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: false
@@ -119,6 +119,7 @@ ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PPIndentWidth: -1
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 1
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 1

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -136,6 +136,7 @@ ReferenceAlignment: Pointer
 ReflowComments: false
 RemoveBracesLLVM: false
 SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 0
 SortIncludes: Never
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -26,7 +26,7 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: No
 AttributeMacros:
   - __capability
-BasedOnStyle: ''
+BasedOnStyle: LLVM
 BinPackArguments: true
 BinPackParameters: true
 BitFieldColonSpacing: Both

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -132,6 +132,7 @@ PenaltyIndentedWhitespace: 1
 PenaltyReturnTypeOnItsOwnLine: 1
 PointerAlignment: Right
 QualifierAlignment: Leave
+ReferenceAlignment: Pointer
 ReflowComments: false
 SortIncludes: Never
 SortUsingDeclarations: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -68,6 +68,7 @@ Cpp11BracedListStyle: false
 DeriveLineEnding: true
 DerivePointerAlignment: true
 DisableFormat: false
+EmptyLineAfterAccessModifier: Leave
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
 ForEachMacros:

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -17,7 +17,7 @@ AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: Always
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 AllowShortLambdasOnASingleLine: Empty
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -131,6 +131,7 @@ PenaltyExcessCharacter: 1
 PenaltyIndentedWhitespace: 1
 PenaltyReturnTypeOnItsOwnLine: 1
 PointerAlignment: Right
+QualifierAlignment: Leave
 ReflowComments: false
 SortIncludes: Never
 SortUsingDeclarations: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -138,6 +138,7 @@ RemoveBracesLLVM: false
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 0
 SortIncludes: Never
+SortJavaStaticImport: Before
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -145,6 +145,7 @@ SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
 SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -69,6 +69,7 @@ DeriveLineEnding: true
 DerivePointerAlignment: true
 DisableFormat: false
 EmptyLineAfterAccessModifier: Leave
+EmptyLineBeforeAccessModifier: Leave
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
 ForEachMacros:

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -1,24 +1,23 @@
 # Source: https://github.com/arduino/tooling-project-assets/tree/main/other/clang-format-configuration
 ---
-Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveMacros: false
 AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: false
 AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: false
 AlignEscapedNewlines: DontAlign
-AlignOperands:   Align
+AlignOperands: Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortLambdasOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: Always
+AllowShortLambdasOnASingleLine: Empty
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
@@ -27,35 +26,35 @@ AlwaysBreakTemplateDeclarations: No
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-  AfterCaseLabel:  false
-  AfterClass:      false
+  AfterCaseLabel: false
+  AfterClass: false
   AfterControlStatement: Never
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
+  AfterStruct: false
+  AfterUnion: false
   AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
+  BeforeCatch: false
+  BeforeElse: false
   BeforeLambdaBody: false
-  BeforeWhile:     false
-  IndentBraces:    false
+  BeforeWhile: false
+  IndentBraces: false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
+BreakAfterJavaFieldAnnotations: false
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Attach
 BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
+BreakConstructorInitializersBeforeComma: false
+BreakInheritanceList: BeforeColon
 BreakStringLiterals: false
-ColumnLimit:     0
-CommentPragmas:  ''
+ColumnLimit: 0
+CommentPragmas: ''
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2
@@ -63,39 +62,40 @@ ContinuationIndentWidth: 2
 Cpp11BracedListStyle: false
 DeriveLineEnding: true
 DerivePointerAlignment: true
-DisableFormat:   false
+DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks:   Preserve
+IncludeBlocks: Preserve
 IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-    SortPriority:    0
-  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
-    Priority:        3
-    SortPriority:    0
-  - Regex:           '.*'
-    Priority:        1
-    SortPriority:    0
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 2
+    SortPriority: 0
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
+    Priority: 3
+    SortPriority: 0
+  - Regex: '.*'
+    Priority: 1
+    SortPriority: 0
 IncludeIsMainRegex: ''
 IncludeIsMainSourceRegex: ''
-IndentCaseLabels: true
 IndentCaseBlocks: true
+IndentCaseLabels: true
+IndentExternBlock: Indent
 IndentGotoLabels: false
 IndentPPDirectives: None
-IndentExternBlock: Indent
-IndentWidth:     2
+IndentWidth: 2
 IndentWrappedFunctionNames: false
 InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
+Language: Cpp
 MacroBlockBegin: ''
-MacroBlockEnd:   ''
+MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 100000
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
@@ -112,8 +112,8 @@ PenaltyBreakTemplateDeclaration: 1
 PenaltyExcessCharacter: 1
 PenaltyReturnTypeOnItsOwnLine: 1
 PointerAlignment: Right
-ReflowComments:  false
-SortIncludes:    false
+ReflowComments: false
+SortIncludes: false
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
@@ -124,26 +124,24 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
-SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-SpaceBeforeSquareBrackets: false
-Standard:        Auto
+Standard: Auto
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
-TabWidth:        2
-UseCRLF:         false
-UseTab:          Never
+TabWidth: 2
+UseCRLF: false
+UseTab: Never
 WhitespaceSensitiveMacros:
   - STRINGIZE
   - PP_STRINGIZE
   - BOOST_PP_STRINGIZE
-...
-

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -2,10 +2,11 @@
 ---
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveBitFields: false
-AlignConsecutiveDeclarations: false
-AlignConsecutiveMacros: false
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: None
 AlignEscapedNewlines: DontAlign
 AlignOperands: Align
 AlignTrailingComments: true
@@ -113,7 +114,7 @@ PenaltyExcessCharacter: 1
 PenaltyReturnTypeOnItsOwnLine: 1
 PointerAlignment: Right
 ReflowComments: false
-SortIncludes: false
+SortIncludes: Never
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -118,6 +118,7 @@ ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
+PPIndentWidth: -1
 PenaltyBreakAssignment: 1
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 1

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -124,6 +124,7 @@ PenaltyBreakAssignment: 1
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 1
 PenaltyBreakFirstLessLess: 1
+PenaltyBreakOpenParenthesis: 1
 PenaltyBreakString: 1
 PenaltyBreakTemplateDeclaration: 1
 PenaltyExcessCharacter: 1

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -94,6 +94,7 @@ IncludeCategories:
     CaseSensitive: false
 IncludeIsMainRegex: ''
 IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
 IndentCaseBlocks: true
 IndentCaseLabels: true
 IndentExternBlock: Indent

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -100,6 +100,7 @@ IndentCaseLabels: true
 IndentExternBlock: Indent
 IndentGotoLabels: false
 IndentPPDirectives: None
+IndentRequires: true
 IndentWidth: 2
 IndentWrappedFunctionNames: false
 InsertTrailingCommas: None

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -163,7 +163,7 @@ SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
-SpacesInAngles: false
+SpacesInAngles: Leave
 SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -128,6 +128,7 @@ PenaltyBreakOpenParenthesis: 1
 PenaltyBreakString: 1
 PenaltyBreakTemplateDeclaration: 1
 PenaltyExcessCharacter: 1
+PenaltyIndentedWhitespace: 1
 PenaltyReturnTypeOnItsOwnLine: 1
 PointerAlignment: Right
 ReflowComments: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -107,6 +107,7 @@ InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
 Language: Cpp
 MacroBlockBegin: ''
 MacroBlockEnd: ''

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -24,6 +24,8 @@ AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: No
+AttributeMacros:
+  - __capability
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
@@ -70,17 +72,22 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks: Preserve
 IncludeCategories:
   - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
     Priority: 2
     SortPriority: 0
+    CaseSensitive: false
   - Regex: '^(<|"(gtest|gmock|isl|json)/)'
     Priority: 3
     SortPriority: 0
+    CaseSensitive: false
   - Regex: '.*'
     Priority: 1
     SortPriority: 0
+    CaseSensitive: false
 IncludeIsMainRegex: ''
 IncludeIsMainSourceRegex: ''
 IndentCaseBlocks: true
@@ -136,6 +143,8 @@ SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
@@ -146,3 +155,5 @@ WhitespaceSensitiveMacros:
   - STRINGIZE
   - PP_STRINGIZE
   - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -134,6 +134,7 @@ PointerAlignment: Right
 QualifierAlignment: Leave
 ReferenceAlignment: Pointer
 ReflowComments: false
+RemoveBracesLLVM: false
 SortIncludes: Never
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -143,6 +143,7 @@ SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true

--- a/other/clang-format-configuration/.clang-format
+++ b/other/clang-format-configuration/.clang-format
@@ -167,6 +167,9 @@ SpacesInAngles: Leave
 SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum: 0
+  Maximum: -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: Auto

--- a/other/clang-format-configuration/notes.md
+++ b/other/clang-format-configuration/notes.md
@@ -6,10 +6,6 @@ This is the additional indent beyond the standard code indentation level.
 
 The Arduino IDE 1.x formatting style indented access modifiers (equivalent to `AccessModifierOffset: 0`), but also added an extra indent for the members. So non-indented access modifiers (`AccessModifierOffset: -2`) is actually closest to the previous formatting style.
 
-## `AttributeMacros`
-
-The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `AttributeMacros: []`.
-
 ## `BasedOnStyle`
 
 This key is irrelevant because we define all configuration keys.
@@ -35,18 +31,6 @@ https://releases.llvm.org/3.8.0/tools/clang/docs/ClangFormatStyleOptions.html#co
 ## `CommentPragmas`
 
 Setting this to an empty string (e.g., `""`) prevents any comments from being matched.
-
-## `ForEachMacros`
-
-The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `ForEachMacros: []`.
-
-## `IfMacros`
-
-The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `IfMacros: []`.
-
-## `IncludeCategories`
-
-The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `IncludeCategories: []`.
 
 ## `IncludeIsMainRegex`
 
@@ -74,14 +58,6 @@ The `DerivePointerAlignment: true` configuration causes whatever pointer alignme
 
 This key is omitted from the `clang-format --dump-config` output when it is set to an empty array. Since Arduino's configuration does not have any need to define such formats, it is expected that this key will be absent from the configuration file even though present in the **ClangFormat** documentation.
 
-## `StatementAttributeLikeMacros`
-
-The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `StatementAttributeLikeMacros: []`.
-
-## `StatementMacros`
-
-The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `StatementMacros: []`.
-
 ## `TabWidth`
 
 During the formatting process, **ClangFormat** always uses spaces initially for indentation and alignment, according to the `IndentWidth` configuration setting value.
@@ -99,10 +75,6 @@ This key is omitted from the `clang-format --dump-config` output when it is set 
 ## `UseCRLF`
 
 The `DeriveLineEnding: true` configuration causes whatever line endings are predominant in the code to be used by **ClangFormat**. In the event no prevailing style can be can't be detected from code, this value is used as a fallback.
-
-## `WhitespaceSensitiveMacros`
-
-The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `WhitespaceSensitiveMacros: []`.
 
 ## "Penalty" keys
 
@@ -133,3 +105,17 @@ They should be set to **ClangFormat**'s default values.
 - `ObjCBreakBeforeNestedBlockParam`
 - `ObjCSpaceAfterProperty`
 - `ObjCSpaceBeforeProtocolList`
+
+## Keys with a forced base value set
+
+Some [sequence type](https://www.yaml.info/learn/index.html#:~:text=A%20sequence%20is%20a%20list) keys have a base set of values which are hard coded into **ClangFormat**. These are appended to any custom values set in the configuration file and thus can not be overridden, even by setting the key to an empty array (e.g., `AttributeMacros: []`).
+
+Arduino's configuration file sets these base set values explicitly even when they are not relevant to the Arduino code style. This provides transparency of the effective configuration and facilitates the maintenance of the configuration file
+
+- `AttributeMacros`
+- `ForEachMacros`
+- `IfMacros`
+- `IncludeCategories`
+- `StatementAttributeLikeMacros`
+- `StatementMacros`
+- `WhitespaceSensitiveMacros`

--- a/other/clang-format-configuration/notes.md
+++ b/other/clang-format-configuration/notes.md
@@ -14,7 +14,7 @@ It is not clear from the documentation, but this truly is an "allow" setting, ra
 
 This key is irrelevant because we define all configuration keys.
 
-Even though it is not one of the documented possible values, `clang-format --dump-config` outputs `BasedOnStyle: ''`, so we use that.
+Even though it is not one of the documented possible values, `clang-format --dump-config` outputs `BasedOnStyle: ''`.
 
 ## `BraceWrapping`
 

--- a/other/clang-format-configuration/notes.md
+++ b/other/clang-format-configuration/notes.md
@@ -46,6 +46,10 @@ Setting this to an empty string (e.g., `""`) prevents any comments from being ma
 
 Setting this to an empty string (e.g., `""`) prevents any `#include` directives from being matched.
 
+## `IndentAccessModifiers`
+
+The Arduino IDE 1.x formatting style for classes is equivalent to `IndentAccessModifiers: true`. Unfortunately, this key also controls the indentation of `struct` members, the Arduino IDE 1.x formatting style of which is equivalent to `IndentAccessModifiers: false`. For this reason, the key must be set to `false` and the previous approach of aligning the class formatting style as closely as possible via the `AccessModifierOffset` configuration continued.
+
 ## `KeepEmptyLinesAtTheStartOfBlocks`
 
 Note that empty lines at the ends of blocks are always removed.

--- a/other/clang-format-configuration/notes.md
+++ b/other/clang-format-configuration/notes.md
@@ -114,6 +114,7 @@ They should be set to **ClangFormat**'s default values.
 
 - `BreakAfterJavaFieldAnnotations`
 - `JavaImportGroups`
+- `SortJavaStaticImport`
 
 ### JavaScript
 

--- a/other/clang-format-configuration/notes.md
+++ b/other/clang-format-configuration/notes.md
@@ -6,6 +6,10 @@ This is the additional indent beyond the standard code indentation level.
 
 The Arduino IDE 1.x formatting style indented access modifiers (equivalent to `AccessModifierOffset: 0`), but also added an extra indent for the members. So non-indented access modifiers (`AccessModifierOffset: -2`) is actually closest to the previous formatting style.
 
+## `AttributeMacros`
+
+The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `AttributeMacros: []`.
+
 ## `BasedOnStyle`
 
 This key is irrelevant because we define all configuration keys.
@@ -36,6 +40,10 @@ Setting this to an empty string (e.g., `""`) prevents any comments from being ma
 
 The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `ForEachMacros: []`.
 
+## `IfMacros`
+
+The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `IfMacros: []`.
+
 ## `IncludeCategories`
 
 The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `IncludeCategories: []`.
@@ -65,6 +73,10 @@ The `DerivePointerAlignment: true` configuration causes whatever pointer alignme
 ## `RawStringFormats`
 
 This key is omitted from the `clang-format --dump-config` output when it is set to an empty array. Since Arduino's configuration does not have any need to define such formats, it is expected that this key will be absent from the configuration file even though present in the **ClangFormat** documentation.
+
+## `StatementAttributeLikeMacros`
+
+The items specified via this key are added to the base set hardcoded into **ClangFormat**, even if you set it to `StatementAttributeLikeMacros: []`.
 
 ## `StatementMacros`
 

--- a/other/clang-format-configuration/notes.md
+++ b/other/clang-format-configuration/notes.md
@@ -14,7 +14,7 @@ It is not clear from the documentation, but this truly is an "allow" setting, ra
 
 This key is irrelevant because we define all configuration keys.
 
-**ClangFormat** uses the `LLVM` style as a base by default.
+Even though it is not one of the documented possible values, `clang-format --dump-config` outputs `BasedOnStyle: ''`, so we use that.
 
 ## `BraceWrapping`
 

--- a/other/clang-format-configuration/notes.md
+++ b/other/clang-format-configuration/notes.md
@@ -20,6 +20,12 @@ This key is irrelevant because we define all configuration keys.
 
 This key is ignored when `BreakBeforeBraces` is set to anything other than `Custom`.
 
+## `BreakBeforeConceptDeclarations`
+
+`true` forces the break.
+
+`false` allows the user to break or not break at their whim, in alignment with the Arduino IDE 1.x formatter behavior and Arduino's `AlwaysBreakTemplateDeclarations: No` configuration.
+
 ## `BreakBeforeInheritanceComma`
 
 Seems to be a backwards compatibility name for `BreakInheritanceList: BeforeComma`:

--- a/other/clang-format-configuration/notes.md
+++ b/other/clang-format-configuration/notes.md
@@ -6,6 +6,10 @@ This is the additional indent beyond the standard code indentation level.
 
 The Arduino IDE 1.x formatting style indented access modifiers (equivalent to `AccessModifierOffset: 0`), but also added an extra indent for the members. So non-indented access modifiers (`AccessModifierOffset: -2`) is actually closest to the previous formatting style.
 
+## `AllowShortIfStatementsOnASingleLine`
+
+It is not clear from the documentation, but this truly is an "allow" setting, rather than ClangFormat's usual approach of forcing a specific formatting style. So the value `AllIfsAndElse` allows the user to break `if` statements according to their whims, in alignment with the Arduino IDE 1.x formatter behavior, while the `Never` is completely restrictive, not allowing short `if`, `else if`, or `else` statements under any conditions.
+
 ## `BasedOnStyle`
 
 This key is irrelevant because we define all configuration keys.

--- a/other/clang-format-configuration/notes.md
+++ b/other/clang-format-configuration/notes.md
@@ -42,6 +42,12 @@ https://releases.llvm.org/3.8.0/tools/clang/docs/ClangFormatStyleOptions.html#co
 
 Setting this to an empty string (e.g., `""`) prevents any comments from being matched.
 
+## `ConstructorInitializerAllOnOneLineOrOnePerLine`
+
+`ConstructorInitializerAllOnOneLineOrOnePerLine: true` forces `PackConstructorInitializers: NextLine` in the effective configuration even if `PackConstructorInitializers` is set to the desired `BinPack` in the configuration file.
+
+Since `ConstructorInitializerAllOnOneLineOrOnePerLine` is deprecated, superseded by `PackConstructorInitializers`, `ConstructorInitializerAllOnOneLineOrOnePerLine` is set to the default `false` value that allows the desired setting for `PackConstructorInitializers` to be attained.
+
 ## `IncludeIsMainRegex`
 
 Setting this to an empty string (e.g., `""`) prevents any `#include` directives from being matched.
@@ -63,6 +69,10 @@ Note that empty lines at the ends of blocks are always removed.
 ## `NamespaceMacros`
 
 This key is omitted from the `clang-format --dump-config` output when it is set to an empty array. Since Arduino's configuration does not have any need to define such macros, it is expected that this key will be absent from the configuration file even though present in the **ClangFormat** documentation.
+
+## `PackConstructorInitializers`
+
+With Arduino's `ColumnLimit` setting of `0` (no limit), `PackConstructorInitializers: BinPack` is the most permissive setting,
 
 ## `PointerAlignment`
 

--- a/other/clang-format-configuration/testdata/golden/samples/arduino-libraries/Arduino_MKRMEM/examples/SPIFFSDirectories/SPIFFSDirectories.ino
+++ b/other/clang-format-configuration/testdata/golden/samples/arduino-libraries/Arduino_MKRMEM/examples/SPIFFSDirectories/SPIFFSDirectories.ino
@@ -41,8 +41,7 @@ void setup() {
   DirEntry entry;
   while (dir.readdir(entry)) {
     if (entry.isFile()) Serial.print("  F ");
-    else if (entry.isDirectory())
-      Serial.print("  D ");
+    else if (entry.isDirectory()) Serial.print("  D ");
     Serial.print(entry.name());
     Serial.println();
   }

--- a/other/clang-format-configuration/testdata/golden/samples/arduino-libraries/EducationShield/examples/Block2-Sports/Projects/Pong/Pong.ino
+++ b/other/clang-format-configuration/testdata/golden/samples/arduino-libraries/EducationShield/examples/Block2-Sports/Projects/Pong/Pong.ino
@@ -75,7 +75,6 @@ void loop() {
 void gameOver() {
   vuMeter.blinkAll(100, 10);
 
-  if (buttonNotPressed == 1) vuMeter.scrollRight(ledTime, 1);  //if button1 was not pressed, scroll LEDs to the right to start over
-  else if (buttonNotPressed == 2)
-    vuMeter.scrollLeft(ledTime, 1);  //if button2 was not pressed, scroll LEDs to the left to start over
+  if (buttonNotPressed == 1) vuMeter.scrollRight(ledTime, 1);      //if button1 was not pressed, scroll LEDs to the right to start over
+  else if (buttonNotPressed == 2) vuMeter.scrollLeft(ledTime, 1);  //if button2 was not pressed, scroll LEDs to the left to start over
 }

--- a/other/clang-format-configuration/testdata/golden/samples/arduino-libraries/EducationShield/examples/Block4-Robots/Projects/CameraRobot/CameraRobot.ino
+++ b/other/clang-format-configuration/testdata/golden/samples/arduino-libraries/EducationShield/examples/Block4-Robots/Projects/CameraRobot/CameraRobot.ino
@@ -41,8 +41,7 @@ void loop() {
     if (panJoystick == 1 && panAngle < 180) panAngle++;
     //If the X value from the joystick equals -1 and
     //panAngle is more than 0 degrees, decrease panAngle with 1
-    else if (panJoystick == -1 && panAngle > 0)
-      panAngle--;
+    else if (panJoystick == -1 && panAngle > 0) panAngle--;
   }
   //If the joysYicks Y value is 0 we will tilt
   if (tiltJoystick != 0) {
@@ -51,8 +50,7 @@ void loop() {
     if (tiltJoystick == 1 && tiltAngle < 180) tiltAngle++;
     //If the Y value from the joystick equals -1 and
     //tiltAngle is more than 0 degrees, decrease tiltAngle with 1
-    else if (tiltJoystick == -1 && tiltAngle > 0)
-      tiltAngle--;
+    else if (tiltJoystick == -1 && tiltAngle > 0) tiltAngle--;
   }
   pan.write(panAngle);    //Set position of the pan servo
   tilt.write(tiltAngle);  //Set position of the tilt servo

--- a/other/clang-format-configuration/testdata/golden/samples/arduino/ArduinoCore-samd/libraries/SBU/examples/SBU_LoadLZSS/lzssEncode.cpp
+++ b/other/clang-format-configuration/testdata/golden/samples/arduino/ArduinoCore-samd/libraries/SBU/examples/SBU_LoadLZSS/lzssEncode.cpp
@@ -108,8 +108,7 @@ void output1(int c) {
   mask = 256;
   while (mask >>= 1) {
     if (c & mask) putbit1();
-    else
-      putbit0();
+    else putbit0();
   }
 }
 
@@ -120,14 +119,12 @@ void output2(int x, int y) {
   mask = N;
   while (mask >>= 1) {
     if (x & mask) putbit1();
-    else
-      putbit0();
+    else putbit0();
   }
   mask = (1 << EJ);
   while (mask >>= 1) {
     if (y & mask) putbit1();
-    else
-      putbit0();
+    else putbit0();
   }
 }
 
@@ -164,8 +161,7 @@ int lzss_encode(const char buf_in[], uint32_t size) {
     if (y <= P) {
       y = 1;
       output1(c);
-    } else
-      output2(x & (N - 1), y - 2);
+    } else output2(x & (N - 1), y - 2);
     r += y;
     s += y;
     if (r >= N * 2 - F) {

--- a/other/clang-format-configuration/testdata/golden/samples/arduino/ArduinoCore-samd/libraries/USBHost/examples/USB_desc/USB_desc.ino
+++ b/other/clang-format-configuration/testdata/golden/samples/arduino/ArduinoCore-samd/libraries/USBHost/examples/USB_desc/USB_desc.ino
@@ -328,16 +328,13 @@ void printepdescr(uint8_t* descr_ptr) {
   printProgStr(End_Header_str);
   printProgStr(End_Address_str);
   if (0x80 & ep_ptr->bEndpointAddress) printProgStr(PSTR("IN\t\t"));
-  else
-    printProgStr(PSTR("OUT\t\t"));
+  else printProgStr(PSTR("OUT\t\t"));
   print_hex((ep_ptr->bEndpointAddress & 0xF), 8);
   printProgStr(End_Attr_str);
   transfer_type = ep_ptr->bmAttributes & bmUSB_TRANSFER_TYPE;
   if (transfer_type == USB_TRANSFER_TYPE_INTERRUPT) printProgStr(PSTR("INTERRUPT\t"));
-  else if (transfer_type == USB_TRANSFER_TYPE_BULK)
-    printProgStr(PSTR("BULK\t"));
-  else if (transfer_type == USB_TRANSFER_TYPE_ISOCHRONOUS)
-    printProgStr(PSTR("ISO\t"));
+  else if (transfer_type == USB_TRANSFER_TYPE_BULK) printProgStr(PSTR("BULK\t"));
+  else if (transfer_type == USB_TRANSFER_TYPE_ISOCHRONOUS) printProgStr(PSTR("ISO\t"));
   print_hex(ep_ptr->bmAttributes, 8);
   printProgStr(End_Pktsize_str);
   print_hex(ep_ptr->wMaxPacketSize, 16);

--- a/other/clang-format-configuration/testdata/golden/targeted/AllowShortIfStatementsOnASingleLine.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/AllowShortIfStatementsOnASingleLine.cpp
@@ -3,16 +3,58 @@ void foo() {
 
   if (a)
     return;
-  else {
+  if (a)
+    return;
+  else if (a)
+    return;
+  else
+    return;
+  if (a)
+    return;
+  else if (a) {
+    return;
+  } else {
     return;
   }
 
   if (a) return;
+  if (a)
+    return;
+  else if (a)
+    return;
   else
     return;
+  if (a)
+    return;
+  else if (a) {
+    return;
+  } else {
+    return;
+  }
 
   if (a) return;
-  else {
+  if (a) return;
+  else if (a)
+    return;
+  else
+    return;
+  if (a) return;
+  else if (a) {
+    return;
+  } else {
+    return;
+  }
+
+  if (a) return;
+  if (a) return;
+  else if (a)
+    return;
+  else
+    return;
+  if (a) return;
+  else if (a) {
+    return;
+  } else {
     return;
   }
 }

--- a/other/clang-format-configuration/testdata/golden/targeted/AllowShortIfStatementsOnASingleLine.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/AllowShortIfStatementsOnASingleLine.cpp
@@ -47,10 +47,8 @@ void foo() {
 
   if (a) return;
   if (a) return;
-  else if (a)
-    return;
-  else
-    return;
+  else if (a) return;
+  else return;
   if (a) return;
   else if (a) {
     return;

--- a/other/clang-format-configuration/testdata/golden/targeted/EmptyLineAfterAccessModifier.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/EmptyLineAfterAccessModifier.cpp
@@ -8,10 +8,12 @@ public:
   int foo;
 
 private:
+
   int bar;
 };
 
 class Baz {
 public:
+
   int foo;
 };

--- a/other/clang-format-configuration/testdata/golden/targeted/EmptyLineBeforeAccessModifier.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/EmptyLineBeforeAccessModifier.cpp
@@ -2,15 +2,14 @@ class Foo {
 public:
 private:
   int foo;
-
 protected:
 };
 
 class Bar {
 public:
+
 private:
   int foo;
-
 protected:
 };
 
@@ -24,6 +23,7 @@ protected:
 
 class Qux {
 public:
+
 private:
   int foo;
 

--- a/other/clang-format-configuration/testdata/golden/targeted/IndentRequires.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/IndentRequires.cpp
@@ -1,7 +1,7 @@
 template<typename T>
-requires(true)
-  T foo() {}
+  requires(true)
+T foo() {}
 
 template<typename T>
-requires(true)
-  T bar() {}
+  requires(true)
+T bar() {}

--- a/other/clang-format-configuration/testdata/golden/targeted/IndentRequires.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/IndentRequires.cpp
@@ -1,5 +1,7 @@
 template<typename T>
-requires true T foo() {}
+requires(true)
+  T foo() {}
 
 template<typename T>
-requires true T bar() {}
+requires(true)
+  T bar() {}

--- a/other/clang-format-configuration/testdata/golden/targeted/PackConstructorInitializers.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/PackConstructorInitializers.cpp
@@ -3,25 +3,38 @@ class Foo {
   Foo(int);
   Foo(int, int);
   Foo(int, int, int);
-  int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
-  int bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
-  int cccccccccccccccccccccccccccccccccccccccccccccccccc;
+  Foo(int, int, int, int);
+  int a;
+  int b;
+  int c;
+  int dddddddddddddddddddddddddddddddddddddddddddddddddd;
+  int eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee;
+  int ffffffffffffffffffffffffffffffffffffffffffffffffff;
   int d;
   int e;
   int f;
-  int ddddddddddddddddddddddddd;
   int ggggggggggggggggggggggggg;
   int hhhhhhhhhhhhhhhhhhhhhhhhh;
   int iiiiiiiiiiiiiiiiiiiiiiiii;
 };
 
 Foo::Foo()
-  : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(42),
-    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(1234),
-    cccccccccccccccccccccccccccccccccccccccccccccccccc(11) {}
+  : a(42),
+    b(1234),
+    c(11) {}
 
 Foo::Foo(int bar)
-  : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(bar), bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(1234), cccccccccccccccccccccccccccccccccccccccccccccccccc(11) {}
+  : dddddddddddddddddddddddddddddddddddddddddddddddddd(bar), eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee(1234), ffffffffffffffffffffffffffffffffffffffffffffffffff(11) {}
+
+Foo::Foo(int bar, int baz)
+  : a(bar), b(baz), c(11) {}
 
 Foo::Foo(int bar, int baz, int qux)
-  : ggggggggggggggggggggggggg(bar), hhhhhhhhhhhhhhhhhhhhhhhhh(baz), iiiiiiiiiiiiiiiiiiiiiiiii(qux) {}
+  : dddddddddddddddddddddddddddddddddddddddddddddddddd(bar),
+    eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee(baz),
+    ffffffffffffffffffffffffffffffffffffffffffffffffff(qux) {}
+
+Foo::Foo(int bar, int baz, int qux, int pippo)
+  : ggggggggggggggggggggggggg(bar), hhhhhhhhhhhhhhhhhhhhhhhhh(baz), iiiiiiiiiiiiiiiiiiiiiiiii(qux) {
+  (void)pippo;
+}

--- a/other/clang-format-configuration/testdata/golden/targeted/PackConstructorInitializers.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/PackConstructorInitializers.cpp
@@ -24,7 +24,8 @@ Foo::Foo()
     c(11) {}
 
 Foo::Foo(int bar)
-  : dddddddddddddddddddddddddddddddddddddddddddddddddd(bar), eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee(1234), ffffffffffffffffffffffffffffffffffffffffffffffffff(11) {}
+  : dddddddddddddddddddddddddddddddddddddddddddddddddd(bar), eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee(1234),
+    ffffffffffffffffffffffffffffffffffffffffffffffffff(11) {}
 
 Foo::Foo(int bar, int baz)
   : a(bar), b(baz), c(11) {}

--- a/other/clang-format-configuration/testdata/golden/targeted/SpacesInAngles.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/SpacesInAngles.cpp
@@ -1,6 +1,6 @@
 template<int foo> void bar() {}
 
 void baz() {
-  bar<42>();
+  bar< 42 >();
   bar<42>();
 }

--- a/other/clang-format-configuration/testdata/golden/targeted/Standard.cpp
+++ b/other/clang-format-configuration/testdata/golden/targeted/Standard.cpp
@@ -1,6 +1,6 @@
 #include <set>
 #include <vector>
 
-std::vector<std::set<int>> foo;
+std::vector<std::set<int> > foo;
 
 std::vector<std::set<int>> bar;

--- a/other/clang-format-configuration/testdata/input/targeted/AllowShortIfStatementsOnASingleLine.cpp
+++ b/other/clang-format-configuration/testdata/input/targeted/AllowShortIfStatementsOnASingleLine.cpp
@@ -3,16 +3,56 @@ void foo() {
 
   if (a)
     return;
-  else {
+  if (a)
+    return;
+  else if (a)
+    return;
+  else
+    return;
+  if (a)
+    return;
+  else if (a) {
+    return;
+  } else {
     return;
   }
 
   if (a) return;
+  if (a)
+    return;
+  else if (a)
+    return;
   else
     return;
+  if (a)
+    return;
+  else if (a) {
+    return;
+  } else {
+    return;
+  }
 
   if (a) return;
-  else {
+  if (a) return;
+  else if (a)
+    return;
+  else
+    return;
+  if (a) return;
+  else if (a) {
+    return;
+  } else {
+    return;
+  }
+
+  if (a) return;
+  if (a) return;
+  else if (a) return;
+  else return;
+  if (a) return;
+  else if (a) {
+    return;
+  } else {
     return;
   }
 }

--- a/other/clang-format-configuration/testdata/input/targeted/IndentRequires.cpp
+++ b/other/clang-format-configuration/testdata/input/targeted/IndentRequires.cpp
@@ -1,5 +1,7 @@
 template<typename T>
-  requires true T foo() {}
+  requires(true)
+T foo() {}
 
 template<typename T>
-requires true T bar() {}
+requires(true)
+T bar() {}

--- a/other/clang-format-configuration/testdata/input/targeted/PackConstructorInitializers.cpp
+++ b/other/clang-format-configuration/testdata/input/targeted/PackConstructorInitializers.cpp
@@ -3,26 +3,38 @@ class Foo {
   Foo(int);
   Foo(int, int);
   Foo(int, int, int);
-  int aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
-  int bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
-  int cccccccccccccccccccccccccccccccccccccccccccccccccc;
+  Foo(int, int, int, int);
+  int a;
+  int b;
+  int c;
+  int dddddddddddddddddddddddddddddddddddddddddddddddddd;
+  int eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee;
+  int ffffffffffffffffffffffffffffffffffffffffffffffffff;
   int d;
   int e;
   int f;
-  int ddddddddddddddddddddddddd;
   int ggggggggggggggggggggggggg;
   int hhhhhhhhhhhhhhhhhhhhhhhhh;
   int iiiiiiiiiiiiiiiiiiiiiiiii;
 };
 
 Foo::Foo()
-  : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(42),
-    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(1234),
-    cccccccccccccccccccccccccccccccccccccccccccccccccc(11) {}
+  : a(42),
+    b(1234),
+    c(11) {}
 
 Foo::Foo(int bar)
-  : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(bar), bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(1234),
-    cccccccccccccccccccccccccccccccccccccccccccccccccc(11) {}
+  : dddddddddddddddddddddddddddddddddddddddddddddddddd(bar), eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee(1234),
+    ffffffffffffffffffffffffffffffffffffffffffffffffff(11) {}
+
+Foo::Foo(int bar, int baz) : a(bar), b(baz), c(11) {}
 
 Foo::Foo(int bar, int baz, int qux)
-  : ggggggggggggggggggggggggg(bar), hhhhhhhhhhhhhhhhhhhhhhhhh(baz), iiiiiiiiiiiiiiiiiiiiiiiii(qux) {}
+  : dddddddddddddddddddddddddddddddddddddddddddddddddd(bar),
+    eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee(baz),
+    ffffffffffffffffffffffffffffffffffffffffffffffffff(qux) {}
+
+Foo::Foo(int bar, int baz, int qux, int pippo)
+  : ggggggggggggggggggggggggg(bar), hhhhhhhhhhhhhhhhhhhhhhhhh(baz), iiiiiiiiiiiiiiiiiiiiiiiii(qux) {
+  (void)pippo;
+}


### PR DESCRIPTION
The **ClangFormat** configuration file hosted in this repository was developed for use with [**ClangFormat** 11.0.1](https://releases.llvm.org/11.0.1/tools/clang/docs/ClangFormat.html). The version of ClangFormat now in use by the Arduino IDE 2.x is 14.0.0:

https://github.com/arduino/arduino-ide/blob/19c0334a91cf562cf63edf0496eae16165499f8f/arduino-ide-extension/package.json#L164-L166

Configuration keys were added, removed, or changed in type in the interim.

The configuration file and its maintenance infrastructure are hereby updated for use with [**ClangFormat** 14.0.0](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormat.html).

## Functional changes

The goal is always be to preserve consistent formatter output through any changes that must be made to the file. Since Arduino IDE 2.x is still in a pre-release state, the output of most interest is that of the stable production Arduino IDE 1.x and the Arduino Web Editor, which use the [**Artistic Style**](http://astyle.sourceforge.net/) code formatter.

The **ClangFormat** configuration file was designed to reproduce the results of the **Artistic Style** tool under [the default configuration provided by the Arduino IDE 1.x installation](https://github.com/arduino/Arduino/blob/master/build/shared/lib/formatter.conf). Unfortunately, it emerged at that time that some changes were unavoidable due to differences in the two tools, most often that **ClangFormat** tends to enforce whichever specific formatting style was chosen, without an option to simply accept whatever formatting the user happened to write, as was the case with **Artistic Style**.

Some of the newly added keys either offer a more lenient behavior or else allow specific behavior that  aligns with the output from **Artistic Style**. This opportunity was taken to achieve a closer alignment of the outputs from the two tools. This resulted in some diffs in the "golden master" test data used to verify the output from **ClangFormat** is as expected under Arduino's configuration. However, these diffs are actually the previously unavoidable unwanted formatting differences being reverted.

## Schema validation failure

The `validate` job of the "Check ClangFormat Configuration" workflow is still failing. This is caused by an error in the JSON schema, so it should not be considered an indication of a defect in this pull request or cause to delay its merge.

I have submitted a fix for that error and the job will pass once that is accepted:
https://github.com/SchemaStore/schemastore/pull/2384