### PR TITLE
Add template for validating GitHub Actions action metadata

### DIFF
--- a/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
+++ b/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
@@ -7,7 +7,7 @@ tasks:
     desc: Validate GitHub Actions metadata against JSON schema
     vars:
       ACTION_METADATA_SCHEMA_PATH:
-        sh: mktemp -t github-action-schema-XXXXXXXXXX.json
+        sh: task utility:mktemp-file TEMPLATE="github-action-schema-XXXXXXXXXX.json"
     deps:
       - task: npm:install-deps
     cmds:

--- a/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
+++ b/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
@@ -11,5 +11,15 @@ tasks:
     deps:
       - task: npm:install-deps
     cmds:
-      - wget --quiet --output-document="{{.ACTION_METADATA_SCHEMA_PATH}}" https://json.schemastore.org/github-action
-      - npx ajv-cli validate --strict=false -s "{{.ACTION_METADATA_SCHEMA_PATH}}" -d "action.yml"
+      - |
+        wget \
+          --quiet \
+          --output-document="{{.ACTION_METADATA_SCHEMA_PATH}}" \
+          https://json.schemastore.org/github-action
+      - |
+        npx \
+          ajv-cli \
+            validate \
+            --strict=false \
+            -s "{{.ACTION_METADATA_SCHEMA_PATH}}" \
+            -d "action.yml"

--- a/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
+++ b/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
@@ -1,0 +1,13 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
+  action:validate:
+    desc: Validate GitHub Actions metadata against JSON schema
+    vars:
+      ACTION_METADATA_SCHEMA_PATH:
+        sh: mktemp -t github-action-schema-XXXXXXXXXX.json
+    cmds:
+      - wget --quiet --output-document="{{.ACTION_METADATA_SCHEMA_PATH}}" https://json.schemastore.org/github-action
+      - npx ajv-cli validate --strict=false -s "{{.ACTION_METADATA_SCHEMA_PATH}}" -d "action.yml"

--- a/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
+++ b/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
@@ -8,6 +8,8 @@ tasks:
     vars:
       ACTION_METADATA_SCHEMA_PATH:
         sh: mktemp -t github-action-schema-XXXXXXXXXX.json
+    deps:
+      - task: npm:install-deps
     cmds:
       - wget --quiet --output-document="{{.ACTION_METADATA_SCHEMA_PATH}}" https://json.schemastore.org/github-action
       - npx ajv-cli validate --strict=false -s "{{.ACTION_METADATA_SCHEMA_PATH}}" -d "action.yml"

--- a/workflow-templates/check-action-metadata-task.md
+++ b/workflow-templates/check-action-metadata-task.md
@@ -1,0 +1,56 @@
+# "Check Action Metadata" workflow (Task)
+
+Validate the [`action.yml`](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions) GitHub Actions action metadata file against its JSON schema.
+
+This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
+
+## Installation
+
+### Workflow
+
+Install the [`check-action-metadata-task.yml`](check-action-metadata-task.yml) GitHub Actions workflow to `.github/workflows/`
+
+### Assets
+
+- [`Taskfile.yml`](assets/check-action-metadata-task/Taskfile.yml] - task for validating `action.yml`
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
+
+### Readme badge
+
+Markdown badge:
+
+```markdown
+[![Check Action Metadata status](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-action-metadata-task.yml/badge.svg)](https://github.com/TODO_REPO_OWNER/TODO_REPO_NAME/actions/workflows/check-action-metadata-task.yml)
+```
+
+Replace the `TODO_REPO_OWNER` and `TODO_REPO_NAME` placeholders in the URLs with the final repository owner and name ([example](https://raw.githubusercontent.com/arduino-libraries/ArduinoIoTCloud/master/README.md)).
+
+---
+
+Asciidoc badge:
+
+```adoc
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-action-metadata-task.yml/badge.svg["Check Action Metadata status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-action-metadata-task.yml"]
+```
+
+Define the `{repository-owner}` and `{repository-name}` attributes and use them throughout the readme ([example](https://raw.githubusercontent.com/arduino-libraries/WiFiNINA/master/README.adoc)).
+
+## Commit message
+
+```text
+Add CI workflow to validate action.yml
+
+A task and GitHub Actions workflow are provided here for validating the action.yml metadata file of GitHub Actions
+actions.
+
+On every push or pull request that affects the metadata file, and periodically, validate action.yml against its JSON
+schema.
+```
+
+## PR message
+
+```markdown
+A task and GitHub Actions workflow are provided here for validating the [`action.yml`](https://docs.github.com/actions/creating-actions/metadata-syntax-for-github-actions) metadata file of [GitHub Actions actions](https://docs.github.com/actions/learn-github-actions/understanding-github-actions#actions).
+
+On every push or pull request that affects the metadata file, and periodically, validate `action.yml` against [its JSON schema](https://json.schemastore.org/github-action.json).
+```

--- a/workflow-templates/check-action-metadata-task.md
+++ b/workflow-templates/check-action-metadata-task.md
@@ -14,6 +14,34 @@ Install the [`check-action-metadata-task.yml`](check-action-metadata-task.yml) G
 
 - [`Taskfile.yml`](assets/check-action-metadata-task/Taskfile.yml] - task for validating `action.yml`
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
+- [`Taskfile.yml`](assets/npm-task/Taskfile.yml) - **npm** tasks.
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
+
+### Dependencies
+
+The tool dependencies of this workflow are managed by [**npm**](https://www.npmjs.com/).
+
+Add the dependencies by running this command:
+
+```text
+npm install --save-dev ajv-cli@^5.0.0
+```
+
+Commit the resulting changes to the `package.json` and `package-lock.json` files.
+
+### Configuration
+
+#### Workflow
+
+Configure the version of **Node.js** used for development of the project in the `env.NODE_VERSION` field of `check-action-metadata-task.yml`.
+
+#### `.gitignore`
+
+Add the following to [`/.gitignore`](https://git-scm.com/docs/gitignore):
+
+```
+/node_modules/
+```
 
 ### Readme badge
 

--- a/workflow-templates/check-action-metadata-task.md
+++ b/workflow-templates/check-action-metadata-task.md
@@ -16,6 +16,8 @@ Install the [`check-action-metadata-task.yml`](check-action-metadata-task.yml) G
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/npm-task/Taskfile.yml) - **npm** tasks.
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
+- [`Taskfile.yml`](assets/windows-task/Taskfile.yml) - utility tasks.
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 
 ### Dependencies
 

--- a/workflow-templates/check-action-metadata-task.yml
+++ b/workflow-templates/check-action-metadata-task.yml
@@ -1,0 +1,37 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-action-metadata-task.md
+name: Check Action Metadata
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-action-metadata-task.ya?ml"
+      - "action.ya?ml"
+      - "Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-action-metadata-task.ya?ml"
+      - "action.ya?ml"
+      - "Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate action.yml
+        run: task --silent action:validate

--- a/workflow-templates/check-action-metadata-task.yml
+++ b/workflow-templates/check-action-metadata-task.yml
@@ -1,17 +1,25 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-action-metadata-task.md
 name: Check Action Metadata
 
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 16.x
+
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
     paths:
       - ".github/workflows/check-action-metadata-task.ya?ml"
       - "action.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-action-metadata-task.ya?ml"
       - "action.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage from changes to the JSON schema.
@@ -26,6 +34,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Task
         uses: arduino/setup-task@v1

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-action-metadata-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-action-metadata-task.yml
@@ -1,0 +1,37 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-action-metadata-task.md
+name: Check Action Metadata
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-action-metadata-task.ya?ml"
+      - "action.ya?ml"
+      - "Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-action-metadata-task.ya?ml"
+      - "action.ya?ml"
+      - "Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate action.yml
+        run: task --silent action:validate

--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-action-metadata-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/check-action-metadata-task.yml
@@ -1,17 +1,25 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-action-metadata-task.md
 name: Check Action Metadata
 
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 16.x
+
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
     paths:
       - ".github/workflows/check-action-metadata-task.ya?ml"
       - "action.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-action-metadata-task.ya?ml"
       - "action.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage from changes to the JSON schema.
@@ -26,6 +34,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Task
         uses: arduino/setup-task@v1


### PR DESCRIPTION
On every push or pull request that affects the [`action.yml`](https://docs.github.com/actions/creating-actions/metadata-syntax-for-github-actions) GitHub Actions metadata file, and periodically, validate `action.yml` against [its JSON schema](https://json.schemastore.org/github-action.json).

These assets have been in use for the last 1.5 years in the `arduino/setup-task` repository (https://github.com/arduino/setup-task/pull/2). They are submitted here for hosting in a centralized location to facilitate their maintenance and use in the the Arduino Tooling Team's other GitHub Actions actions projects.

Minor fixes and enhancements have been added to the initial import to bring the assets up to the current state of the art (see the individual commit messages for details).