### PR TITLE
Use correct task name to build project in release workflow

### DIFF
--- a/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
+++ b/workflow-templates/dependabot/workflow-template-copies/.github/workflows/release-go-task.yml
@@ -55,7 +55,7 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:all
+        run: task dist:${{ matrix.os }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -55,7 +55,7 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:all
+        run: task dist:${{ matrix.os }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The **"Release" workflow (Go, Task, CGO)** template was recently changed to use a job matrix to run builds for each target in parallel. The new design is intended to use a dedicated task for each target instead of the previous approach of executing a single `dist:all` task.

The task name was not updated at that time, which caused the workflow to fail:

```text
task: Task "dist:all" not found
```

The task invocation is hereby updated to use the target-specific task names.