### PR TITLE
Use OpenSSL "legacy" provider in "Check Certificates" for compatibility w/ RC2-40-CBC encrypted PKS#12

### DIFF
--- a/workflow-templates/check-certificates.yml
+++ b/workflow-templates/check-certificates.yml
@@ -95,7 +95,9 @@ jobs:
           (
             openssl pkcs12 \
               -in "${{ env.CERTIFICATE_PATH }}" \
-              -noout -passin env:CERTIFICATE_PASSWORD
+              -legacy \
+              -noout \
+              -passin env:CERTIFICATE_PASSWORD
           ) || (
             echo "::error::Verification of ${{ matrix.certificate.identifier }} failed!!!"
             exit 1
@@ -123,6 +125,7 @@ jobs:
               openssl pkcs12 \
                 -in "${{ env.CERTIFICATE_PATH }}" \
                 -clcerts \
+                -legacy \
                 -nodes \
                 -passin env:CERTIFICATE_PASSWORD
             ) | (


### PR DESCRIPTION
The "Check Certificates" GitHub Actions workflow uses [**OpenSSL**](https://www.openssl.org/) to check for problems with the project's signing certificates.

Certificates exported to [PKS #12](https://en.wikipedia.org/wiki/PKCS_12) archive files using older tools may have been encrypted using the ["RC2-40-CBC" algorithm](https://en.wikipedia.org/wiki/RC2).

Due to the availability of more secure modern alternatives, [default support for RC2-40-CBC encryption was dropped in **OpenSSL** 3.x](https://www.openssl.org/docs/man3.0/man7/migration_guide.html#PKCS-12-API-updates).

The macOS signing certificate currently used by Arduino uses this "RC2-40-CBC" encryption so it will be best to configure the workflow to still support this algorithm.

The "Check Certificates" GitHub Actions workflow runs on [the `ubuntu-latest` runner](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners). Previously, this runner used Ubuntu 20.04. [This has now changed to Ubuntu 22.04](https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/). With the operating system update came an **OpenSSL** update from 1.1.1f to 3.0.2. This caused the workflow runs to fail on the macOS certificate job:

https://github.com/arduino/arduino-cli/actions/runs/3634539791/jobs/6132720176#step:5:16

```text
Error outputting keys and certificates
80FBB0C5087F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:349:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
```

Even though no longer done by default, **OpenSSL** still supports RC2-40-CBC encryption via its "legacy" [provider](https://www.openssl.org/docs/man3.0/man7/migration_guide.html#Providers-and-FIPS-support). So compatibility with the certificate is restored by adding [the `-legacy` flag](https://www.openssl.org/docs/man3.0/man1/openssl-pkcs12.html#legacy) to the `openssl pkcs12` commands.