### PR TITLE
Reduce line length to <=120 in YAML files where feasible

### DIFF
--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -101,7 +101,11 @@ jobs:
         run: |
           cd "${{ env.INSTALL_PATH }}"
           tar --extract --file="${{ steps.download.outputs.name }}"
-          EXTRACTION_FOLDER="$(basename "${{ steps.download.outputs.name }}" "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}")"
+          EXTRACTION_FOLDER="$(
+            basename \
+              "${{ steps.download.outputs.name }}" \
+              "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}"
+          )"
           # Add installation to PATH:
           # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -26,10 +26,14 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      PROJECT_OWNER_PLACEHOLDER: arduino # Placeholder value of the PROJECT_OWNER variable in the template script
-      PROJECT_OWNER: arduino # Replacement value used for the tests
-      PROJECT_NAME_PLACEHOLDER: TODO_PROJECT_NAME # Placeholder value of the PROJECT_NAME variable in the template script
-      PROJECT_NAME: arduino-lint # Replacement value used for the tests
+      # Placeholder value of the PROJECT_OWNER variable in the template script
+      PROJECT_OWNER_PLACEHOLDER: arduino
+      # Replacement value used for the tests
+      PROJECT_OWNER: arduino
+      # Placeholder value of the PROJECT_NAME variable in the template script
+      PROJECT_NAME_PLACEHOLDER: TODO_PROJECT_NAME
+      # Replacement value used for the tests
+      PROJECT_NAME: arduino-lint
       SCRIPT_FOLDER: other/installation-script
 
     steps:
@@ -254,7 +258,8 @@ jobs:
               -F \
               '${{ env.TOOL_NAME }} was found at ${{ env.FIRST_BINDIR }}/${{ env.TOOL_NAME }}. Please prepend "${{ env.BINDIR }}" to your $PATH'
 
-      # ${{ runner.temp }} is a Windows style path on the windows runner, but the script output uses the equivalent POSIX style path.
+      # ${{ runner.temp }} is a Windows style path on the windows runner, but the script output uses the equivalent
+      # POSIX style path.
       # So a regex is used for the output check on Windows.
       - name: Check script output with previous installation in PATH (Windows)
         if: runner.os == 'Windows'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -144,14 +144,17 @@ tasks:
     cmds:
       - |
         if ! which clang-format &>/dev/null; then
-          echo "clang-format not found or not in PATH. Please install: https://github.com/arduino/clang-static-binaries/releases"
+          echo "clang-format not found or not in PATH."
+          echo "Please install: https://github.com/arduino/clang-static-binaries/releases"
           exit 1
         fi
       - |
         INSTALLED_CLANG_FORMAT_VERSION_ARRAY=($(clang-format --version))
         INSTALLED_CLANG_FORMAT_VERSION="${INSTALLED_CLANG_FORMAT_VERSION_ARRAY[${#INSTALLED_CLANG_FORMAT_VERSION_ARRAY[@]}-1]}"
         if [[ "$INSTALLED_CLANG_FORMAT_VERSION" != "{{.EXPECTED_CLANG_FORMAT_VERSION}}" ]]; then
-          echo "Installed version of clang-format $INSTALLED_CLANG_FORMAT_VERSION (at $(which clang-format)) does not match expected {{.EXPECTED_CLANG_FORMAT_VERSION}}"
+          echo "Installed version of clang-format does not match expected:"
+          echo "Installed: $INSTALLED_CLANG_FORMAT_VERSION (at $(which clang-format))"
+          echo "Expected: {{.EXPECTED_CLANG_FORMAT_VERSION}}"
           exit 1
         fi
 
@@ -522,7 +525,8 @@ tasks:
           # npx --call uses the native shell, which makes it too difficult to use npx for this application on Windows,
           # so the Windows user is required to have markdown-link-check installed and in PATH.
           if ! which markdown-link-check &>/dev/null; then
-            echo "markdown-link-check not found or not in PATH. Please install: https://github.com/tcort/markdown-link-check#readme"
+            echo "markdown-link-check not found or not in PATH."
+            echo "Please install: https://github.com/tcort/markdown-link-check#readme"
             exit 1
           fi
           # Default behavior of the task on Windows is to exit the task when the first broken link causes a non-zero
@@ -723,7 +727,8 @@ tasks:
     cmds:
       - |
         if ! which shellcheck &>/dev/null; then
-          echo "shellcheck not installed or not in PATH. Please install: https://github.com/koalaman/shellcheck#installing"
+          echo "shellcheck not installed or not in PATH."
+          echo "Please install: https://github.com/koalaman/shellcheck#installing"
           exit 1
         fi
       - |

--- a/workflow-templates/assets/check-dependencies-task/Taskfile.yml
+++ b/workflow-templates/assets/check-dependencies-task/Taskfile.yml
@@ -12,7 +12,8 @@ tasks:
             echo "Licensed does not have Windows support."
             echo "Please use Linux/macOS or download the dependencies cache from the GitHub Actions workflow artifact."
           else
-            echo "licensed not found or not in PATH. Please install: https://github.com/github/licensed#as-an-executable"
+            echo "licensed not found or not in PATH."
+            echo "Please install: https://github.com/github/licensed#as-an-executable"
           fi
           exit 1
         fi

--- a/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
+++ b/workflow-templates/assets/check-general-formatting-task/Taskfile.yml
@@ -8,7 +8,8 @@ tasks:
     cmds:
       - |
         if ! which ec &>/dev/null; then
-          echo "ec not found or not in PATH. Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
+          echo "ec not found or not in PATH."
+          echo "Please install: https://github.com/editorconfig-checker/editorconfig-checker#installation"
           exit 1
         fi
       - ec

--- a/workflow-templates/assets/check-markdown-task/Taskfile.yml
+++ b/workflow-templates/assets/check-markdown-task/Taskfile.yml
@@ -19,7 +19,8 @@ tasks:
           # npx --call uses the native shell, which makes it too difficult to use npx for this application on Windows,
           # so the Windows user is required to have markdown-link-check installed and in PATH.
           if ! which markdown-link-check &>/dev/null; then
-            echo "markdown-link-check not found or not in PATH. Please install: https://github.com/tcort/markdown-link-check#readme"
+            echo "markdown-link-check not found or not in PATH."
+            echo "Please install: https://github.com/tcort/markdown-link-check#readme"
             exit 1
           fi
           # Default behavior of the task on Windows is to exit the task when the first broken link causes a non-zero

--- a/workflow-templates/assets/check-shell-task/Taskfile.yml
+++ b/workflow-templates/assets/check-shell-task/Taskfile.yml
@@ -8,7 +8,8 @@ tasks:
     cmds:
       - |
         if ! which shellcheck &>/dev/null; then
-          echo "shellcheck not installed or not in PATH. Please install: https://github.com/koalaman/shellcheck#installing"
+          echo "shellcheck not installed or not in PATH."
+          echo "Please install: https://github.com/koalaman/shellcheck#installing"
           exit 1
         fi
       - |

--- a/workflow-templates/assets/go-task/Taskfile.yml
+++ b/workflow-templates/assets/go-task/Taskfile.yml
@@ -6,7 +6,11 @@ vars:
   DEFAULT_GO_MODULE_PATH: ./
   DEFAULT_GO_PACKAGES:
     sh: |
-      echo $(cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
+      echo $(
+        cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} &&
+        go list ./... | tr '\n' ' ' ||
+        echo '"ERROR: Unable to discover Go packages"'
+      )
   # `-ldflags` flag to use for `go build` command
   # TODO: define flag if required by the project, or leave empty if not needed.
   LDFLAGS:

--- a/workflow-templates/check-shell-task.yml
+++ b/workflow-templates/check-shell-task.yml
@@ -101,7 +101,11 @@ jobs:
         run: |
           cd "${{ env.INSTALL_PATH }}"
           tar --extract --file="${{ steps.download.outputs.name }}"
-          EXTRACTION_FOLDER="$(basename "${{ steps.download.outputs.name }}" "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}")"
+          EXTRACTION_FOLDER="$(
+            basename \
+              "${{ steps.download.outputs.name }}" \
+              "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}"
+          )"
           # Add installation to PATH:
           # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"

--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -36,7 +36,13 @@ jobs:
         id: determination
         run: |
           RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
-          if [[ "${{ github.event_name }}" == "push" || ( "${{ github.event_name }}" == "create" && "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX ) ]]; then
+          if [[
+            "${{ github.event_name }}" == "push" ||
+            (
+              "${{ github.event_name }}" == "create" &&
+              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+            )
+          ]]; then
             RESULT="true"
           else
             RESULT="false"
@@ -85,7 +91,12 @@ jobs:
           # Publishing implies creating a git commit on the gh-pages branch, we let @ArduinoBot own these commits.
           git config --global user.email "bot@arduino.cc"
           git config --global user.name "ArduinoBot"
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/gh-pages:refs/remotes/origin/gh-pages
+          git fetch \
+            --no-tags \
+            --prune \
+            --depth=1 \
+            origin \
+            +refs/heads/gh-pages:refs/remotes/origin/gh-pages
           poetry run mike deploy \
             --update-aliases \
             --push \

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.yml
@@ -31,7 +31,13 @@ jobs:
         id: determination
         run: |
           RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
-          if [[ "${{ github.event_name }}" == "push" || ( "${{ github.event_name }}" == "create" && "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX ) ]]; then
+          if [[
+            "${{ github.event_name }}" == "push" ||
+            (
+              "${{ github.event_name }}" == "create" &&
+              "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+            )
+          ]]; then
             RESULT="true"
           else
             RESULT="false"
@@ -71,7 +77,12 @@ jobs:
           # Publishing implies creating a git commit on the gh-pages branch, we let @ArduinoBot own these commits.
           git config --global user.email "bot@arduino.cc"
           git config --global user.name "ArduinoBot"
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/gh-pages:refs/remotes/origin/gh-pages
+          git fetch \
+            --no-tags \
+            --prune \
+            --depth=1 \
+            origin \
+            +refs/heads/gh-pages:refs/remotes/origin/gh-pages
           poetry run mike deploy \
             --update-aliases \
             --push \

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -91,7 +91,8 @@ jobs:
         env:
           KEYCHAIN: "sign.keychain"
           INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
-          KEYCHAIN_PASSWORD: keychainpassword # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+          # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+          KEYCHAIN_PASSWORD: keychainpassword
         run: |
           echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
           security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -89,7 +89,8 @@ jobs:
         env:
           KEYCHAIN: "sign.keychain"
           INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
-          KEYCHAIN_PASSWORD: keychainpassword # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+          # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+          KEYCHAIN_PASSWORD: keychainpassword
         run: |
           echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
           security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
@@ -180,7 +181,12 @@ jobs:
 
       - name: Update checksum
         run: |
-          declare -a checksum_lines=("${{ needs.notarize-macos.outputs.checksum-darwin_amd64 }}" "${{ needs.notarize-macos.outputs.checksum-darwin_arm64 }}")
+          declare \
+            -a \
+            checksum_lines=(
+              "${{ needs.notarize-macos.outputs.checksum-darwin_amd64 }}" \
+              "${{ needs.notarize-macos.outputs.checksum-darwin_arm64 }}"
+            )
           for checksum_line in "${checksum_lines[@]}"
           do
             CHECKSUM=$(echo ${checksum_line} | cut -d " " -f 1)

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -97,7 +97,8 @@ jobs:
         env:
           KEYCHAIN: "sign.keychain"
           INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
-          KEYCHAIN_PASSWORD: keychainpassword # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+          # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
+          KEYCHAIN_PASSWORD: keychainpassword
         run: |
           echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
           security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
@@ -193,7 +194,14 @@ jobs:
         run: |
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
           unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "IS_PRE=true" >> $GITHUB_OUTPUT; fi
+          if [[
+            "$(
+              /tmp/semver get prerel \
+                "${GITHUB_REF/refs\/tags\//}"
+            )"
+          ]]; then
+            echo "IS_PRE=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1

--- a/workflow-templates/release-tag.yml
+++ b/workflow-templates/release-tag.yml
@@ -53,7 +53,14 @@ jobs:
       - name: Identify Prerelease
         id: prerelease
         run: |
-          if [[ "$("${{ env.SEMVER_TOOL_PATH }}" get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "IS_PRE=true" >> $GITHUB_OUTPUT"; fi
+          if [[
+            "$(
+              "${{ env.SEMVER_TOOL_PATH }}" get prerel \
+                "${GITHUB_REF/refs\/tags\//}"
+            )"
+          ]]; then
+            echo "IS_PRE=true" >> $GITHUB_OUTPUT"
+          fi
 
       - name: Create Github release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
[120 columns](https://github.com/arduino/tooling-project-assets/blob/3ebb02742786e76d3f51d7d6e48fe80af6c01c73/workflow-templates/assets/check-yaml/.yamllint.yml#L36) is the [recommended](https://github.com/arduino/tooling-project-assets/blob/3ebb02742786e76d3f51d7d6e48fe80af6c01c73/workflow-templates/assets/check-yaml/.yamllint.yml#L35) line length for YAML code in Arduino tooling projects. The [**yamllint**](https://github.com/adrienverge/yamllint) tool used by [the "Check YAML" template](https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-yaml-task.md) produces a warning when a line exceeds this length.

This is not a hard limit and in some cases it is either impossible or not beneficial to make lines less than 120 in length so some violations of the guideline are unavoidable. However, a survey of the YAML files in the repository revealed some opportunities for improving the code by reducing the lengths.