### PR TITLE
Install npm dependencies in "Check npm Dependencies" template

### DIFF
--- a/workflow-templates/assets/check-dependencies-task/Taskfile.yml
+++ b/workflow-templates/assets/check-dependencies-task/Taskfile.yml
@@ -5,6 +5,8 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
   general:cache-dep-licenses:
     desc: Cache dependency license metadata
+    deps:
+      - task: general:prepare-deps
     cmds:
       - |
         if ! which licensed &>/dev/null; then

--- a/workflow-templates/assets/check-go-dependencies-task/Taskfile.yml
+++ b/workflow-templates/assets/check-go-dependencies-task/Taskfile.yml
@@ -1,0 +1,8 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-dependencies-task/Taskfile.yml
+  general:prepare-deps:
+    desc: Prepare project dependencies for license check
+    # No preparation is needed for Go module-based projects.

--- a/workflow-templates/assets/check-npm-dependencies-task/Taskfile.yml
+++ b/workflow-templates/assets/check-npm-dependencies-task/Taskfile.yml
@@ -3,7 +3,7 @@ version: "3"
 
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-npm-dependencies-task/Taskfile.yml
-  general:install-deps:
-    desc: Install project dependencies
+  general:prepare-deps:
+    desc: Prepare project dependencies for license check
     deps:
       - task: npm:install-deps

--- a/workflow-templates/check-go-dependencies-task.md
+++ b/workflow-templates/check-go-dependencies-task.md
@@ -19,6 +19,8 @@ Install the [`check-go-dependencies-task.yml`](check-go-dependencies-task.yml) G
 
 - [`Taskfile.yml`](assets/check-dependencies-task/Taskfile.yml) - [tasks](https://taskfile.dev/) to cache metadata for and check compatibility of dependency licenses.
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
+- [`Taskfile.yml`](assets/check-go-dependencies-task/Taskfile.yml) - tasks to check **Go** dependencies.
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`.licensed.yml](assets/check-dependencies) - suggested allowed dependency license types list for the project's license type.
   - Install to: repository root.
 


### PR DESCRIPTION
The "Check npm Dependencies" template is used to check for compatibility of dependencies with the licensing of projects that use [**npm**](https://www.npmjs.com/) for dependency management.

The [**Licensed**](https://github.com/github/licensed) tool is used for this check. This tool requires the dependencies to have been installed in advance.

Previously, the template's task did not install the dependencies. This caused the check to fail whenever the dependencies were not already installed by chance.

The dependency check tasks are intended to be applicable to projects of any type since the **Licensed** tool [supports multiple project types (referred to as "sources")](https://github.com/github/licensed/blob/master/docs/sources). Each project type might have different requirements for advance preparation of the dependencies. A call to a `general:install-deps` task was added to the dependency check tasks for this purpose. A different variant of that task will be provided for each specific project type. In project types where no preparation is needed, an empty `general:install-deps` task must be added in order to allow the task call to succeed.

---

I did set up the `general:cache-dep-licenses` task to install dependencies when I wrote the original version for the `arduino/setup-task` repository (https://github.com/arduino/setup-task/pull/497), but somehow left that part out when I added the template here in the assets repo (https://github.com/arduino/tooling-project-assets/pull/259).

---

I originally named the dependencies preparation task `general:install-deps`. However, the actual preparation might not involve installing dependencies in some project types (e.g., no preparation at all is needed in Go module-based projects). So I decided that task name might cause confusion and changed it to the more generally applicable `general:prepare-deps`.

---

Example of the previous version of the template causing a spurious failed workflow run in an npm-based project due to the dependencies not being installed:

https://github.com/per1234/arduino-lint-action/actions/runs/3755689041/jobs/6380983198#step:6:7

```text
Caching dependency records for arduino-lint-action
  npm
    Error @actions/core (^1.10.0)
task: Failed to run task "general:cache-dep-licenses": exit status 1
    Error @actions/http-client ()
    Error @actions/tool-cache ()
    Error semver ()

  * Errors:
    * arduino-lint-action.npm.@actions/core
      - missing: @actions/core@^1.10.0, required by arduino-lint-action@

    * arduino-lint-action.npm.@actions/http-client
      - missing: @actions/http-client@^2.0.1, required by arduino-lint-action@

    * arduino-lint-action.npm.@actions/tool-cache
      - missing: @actions/tool-cache@^2.0.1, required by arduino-lint-action@

    * arduino-lint-action.npm.semver
      - missing: semver@^[7](https://github.com/per1234/arduino-lint-action/actions/runs/3755689041/jobs/6380983198#step:6:8).3.[8](https://github.com/per1234/arduino-lint-action/actions/runs/3755689041/jobs/6380983198#step:6:9), required by arduino-lint-action@

Error: Process completed with exit code 1.
```

The same process completing successfully once the dependency installation operation was added to the task:

https://github.com/per1234/arduino-lint-action/actions/runs/3755779962/jobs/6381158769#step:6:20

```text
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

added 462 packages, and audited 463 packages in [7](https://github.com/per1234/arduino-lint-action/actions/runs/3755779962/jobs/6381158769#step:6:8)s

31 packages are looking for funding
  run `npm fund` for details

1 high severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
Caching dependency records for arduino-lint-action
  npm
    Caching @actions/core (1.10.0)
    Caching @actions/exec (1.1.0)
    Caching @actions/http-client (2.0.1)
    Caching @actions/io (1.1.2)
    Caching @actions/tool-cache (2.0.1)
    Caching lru-cache (6.0.0)
    Caching semver-6.3.0 (6.3.0)
    Caching semver-7.3.[8](https://github.com/per1234/arduino-lint-action/actions/runs/3755779962/jobs/6381158769#step:6:9) (7.3.8)
    Caching tunnel (0.0.6)
    Caching uuid-3.4.0 (3.4.0)
    Caching uuid-8.3.2 (8.3.2)
    Caching yallist (4.0.0)
  * [12](https://github.com/per1234/arduino-lint-action/actions/runs/3755779962/jobs/6381158769#step:6:13) npm dependencies
```

---

The previous template version was installed in the `arduino/setup-protoc` repository (https://github.com/arduino/setup-protoc/pull/35). Confusingly, the workflow runs in that repository are passing despite the use of the flawed template. The explanation is that the current action packaging approach involves checking [the `node_modules` folder](https://github.com/arduino/setup-protoc/tree/master/node_modules) into the repository. Those dependencies are generally only updated on release, so even though the workflow runs are passing they don't provide an accurate indication of the project's current dependency license compliance status.