### PR TITLE
Fix `markdownlint-cli` version typo in `check-markdown-task` documentation

### DIFF
--- a/workflow-templates/check-markdown-task.md
+++ b/workflow-templates/check-markdown-task.md
@@ -37,7 +37,7 @@ The tool dependencies of this workflow are managed by [npm](https://www.npmjs.co
 Add the dependencies by running this command:
 
 ```text
-npm install --save-dev markdown-link-check@^3.10.3 markdownlint-cli@^0.33.2
+npm install --save-dev markdown-link-check@^3.10.3 markdownlint-cli@^0.33.0
 ```
 
 Commit the resulting changes to the `package.json` and `package-lock.json` files.


### PR DESCRIPTION
The dependency `markdownlint-cli` was recently [bumped](https://github.com/arduino/tooling-project-assets/pull/311) to version `0.33.0`. This PR fixes a typo introduced in `check-markdown-task`'s documentation.