### PR TITLE
Remove extra quote from shell command in release-tag workflow

### DIFF
--- a/workflow-templates/release-tag.yml
+++ b/workflow-templates/release-tag.yml
@@ -60,7 +60,7 @@ jobs:
             )" != \
             "" \
           ]]; then
-            echo "IS_PRE=true" >> $GITHUB_OUTPUT"
+            echo "IS_PRE=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Github release


### PR DESCRIPTION
A stray quote was present in a shell command in the workflow. This caused a spurious failure of the "Identify Prerelease" step:

```
unexpected EOF while looking for matching `"'
```