### PR TITLE
[AE-45] Multipath options for `check-license.yml`

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,12 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-license.md
 name: Check License
 
-env:
-  # TODO: Define the project's license file name here:
-  EXPECTED_LICENSE_FILENAME: LICENSE.txt
-  # SPDX identifier: https://spdx.org/licenses/
-  EXPECTED_LICENSE_TYPE: CC0-1.0
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   create:
@@ -36,9 +30,9 @@ on:
 jobs:
   run-determination:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       result: ${{ steps.determination.outputs.result }}
-    permissions: {}
     steps:
       - name: Determine if the rest of the workflow should run
         id: determination
@@ -56,14 +50,28 @@ jobs:
             RESULT="false"
           fi
 
-          echo "::set-output name=result::$RESULT"
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
 
   check-license:
+    name: ${{ matrix.check-license.path }}
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        check-license:
+          # TODO: Add additional paths where license files should be
+          - path: ./
+            # TODO: Define the project's license file name here:
+            expected-filename: LICENSE.txt
+            # SPDX identifier: https://spdx.org/licenses/
+            # TODO: Define the project's license type here
+            expected-type: CC0-1.0
 
     steps:
       - name: Checkout repository
@@ -77,23 +85,27 @@ jobs:
       - name: Install licensee
         run: gem install licensee
 
-      - name: Check license file
+      - name: Check license file for ${{ matrix.check-license.path }}
         run: |
           EXIT_STATUS=0
+
+          # Go into folder path
+          cd ./${{ matrix.check-license.path }}
+
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
 
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
-          if [ "$DETECTED_LICENSE_FILE" != "\"${EXPECTED_LICENSE_FILENAME}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: $EXPECTED_LICENSE_FILENAME"
+          if [ "$DETECTED_LICENSE_FILE" != "\"${{ matrix.check-license.expected-filename }}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: ${{ matrix.check-license.expected-filename }}"
             EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
-          if [ "$DETECTED_LICENSE_TYPE" != "\"${EXPECTED_LICENSE_TYPE}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${EXPECTED_LICENSE_TYPE}\""
+          if [ "$DETECTED_LICENSE_TYPE" != "\"${{ matrix.check-license.expected-type }}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${{ matrix.check-license.expected-type }}\""
             EXIT_STATUS=1
           fi
 

--- a/workflow-templates/check-license.md
+++ b/workflow-templates/check-license.md
@@ -14,7 +14,7 @@ Install the [`check-license.yml`](check-license.yml) GitHub Actions workflow to 
 
 - Configure the license filename in the `env.EXPECTED_LICENSE_FILENAME` field of `check-license.yml`.
 - Configure the license type in the `env.EXPECTED_LICENSE_TYPE` field of `check-license.yml`.
-- (Optional) If license files should be present outisde the root directory, configure additional `path:` locations.
+- (Optional) If license files should be present outisde the root directory, add the configuration for additional paths to the `jobs.check-license.strategy.matrix.licenses` array in `check-license.yml`.
 
 ### Readme badge
 

--- a/workflow-templates/check-license.md
+++ b/workflow-templates/check-license.md
@@ -14,7 +14,7 @@ Install the [`check-license.yml`](check-license.yml) GitHub Actions workflow to 
 
 - Configure the license filename in the `env.EXPECTED_LICENSE_FILENAME` field of `check-license.yml`.
 - Configure the license type in the `env.EXPECTED_LICENSE_TYPE` field of `check-license.yml`.
-- (Optional) If license files should be present outisde the root directory, add the configuration for additional paths to the `jobs.check-license.strategy.matrix.licenses` array in `check-license.yml`.
+- (Optional) If license files should be present outside the root directory, add the configuration for additional paths to the `jobs.check-license.strategy.matrix.licenses` array in `check-license.yml`.
 
 ### Readme badge
 

--- a/workflow-templates/check-license.md
+++ b/workflow-templates/check-license.md
@@ -14,6 +14,7 @@ Install the [`check-license.yml`](check-license.yml) GitHub Actions workflow to 
 
 - Configure the license filename in the `env.EXPECTED_LICENSE_FILENAME` field of `check-license.yml`.
 - Configure the license type in the `env.EXPECTED_LICENSE_TYPE` field of `check-license.yml`.
+- (Optional) If license files should be present outisde the root directory, configure additional `path:` locations.
 
 ### Readme badge
 

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        module:
+        licenses:
           #TODO Add additional paths where license files should be
           - path: 
 

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -66,6 +66,14 @@ jobs:
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          #TODO Add additional paths where license files should be
+          - path: 
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -78,11 +86,17 @@ jobs:
       - name: Install licensee
         run: gem install licensee
 
-      - name: Check license file
+      - name: Check license file for ${{ matrix.module.path }}
         run: |
           EXIT_STATUS=0
+
+          # Go into folder path
+          cd ./${{ matrix.module.path }}
+
+          
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
+
 
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -1,12 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-license.md
-name: Check License
 
-env:
-  # TODO: Define the project's license file name here:
-  EXPECTED_LICENSE_FILENAME: LICENSE.txt
-  # SPDX identifier: https://spdx.org/licenses/
-  # TODO: Define the project's license type here
-  EXPECTED_LICENSE_TYPE: AGPL-3.0
+name: Check License
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
@@ -74,7 +68,10 @@ jobs:
         check-license:
           # TODO: Add additional paths where license files should be
           - path: ./
+             # TODO: Define the project's license file name here:
             expected-filename: LICENSE.txt
+            # SPDX identifier: https://spdx.org/licenses/
+            # TODO: Define the project's license type here
             expected-type: AGPL-3.0
 
     steps:
@@ -102,15 +99,17 @@ jobs:
 
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
-          if [ "$DETECTED_LICENSE_FILE" != "\"${{ matrix.check-license.EXPECTED_LICENSE_FILENAME }}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: ${{ matrix.check-license.EXPECTED_LICENSE_FILENAME }}"
+          if [ "$DETECTED_LICENSE_FILE" != "\"${{ matrix.check-license.expected-filename }}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: ${{ matrix.check-license.expected-filename }}"
+
             EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
-          if [ "$DETECTED_LICENSE_TYPE" != "\"${{ matrix.check-license.EXPECTED_LICENSE_TYPE }}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${{ matrix.check-license.EXPECTED_LICENSE_TYPE }}\""
+
+          if [ "$DETECTED_LICENSE_TYPE" != "\"${{ matrix.check-license.expected-type }}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${{ matrix.check-license.expected-type }}\""
             EXIT_STATUS=1
           fi
 

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        licenses:
+        check-license:
           #TODO Add additional paths where license files should be
           - path: ./
             EXPECTED_LICENSE_FILENAME: LICENSE.txt
@@ -94,12 +94,12 @@ jobs:
       - name: Install licensee
         run: gem install licensee
 
-      - name: Check license file for ${{ matrix.module.path }}
+      - name: Check license file for ${{ matrix.check-license.path }}
         run: |
           EXIT_STATUS=0
 
           # Go into folder path
-          cd ./${{ matrix.module.path }}
+          cd ./${{ matrix.check-license.path }}
 
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
@@ -107,15 +107,15 @@ jobs:
 
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
-          if [ "$DETECTED_LICENSE_FILE" != "\"${EXPECTED_LICENSE_FILENAME}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: $EXPECTED_LICENSE_FILENAME"
+          if [ "$DETECTED_LICENSE_FILE" != "\"${matrix.check-license.EXPECTED_LICENSE_FILENAME}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: $matrix.check-license.EXPECTED_LICENSE_FILENAME"
             EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
-          if [ "$DETECTED_LICENSE_TYPE" != "\"${EXPECTED_LICENSE_TYPE}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${EXPECTED_LICENSE_TYPE}\""
+          if [ "$DETECTED_LICENSE_TYPE" != "\"${matrix.check-license.EXPECTED_LICENSE_TYPE}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${matrix.check-license.EXPECTED_LICENSE_TYPE}\""
             EXIT_STATUS=1
           fi
 

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -96,18 +96,15 @@ jobs:
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
 
-
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
           if [ "$DETECTED_LICENSE_FILE" != "\"${{ matrix.check-license.expected-filename }}\"" ]; then
             echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: ${{ matrix.check-license.expected-filename }}"
-
             EXIT_STATUS=1
           fi
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
-
           if [ "$DETECTED_LICENSE_TYPE" != "\"${{ matrix.check-license.expected-type }}\"" ]; then
             echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${{ matrix.check-license.expected-type }}\""
             EXIT_STATUS=1

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -59,7 +59,8 @@ jobs:
 
           echo "result=$RESULT" >> $GITHUB_OUTPUT
 
-  check-license:
+  build:
+    name: ${{ matrix.check-license.path }}
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
@@ -73,6 +74,13 @@ jobs:
         licenses:
           #TODO Add additional paths where license files should be
           - path: ./
+            EXPECTED_LICENSE_FILENAME: LICENSE.txt
+            EXPECTED_LICENSE_TYPE: AGPL-3.0
+          - path: Arduino_BHY2
+            EXPECTED_LICENSE_FILENAME: LICENSE.md
+            EXPECTED_LICENSE_TYPE: GPL-3.0
+
+
 
     steps:
       - name: Checkout repository

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -1,5 +1,4 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-license.md
-
 name: Check License
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -74,8 +74,8 @@ jobs:
         check-license:
           #TODO Add additional paths where license files should be
           - path: ./
-            EXPECTED_LICENSE_FILENAME: LICENSE.txt
-            EXPECTED_LICENSE_TYPE: AGPL-3.0
+            expected-filename: LICENSE.txt
+            expected-type: AGPL-3.0
           - path: Arduino_BHY2
             EXPECTED_LICENSE_FILENAME: LICENSE.md
             EXPECTED_LICENSE_TYPE: GPL-3.0

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -114,8 +114,8 @@ jobs:
 
           DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
           echo "Detected license type: $DETECTED_LICENSE_TYPE"
-          if [ "$DETECTED_LICENSE_TYPE" != "\"${matrix.check-license.EXPECTED_LICENSE_TYPE}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${matrix.check-license.EXPECTED_LICENSE_TYPE}\""
+          if [ "$DETECTED_LICENSE_TYPE" != "\"${{ matrix.check-license.EXPECTED_LICENSE_TYPE }}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license type $DETECTED_LICENSE_TYPE doesn't match expected \"${{ matrix.check-license.EXPECTED_LICENSE_TYPE }}\""
             EXIT_STATUS=1
           fi
 

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -76,11 +76,6 @@ jobs:
           - path: ./
             expected-filename: LICENSE.txt
             expected-type: AGPL-3.0
-          - path: Arduino_BHY2
-            EXPECTED_LICENSE_FILENAME: LICENSE.md
-            EXPECTED_LICENSE_TYPE: GPL-3.0
-
-
 
     steps:
       - name: Checkout repository

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -72,7 +72,7 @@ jobs:
 
       matrix:
         check-license:
-          #TODO Add additional paths where license files should be
+          # TODO: Add additional paths where license files should be
           - path: ./
             expected-filename: LICENSE.txt
             expected-type: AGPL-3.0

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -59,7 +59,7 @@ jobs:
 
           echo "result=$RESULT" >> $GITHUB_OUTPUT
 
-  build:
+  check-license:
     name: ${{ matrix.check-license.path }}
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -107,8 +107,8 @@ jobs:
 
           DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
           echo "Detected license file: $DETECTED_LICENSE_FILE"
-          if [ "$DETECTED_LICENSE_FILE" != "\"${matrix.check-license.EXPECTED_LICENSE_FILENAME}\"" ]; then
-            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: $matrix.check-license.EXPECTED_LICENSE_FILENAME"
+          if [ "$DETECTED_LICENSE_FILE" != "\"${{ matrix.check-license.EXPECTED_LICENSE_FILENAME }}\"" ]; then
+            echo "::error file=${DETECTED_LICENSE_FILE}::detected license file $DETECTED_LICENSE_FILE doesn't match expected: ${{ matrix.check-license.EXPECTED_LICENSE_FILENAME }}"
             EXIT_STATUS=1
           fi
 

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -68,7 +68,7 @@ jobs:
         check-license:
           # TODO: Add additional paths where license files should be
           - path: ./
-             # TODO: Define the project's license file name here:
+            # TODO: Define the project's license file name here:
             expected-filename: LICENSE.txt
             # SPDX identifier: https://spdx.org/licenses/
             # TODO: Define the project's license type here

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         licenses:
           #TODO Add additional paths where license files should be
-          - path: 
+          - path: ./
 
     steps:
       - name: Checkout repository

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -93,7 +93,6 @@ jobs:
           # Go into folder path
           cd ./${{ matrix.module.path }}
 
-          
           # See: https://github.com/licensee/licensee
           LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
 


### PR DESCRIPTION
The `check-license.yml` workflow checks if the specified license file is present in the root directory of the repository. This PR, provides the option of checking any subdirectories as well

- 🧷 Works without regression even if additional `path:` keys are not specified
- 😄 Minimalistic: uses `cd` to enter `path:` keys and run the steps
- ⏳ All license checks are performed in the same job saving compute resources

This PR feeds back improvements upstream from https://github.com/arduino/nicla-sense-me-fw/pull/115