### PR TITLE
Prevent uncontrolled file tree recursion while validating configuration files

### DIFF
--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -77,11 +77,19 @@ jobs:
         run: task --silent npm:validate
 
   check-sync:
+    name: check-sync (${{ matrix.project.path }})
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          # TODO: add paths of all npm-managed projects in the repository here.
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -99,7 +107,7 @@ jobs:
           version: 3.x
 
       - name: Install npm dependencies
-        run: task npm:install-deps
+        run: task npm:install-deps PROJECT_PATH="${{ matrix.project.path }}"
 
       - name: Check package-lock.json
-        run: git diff --color --exit-code package-lock.json
+        run: git diff --color --exit-code "${{ matrix.project.path }}/package-lock.json"

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -52,11 +52,19 @@ jobs:
           echo "result=$RESULT" >> $GITHUB_OUTPUT
 
   validate:
+    name: validate (${{ matrix.project.path }})
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          # TODO: add paths of all npm-managed projects in the repository here.
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -74,7 +82,7 @@ jobs:
           version: 3.x
 
       - name: Validate package.json
-        run: task --silent npm:validate
+        run: task --silent npm:validate PROJECT_PATH="${{ matrix.project.path }}"
 
   check-sync:
     name: check-sync (${{ matrix.project.path }})

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -359,7 +359,10 @@ tasks:
       SCHEMA_URL: https://json.schemastore.org/dependabot-2.0
       SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="dependabot-schema-XXXXXXXXXX.json"
-      DATA_PATH: "**/dependabot.yml"
+      # The Dependabot configuration file for the repository.
+      DATA_PATH: ".github/dependabot.yml"
+      # The asset Dependabot configuration files.
+      ASSETS_DATA_PATH: "workflow-templates/assets/dependabot/**/dependabot.yml"
       PROJECT_FOLDER:
         sh: pwd
       WORKING_FOLDER:
@@ -372,6 +375,12 @@ tasks:
           --all-errors \
           -s "{{.SCHEMA_PATH}}" \
           -d "{{.PROJECT_FOLDER}}/{{.DATA_PATH}}"
+      - |
+        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
+        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
+          --all-errors \
+          -s "{{.SCHEMA_PATH}}" \
+          -d "{{.PROJECT_FOLDER}}/{{.ASSETS_DATA_PATH}}"
 
   docs:generate:
     desc: Create all generated documentation content

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -705,7 +705,7 @@ tasks:
       SCHEMA_URL: https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json
       SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="markdownlint-schema-XXXXXXXXXX.json"
-      DATA_PATH: "**/.markdownlint.{yml,yaml}"
+      DATA_PATH: "workflow-templates/assets/check-markdown/.markdownlint.yml"
     deps:
       - task: npm:install-deps
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -722,9 +722,13 @@ tasks:
             -s "{{.SCHEMA_PATH}}" \
             -d "{{.DATA_PATH}}"
 
+  # Parameter variables:
+  # - PROJECT_PATH: path of the npm-managed project. Default value: "./"
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:
     desc: Install dependencies managed by npm
+    dir: |
+      "{{default "./" .PROJECT_PATH}}"
     cmds:
       - npm install
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -732,6 +732,8 @@ tasks:
     cmds:
       - npm install
 
+  # Parameter variables:
+  # - PROJECT_PATH: path of the npm-managed project. Default value: "./"
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-npm-task/Taskfile.yml
   npm:validate:
     desc: Validate npm configuration files against their JSON schema
@@ -768,7 +770,8 @@ tasks:
       STYLELINTRC_SCHEMA_URL: https://json.schemastore.org/stylelintrc.json
       STYLELINTRC_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
-      INSTANCE_PATH: "**/package.json"
+      INSTANCE_PATH: >-
+        {{default "." .PROJECT_PATH}}/package.json
       PROJECT_FOLDER:
         sh: pwd
       WORKING_FOLDER:

--- a/workflow-templates/assets/check-npm-task/Taskfile.yml
+++ b/workflow-templates/assets/check-npm-task/Taskfile.yml
@@ -6,6 +6,8 @@ vars:
   SCHEMA_DRAFT_4_AJV_CLI_VERSION: 3.3.0
 
 tasks:
+  # Parameter variables:
+  # - PROJECT_PATH: path of the npm-managed project. Default value: "./"
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-npm-task/Taskfile.yml
   npm:validate:
     desc: Validate npm configuration files against their JSON schema
@@ -42,7 +44,8 @@ tasks:
       STYLELINTRC_SCHEMA_URL: https://json.schemastore.org/stylelintrc.json
       STYLELINTRC_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
-      INSTANCE_PATH: "**/package.json"
+      INSTANCE_PATH: >-
+        {{default "." .PROJECT_PATH}}/package.json
       PROJECT_FOLDER:
         sh: pwd
       WORKING_FOLDER:

--- a/workflow-templates/assets/npm-task/Taskfile.yml
+++ b/workflow-templates/assets/npm-task/Taskfile.yml
@@ -2,8 +2,12 @@
 version: "3"
 
 tasks:
+  # Parameter variables:
+  # - PROJECT_PATH: path of the npm-managed project. Default value: "./"
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:
     desc: Install dependencies managed by npm
+    dir: |
+      "{{default "./" .PROJECT_PATH}}"
     cmds:
       - npm install

--- a/workflow-templates/check-npm-task.md
+++ b/workflow-templates/check-npm-task.md
@@ -23,6 +23,11 @@ Install the [check-npm-task.yml](check-npm-task.yml) GitHub Actions workflow to 
 
 Configure the version of Node.js used for development of the project in the `env.NODE_VERSION` field of `check-npm-task.yml`.
 
+If the project contains **npm**-managed projects (i.e., a folder containing a `package.json` file) in paths other than the root of the repository, add their paths to the [job matrices](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) of `check-npm-task.yml` at:
+
+- `jobs.validate.strategy.matrix.project[].path`
+- `jobs.check-sync.strategy.matrix.project[].path`
+
 ## Readme badge
 
 Markdown badge:

--- a/workflow-templates/check-npm-task.yml
+++ b/workflow-templates/check-npm-task.yml
@@ -77,11 +77,19 @@ jobs:
         run: task --silent npm:validate
 
   check-sync:
+    name: check-sync (${{ matrix.project.path }})
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          # TODO: add paths of all npm-managed projects in the repository here.
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -99,7 +107,7 @@ jobs:
           version: 3.x
 
       - name: Install npm dependencies
-        run: task npm:install-deps
+        run: task npm:install-deps PROJECT_PATH="${{ matrix.project.path }}"
 
       - name: Check package-lock.json
-        run: git diff --color --exit-code package-lock.json
+        run: git diff --color --exit-code "${{ matrix.project.path }}/package-lock.json"

--- a/workflow-templates/check-npm-task.yml
+++ b/workflow-templates/check-npm-task.yml
@@ -52,11 +52,19 @@ jobs:
           echo "result=$RESULT" >> $GITHUB_OUTPUT
 
   validate:
+    name: validate (${{ matrix.project.path }})
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          # TODO: add paths of all npm-managed projects in the repository here.
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -74,7 +82,7 @@ jobs:
           version: 3.x
 
       - name: Validate package.json
-        run: task --silent npm:validate
+        run: task --silent npm:validate PROJECT_PATH="${{ matrix.project.path }}"
 
   check-sync:
     name: check-sync (${{ matrix.project.path }})


### PR DESCRIPTION
The assets and repository infrastructure validates various configuration file against their [JSON schema](https://json-schema.org/overview/what-is-jsonschema).

The [**ajv-cli**](https://ajv.js.org/packages/ajv-cli.html) validator is used to perform the validation. **ajv-cli** supports the use of globs in [the data file path argument](https://ajv.js.org/packages/ajv-cli.html#d-json-data). "[globstar](https://github.com/isaacs/node-glob#glob-primer:~:text=**%20If%20a%20%22globstar%22%20is%20alone%20in%20a%20path%20portion%2C%20then%20it%20matches%20zero%20or%20more%20directories%20and%20subdirectories%20searching%20for%20matches.)s" are used to cause the tool to search the file tree in the repository recursively for data files to validate.

Previously these glob patterns were not carefully chosen, which made it possible for unintended data files to be validated. Searching and validating these files is inefficient at best and the cause of spurious failures at worst. That worst case scenario has now occurred as the unintended validation of a file discovered through uncontrolled recursive searching is failing validation and causing the spurious failure of the markdownlint configuration validation task and workflow:

https://github.com/arduino/tooling-project-assets/actions/runs/6961626319/job/18943637236#step:4:45

```text
node_modules/markdownlint/schema/.markdownlint.yaml invalid
```

In this case, the file is externally maintained (meaning that the cause of a validation failure can not reasonably be fixed from inside this project) and not even the type of data being targeted (it is a JSON schema file for the markdownlint configuration rather than an actual markdownlint configuration  file).

Various strategies are used here to ensure only intended files are validated. See the individual commit messages for details.

