### PR TITLE
Use modern version of validator to validate Dependabot configuration files

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -363,24 +363,22 @@ tasks:
       DATA_PATH: ".github/dependabot.yml"
       # The asset Dependabot configuration files.
       ASSETS_DATA_PATH: "workflow-templates/assets/dependabot/**/dependabot.yml"
-      PROJECT_FOLDER:
-        sh: pwd
       WORKING_FOLDER:
         sh: task utility:mktemp-folder TEMPLATE="dependabot-validate-XXXXXXXXXX"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - |
-        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
-        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
+        npx ajv-cli validate \
           --all-errors \
+          --strict=false \
           -s "{{.SCHEMA_PATH}}" \
-          -d "{{.PROJECT_FOLDER}}/{{.DATA_PATH}}"
+          -d "{{.DATA_PATH}}"
       - |
-        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
-        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
+        npx ajv-cli validate \
           --all-errors \
+          --strict=false \
           -s "{{.SCHEMA_PATH}}" \
-          -d "{{.PROJECT_FOLDER}}/{{.ASSETS_DATA_PATH}}"
+          -d "{{.ASSETS_DATA_PATH}}"
 
   docs:generate:
     desc: Create all generated documentation content


### PR DESCRIPTION
The repository infrastructure validates the project's own, as well as the "asset", [**Dependabot** configuration files](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file) against [the JSON schema](https://json.schemastore.org/dependabot-2.0). The [**ajv-cli**](https://ajv.js.org/packages/ajv-cli.html) JSON schema validator is used to perform the validation.

Support for the JSON schema ["Draft-04" specification](https://json-schema.org/specification-links#draft-4) was dropped at the [4.0.0 release of **ajv-cli**](https://github.com/ajv-validator/ajv-cli/releases/tag/v4.0.0). This means that the previous version ([3.3.0](https://github.com/ajv-validator/ajv-cli/releases/tag/v3.3.0)) must be used when validating files against a JSON schema based on the "Draft 4" specification. When working with schemas based on newer specification versions, it is preferred to use the latest version of ajv-cli in order to benefit from the ongoing development on the tool. For this reason, two different versions of ajv-cli are used.

At the time the system for validating the Dependabot configuration files was set up, that JSON schema was based on the "Draft-04" specification, so ajv-cli 3.3.0 was used. Since that time the schema was updated to "[Draft-07](https://json-schema.org/specification-links#draft-7)" so it is now possible to use the modern **ajv-cli** for this validation.