### PR TITLE
add support to x509 certificates

### DIFF
--- a/workflow-templates/check-certificates.yml
+++ b/workflow-templates/check-certificates.yml
@@ -77,6 +77,7 @@ jobs:
           - identifier: macOS signing certificate # Text used to identify certificate in notifications.
             certificate-secret: INSTALLER_CERT_MAC_P12 # Name of the secret that contains the certificate.
             password-secret: INSTALLER_CERT_MAC_PASSWORD # Name of the secret that contains the certificate password.
+            type: pkcs12 # here you can use `x509` too in case you have a .cer file with a single certificate
 
     steps:
       - name: Set certificate path environment variable
@@ -95,7 +96,7 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets[matrix.certificate.password-secret] }}
         run: |
           (
-            openssl pkcs12 \
+            openssl ${{ matrix.certificate.type }} \
               -in "${{ env.CERTIFICATE_PATH }}" \
               -legacy \
               -noout \
@@ -122,26 +123,43 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets[matrix.certificate.password-secret] }}
         id: get-days-before-expiration
         run: |
-          EXPIRATION_DATE="$(
-            (
-              openssl pkcs12 \
-                -in "${{ env.CERTIFICATE_PATH }}" \
-                -clcerts \
-                -legacy \
-                -nodes \
-                -passin env:CERTIFICATE_PASSWORD
-            ) | (
-              openssl x509 \
-                -noout \
-                -enddate
-            ) | (
-              grep \
-                --max-count=1 \
-                --only-matching \
-                --perl-regexp \
-                'notAfter=(\K.*)'
-            )
-          )"
+          if [[ ${{ matrix.certificate.type }} == "pkcs12" ]]; then
+            EXPIRATION_DATE="$(
+                (
+                openssl pkcs12 \
+                    -in ${{ env.CERTIFICATE_PATH }} \
+                    -clcerts \
+                    -legacy \
+                    -nodes \
+                    -passin env:CERTIFICATE_PASSWORD
+                ) | (
+                openssl x509 \
+                    -noout \
+                    -enddate
+                ) | (
+                grep \
+                    --max-count=1 \
+                    --only-matching \
+                    --perl-regexp \
+                    'notAfter=(\K.*)'
+                )
+            )"
+          elif [[ ${{ matrix.certificate.type }} == "x509" ]]; then
+            EXPIRATION_DATE="$(
+                (
+                openssl x509 \
+                    -in ${{ env.CERTIFICATE_PATH }} \
+                    -noout \
+                    -enddate
+                ) | (
+                grep \
+                    --max-count=1 \
+                    --only-matching \
+                    --perl-regexp \
+                    'notAfter=(\K.*)'
+                )
+            )"
+          fi
 
           DAYS_BEFORE_EXPIRATION="$((($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24))"
 


### PR DESCRIPTION
The new windows certificate we have is no more distributed digitally, and it's not inside a certificate container anymore.

This PR adds support for a single certificate.

An implementation of this can be seen in:
- https://github.com/arduino/arduino-cli/pull/2599
- https://github.com/arduino/arduino-create-agent/pull/950