### PR TITLE
Update some workflows upload/download artifact actions

### DIFF
--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -111,7 +111,7 @@ jobs:
       # Some might find it convenient to have CI generate the cache rather than setting up for it locally
       - name: Upload cache to workflow artifact
         if: failure() && steps.diff.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: dep-licenses-cache

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -54,10 +54,10 @@ jobs:
         run: task dist:${{ matrix.os }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os }}
           path: ${{ env.DIST_DIR }}
 
   notarize-macos:
@@ -88,9 +88,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          pattern: ${{ env.ARTIFACT_NAME }}-*
+          merge-multiple: true
           path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
@@ -165,10 +166,10 @@ jobs:
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}-notarized-${{ matrix.artifact.name }}
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   publish-nightly:
@@ -180,9 +181,10 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          pattern: ${{ env.ARTIFACT_NAME }}-*
+          merge-multiple: true
           path: ${{ env.DIST_DIR }}
 
       - name: Create checksum file

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -131,7 +131,7 @@ jobs:
 
       # Transfer builds to artifacts job
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
           name: ${{ matrix.os.name }}
@@ -146,7 +146,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Create checksum file
         run: |
@@ -161,7 +161,7 @@ jobs:
           done
 
       - name: Upload checksum artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./*checksums.txt
           name: checksums

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -61,10 +61,10 @@ jobs:
         run: task dist:${{ matrix.os }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}-${{ matrix.os }}
           path: ${{ env.DIST_DIR }}
 
   notarize-macos:
@@ -93,9 +93,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          pattern: ${{ env.ARTIFACT_NAME }}-*
+          merge-multiple: true
           path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
@@ -170,10 +171,10 @@ jobs:
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}-notarized-${{ matrix.artifact.name }}
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   create-release:
@@ -186,9 +187,10 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          pattern: ${{ env.ARTIFACT_NAME }}-*
+          merge-multiple: true
           path: ${{ env.DIST_DIR }}
 
       - name: Create checksum file

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -73,13 +73,13 @@ jobs:
           file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
 
       - name: Pass configuration files to next job via workflow artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: |
             *.yaml
             *.yml
           if-no-files-found: error
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}-${{ matrix.filename }}
 
   sync:
     needs: download
@@ -114,15 +114,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download configuration files artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          pattern: ${{ env.CONFIGURATIONS_ARTIFACT }}-*
+          merge-multiple: true
           path: ${{ env.CONFIGURATIONS_FOLDER }}
 
       - name: Remove unneeded artifact
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          name: ${{ env.CONFIGURATIONS_ARTIFACT }}-*
 
       - name: Merge label configuration files
         run: |


### PR DESCRIPTION
Updates the artifacts-related actions to the latest version:

* [actions/upload-artifact@v4](https://github.com/actions/upload-artifact)
* [actions/download-artifact@v4](https://github.com/actions/download-artifact)
* [geekyeggo/delete-artifact@v5](https://github.com/geekyeggo/delete-artifact)

Here the migration guide > https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md

This changes have been successfully used in the Arduino CLI: 
- https://github.com/arduino/arduino-cli/pull/2679
- https://github.com/arduino/arduino-cli/pull/2682