### PR TITLE
Update redirecting URLs in reference links

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,5 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-javascript/.eslintrc.yml
-# See: https://eslint.org/docs/user-guide/configuring/
+# See: https://eslint.org/docs/latest/use/configure/
 # The code style defined in this file is the official standardized style to be used in all Arduino projects and should
 # not be modified.
 

--- a/.github/workflows/check-ci-sync.yml
+++ b/.github/workflows/check-ci-sync.yml
@@ -6,7 +6,7 @@
 
 name: Check CI Workflows Sync
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/check-clang-format.yml
+++ b/.github/workflows/check-clang-format.yml
@@ -4,7 +4,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           if [[ "${{ github.event.inputs.clang-format-version }}" == "" ]]; then
             echo "CLANG_FORMAT_VERSION=$(task clang-format:get-version)" >> "$GITHUB_ENV"
           else
@@ -99,7 +99,7 @@ jobs:
           cd "${{ env.CLANG_FORMAT_INSTALL_PATH }}"
           tar --extract --file="${{ steps.download-clang-format.outputs.name }}"
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.CLANG_FORMAT_INSTALL_PATH }}/clang_Linux_64bit" >> "$GITHUB_PATH"
 
       - name: Download yq
@@ -115,7 +115,7 @@ jobs:
           cd "${{ env.YQ_INSTALL_PATH }}"
           tar --extract --file="${{ steps.download-yq.outputs.name }}"
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.YQ_INSTALL_PATH }}/yq" >> "$GITHUB_PATH"
 
       - name: Check ClangFormat configuration file
@@ -152,7 +152,7 @@ jobs:
 
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           if [[ "${{ github.event.inputs.clang-format-version }}" == "" ]]; then
             echo "CLANG_FORMAT_VERSION=$(task clang-format:get-version)" >> "$GITHUB_ENV"
           else
@@ -175,7 +175,7 @@ jobs:
           cd "${{ env.CLANG_FORMAT_INSTALL_PATH }}"
           tar --extract --file="${{ steps.download.outputs.name }}"
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.CLANG_FORMAT_INSTALL_PATH }}/clang_Linux_64bit" >> "$GITHUB_PATH"
 
       - name: Check ClangFormat output
@@ -220,7 +220,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "CONVERSION_OUTPUT_PATH=${{ runner.temp }}/clang-format-js-object.txt" >> "$GITHUB_ENV"
 
       - name: Checkout repository

--- a/.github/workflows/check-community-health-sync.yml
+++ b/.github/workflows/check-community-health-sync.yml
@@ -6,7 +6,7 @@
 
 name: Check Community Health Files Sync
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/check-config-sync.yml
+++ b/.github/workflows/check-config-sync.yml
@@ -6,7 +6,7 @@
 
 name: Check Configuration Files Sync
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
   pull_request:

--- a/.github/workflows/check-dependabot.yml
+++ b/.github/workflows/check-dependabot.yml
@@ -1,6 +1,6 @@
 name: Check Dependabot Configuration
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/check-eslint.yml
+++ b/.github/workflows/check-eslint.yml
@@ -4,7 +4,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/check-files-task.yml
+++ b/.github/workflows/check-files-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-files-task.md
 name: Check Files
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-general-formatting-task.md
 name: Check General Formatting
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >> "$GITHUB_ENV"
 
       - name: Checkout repository
@@ -75,7 +75,7 @@ jobs:
           # Give the binary a standard name
           mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
 
       - name: Check formatting

--- a/.github/workflows/check-issue-templates.yml
+++ b/.github/workflows/check-issue-templates.yml
@@ -1,6 +1,6 @@
 name: Check Issue Templates
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/check-javascript-task.yml
+++ b/.github/workflows/check-javascript-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,6 +1,6 @@
 name: Check Label Configuration
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-license.md
 name: Check License
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-markdownlint.yml
+++ b/.github/workflows/check-markdownlint.yml
@@ -1,6 +1,6 @@
 name: Check markdownlint Configuration
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-shell-task.md
 name: Check Shell Scripts
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >> "$GITHUB_ENV"
 
       - name: Checkout repository
@@ -112,7 +112,7 @@ jobs:
               "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}"
           )"
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
 
       - name: Run ShellCheck
@@ -140,7 +140,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >> "$GITHUB_ENV"
 
       - name: Checkout repository
@@ -168,7 +168,7 @@ jobs:
           # Standardize binary name
           mv "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}" "${{ env.SHFMT_INSTALL_PATH }}/shfmt"
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.SHFMT_INSTALL_PATH }}" >> "$GITHUB_PATH"
 
       - name: Format shell scripts

--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -1,11 +1,11 @@
-# Source: https://github.com/arduino/tooling-project-assets/blob/master/workflow-templates/check-workflows-task.md
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-workflows-task.md
 name: Check Workflows
 
 env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:
@@ -13,7 +13,8 @@ on:
       - ".yamllint*"
       - "poetry.lock"
       - "pyproject.toml"
-      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
+      # (used by Prettier)
       - "**/.clang-format"
       - "**/.clang-tidy"
       - "**/.gemrc"
@@ -29,7 +30,8 @@ on:
       - ".yamllint*"
       - "poetry.lock"
       - "pyproject.toml"
-      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
+      # (used by Prettier)
       - "**/.clang-format"
       - "**/.clang-tidy"
       - "**/.gemrc"

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -7,7 +7,7 @@ env:
   CONFIGURATIONS_FOLDER: .github/label-configuration-files
   CONFIGURATIONS_ARTIFACT_PREFIX: label-configuration-file-
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:
@@ -101,7 +101,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
 
       - name: Determine whether to dry run

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -13,7 +13,7 @@ on:
     # Run every day at 03:00 UTC to catch breakage caused by external events
     - cron: "0 3 * * *"
   # workflow_dispatch event allows the workflow to be triggered manually.
-  # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+  # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch:
 
 env:
@@ -110,7 +110,7 @@ jobs:
       - name: Set install path environment variable
         shell: bash
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "BINDIR=${{ runner.temp }}/custom-installation-folder" >> "$GITHUB_ENV"
 
       - name: Download script artifact
@@ -219,7 +219,7 @@ jobs:
       - name: Set install path environment variables
         shell: bash
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           FIRST_INSTALLATION_FOLDER="first-installation-folder"
           echo "FIRST_INSTALLATION_FOLDER=${FIRST_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
           echo "FIRST_BINDIR=${{ runner.temp }}/${FIRST_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
@@ -249,7 +249,7 @@ jobs:
       - name: Add first installation to PATH
         shell: bash
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.FIRST_BINDIR }}" >> "$GITHUB_PATH"
 
       - name: Check script output with previous installation in PATH (non-Windows)

--- a/.github/workflows/test-python-poetry-task.yml
+++ b/.github/workflows/test-python-poetry-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -53,7 +53,8 @@ rules:
     check-keys: true
 
 yaml-files:
-  # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+  # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
+  # (used by Prettier)
   - ".clang-format"
   - ".clang-tidy"
   - ".gemrc"

--- a/workflow-templates/assets/check-dependencies/AGPL-3.0/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/AGPL-3.0/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/master/docs/configuration.md
+# See: https://github.com/github/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/AGPL-3.0/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-dependencies/Apache-2.0/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/Apache-2.0/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/master/docs/configuration.md
+# See: https://github.com/github/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/Apache-2.0/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-dependencies/GPL-2.0/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/GPL-2.0/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/master/docs/configuration.md
+# See: https://github.com/github/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/GPL-2.0/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/master/docs/configuration.md
+# See: https://github.com/github/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-dependencies/LGPL-2.1/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/LGPL-2.1/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/master/docs/configuration.md
+# See: https://github.com/github/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/LGPL-2.1/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-javascript/.eslintrc.yml
+++ b/workflow-templates/assets/check-javascript/.eslintrc.yml
@@ -1,5 +1,5 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-javascript/.eslintrc.yml
-# See: https://eslint.org/docs/user-guide/configuring/
+# See: https://eslint.org/docs/latest/use/configure/
 # The code style defined in this file is the official standardized style to be used in all Arduino projects and should
 # not be modified.
 

--- a/workflow-templates/assets/check-yaml/.yamllint.yml
+++ b/workflow-templates/assets/check-yaml/.yamllint.yml
@@ -53,7 +53,8 @@ rules:
     check-keys: true
 
 yaml-files:
-  # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+  # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
+  # (used by Prettier)
   - ".clang-format"
   - ".clang-tidy"
   - ".gemrc"

--- a/workflow-templates/check-action-metadata-task.yml
+++ b/workflow-templates/check-action-metadata-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-certificates.yml
+++ b/workflow-templates/check-certificates.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-certificates.md
 name: Check Certificates
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Set certificate path environment variable
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "CERTIFICATE_PATH=${{ runner.temp }}/certificate.p12" >> "$GITHUB_ENV"
 
       - name: Decode certificate

--- a/workflow-templates/check-files-task.yml
+++ b/workflow-templates/check-files-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-files-task.md
 name: Check Files
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-general-formatting-task.yml
+++ b/workflow-templates/check-general-formatting-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-general-formatting-task.md
 name: Check General Formatting
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >> "$GITHUB_ENV"
 
       - name: Checkout repository
@@ -75,7 +75,7 @@ jobs:
           # Give the binary a standard name
           mv "${{ env.EC_INSTALL_PATH }}/bin/ec-linux-amd64" "${{ env.EC_INSTALL_PATH }}/bin/ec"
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
 
       - name: Check formatting

--- a/workflow-templates/check-go-dependencies-task.md
+++ b/workflow-templates/check-go-dependencies-task.md
@@ -6,8 +6,8 @@ Use [**Licensed**](https://github.com/github/licensed) to check if the Go projec
 
 There are several options for configuring approvals. The most useful being:
 
-- [Allowed licenses](https://github.com/github/licensed/blob/master/docs/configuration/allowed_licenses.md) - allow any dependency that has this license type.
-- [Reviewed dependency](https://github.com/github/licensed/blob/master/docs/configuration/reviewing_dependencies.md) - allow specific dependencies that don't pass the global allowed license configuration, but have been individually reviewed and found acceptable.
+- [Allowed licenses](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md) - allow any dependency that has this license type.
+- [Reviewed dependency](https://github.com/github/licensed/blob/main/docs/configuration/reviewing_dependencies.md) - allow specific dependencies that don't pass the global allowed license configuration, but have been individually reviewed and found acceptable.
 
 ## Installation
 
@@ -28,15 +28,15 @@ Install the [`check-go-dependencies-task.yml`](check-go-dependencies-task.yml) G
 
 The **Licensed** tool is configured via `.licensed.yml` configuration file, located in the repository root folder:
 
-https://github.com/github/licensed/blob/master/docs/configuration.md
+https://github.com/github/licensed/blob/main/docs/configuration.md
 
 #### Project paths
 
-By default, the project in the root of the repository will be checked. If the project is in a subfolder of the repository or if the repository contains multiple projects with dependencies that should be checked then the path to each project should be defined via [`apps[*].source_path` keys](https://github.com/github/licensed/blob/master/docs/configuration/application_source.md#application-source-path) in `.licensed.yml`.
+By default, the project in the root of the repository will be checked. If the project is in a subfolder of the repository or if the repository contains multiple projects with dependencies that should be checked then the path to each project should be defined via [`apps[*].source_path` keys](https://github.com/github/licensed/blob/main/docs/configuration/application_source.md#application-source-path) in `.licensed.yml`.
 
 #### Allowed licenses
 
-A list of [allowed license types](https://github.com/github/licensed/blob/master/docs/configuration/allowed_licenses.md) can be defined in the `.licensed.yml` configuration file under:
+A list of [allowed license types](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md) can be defined in the `.licensed.yml` configuration file under:
 
 - The `allowed` key to apply to all projects.
 - The `apps[*].allowed` key to apply to a specific project.
@@ -139,6 +139,6 @@ On every push and pull request that affects relevant files, the CI workflow will
 
 Approval can be based on:
 
-- [Allowed license type](https://github.com/github/licensed/blob/master/docs/configuration/allowed_licenses.md)
-- [Individual dependency](https://github.com/github/licensed/blob/master/docs/configuration/reviewing_dependencies.md)
+- [Allowed license type](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md)
+- [Individual dependency](https://github.com/github/licensed/blob/main/docs/configuration/reviewing_dependencies.md)
 ```

--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-javascript-task.md
+++ b/workflow-templates/check-javascript-task.md
@@ -80,7 +80,7 @@ On every push and pull request that affects relevant files, and periodically, ru
 files.
 
 ESLint is configured via the .eslintrc.yml file:
-https://eslint.org/docs/user-guide/configuring/configuration-files
+https://eslint.org/docs/latest/use/configure/configuration-files
 ```
 
 ## PR message

--- a/workflow-templates/check-javascript-task.yml
+++ b/workflow-templates/check-javascript-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-license.md
 name: Check License
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-markdown-task.yml
+++ b/workflow-templates/check-markdown-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-mkdocs-task.yml
+++ b/workflow-templates/check-mkdocs-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-npm-dependencies-task.md
+++ b/workflow-templates/check-npm-dependencies-task.md
@@ -6,8 +6,8 @@ Use [**Licensed**](https://github.com/github/licensed) to check if the project h
 
 There are several options for configuring approvals. The most useful being:
 
-- [Allowed licenses](https://github.com/github/licensed/blob/master/docs/configuration/allowed_licenses.md) - allow any dependency that has this license type.
-- [Reviewed dependency](https://github.com/github/licensed/blob/master/docs/configuration/reviewing_dependencies.md) - allow specific dependencies that don't pass the global allowed license configuration, but have been individually reviewed and found acceptable.
+- [Allowed licenses](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md) - allow any dependency that has this license type.
+- [Reviewed dependency](https://github.com/github/licensed/blob/main/docs/configuration/reviewing_dependencies.md) - allow specific dependencies that don't pass the global allowed license configuration, but have been individually reviewed and found acceptable.
 
 ## Installation
 
@@ -30,15 +30,15 @@ Install the [`check-npm-dependencies-task.yml`](check-npm-dependencies-task.yml)
 
 The **Licensed** tool is configured via `.licensed.yml` configuration file, located in the repository root folder:
 
-https://github.com/github/licensed/blob/master/docs/configuration.md
+https://github.com/github/licensed/blob/main/docs/configuration.md
 
 #### Project paths
 
-By default, the project in the root of the repository will be checked. If the project is in a subfolder of the repository or if the repository contains multiple projects with dependencies that should be checked then the path to each project should be defined via [`apps[*].source_path` keys](https://github.com/github/licensed/blob/master/docs/configuration/application_source.md#application-source-path) in `.licensed.yml`.
+By default, the project in the root of the repository will be checked. If the project is in a subfolder of the repository or if the repository contains multiple projects with dependencies that should be checked then the path to each project should be defined via [`apps[*].source_path` keys](https://github.com/github/licensed/blob/main/docs/configuration/application_source.md#application-source-path) in `.licensed.yml`.
 
 #### Allowed licenses
 
-A list of [allowed license types](https://github.com/github/licensed/blob/master/docs/configuration/allowed_licenses.md) can be defined in the `.licensed.yml` configuration file under:
+A list of [allowed license types](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md) can be defined in the `.licensed.yml` configuration file under:
 
 - The `allowed` key to apply to all projects.
 - The `apps[*].allowed` key to apply to a specific project.
@@ -162,6 +162,6 @@ On every push and pull request that affects relevant files, the CI workflow will
 
 Approval can be based on:
 
-- [Allowed license type](https://github.com/github/licensed/blob/master/docs/configuration/allowed_licenses.md)
-- [Individual dependency](https://github.com/github/licensed/blob/master/docs/configuration/reviewing_dependencies.md)
+- [Allowed license type](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md)
+- [Individual dependency](https://github.com/github/licensed/blob/main/docs/configuration/reviewing_dependencies.md)
 ```

--- a/workflow-templates/check-npm-dependencies-task.yml
+++ b/workflow-templates/check-npm-dependencies-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-npm-task.yml
+++ b/workflow-templates/check-npm-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-prettier-formatting-task.yml
+++ b/workflow-templates/check-prettier-formatting-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-python-task.yml
+++ b/workflow-templates/check-python-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-shell-task.yml
+++ b/workflow-templates/check-shell-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-shell-task.md
 name: Check Shell Scripts
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >> "$GITHUB_ENV"
 
       - name: Checkout repository
@@ -113,7 +113,7 @@ jobs:
               "${{ env.SHELLCHECK_RELEASE_ASSET_SUFFIX }}"
           )"
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
 
       - name: Run ShellCheck
@@ -147,7 +147,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >> "$GITHUB_ENV"
 
       - name: Checkout repository
@@ -175,7 +175,7 @@ jobs:
           # Standardize binary name
           mv "${{ env.SHFMT_INSTALL_PATH }}/${{ steps.download.outputs.name }}" "${{ env.SHFMT_INSTALL_PATH }}/shfmt"
           # Add installation to PATH:
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
           echo "${{ env.SHFMT_INSTALL_PATH }}" >> "$GITHUB_PATH"
 
       - name: Format shell scripts

--- a/workflow-templates/check-taskfiles.yml
+++ b/workflow-templates/check-taskfiles.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-toc-task.yml
+++ b/workflow-templates/check-toc-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/check-workflows-task.yml
+++ b/workflow-templates/check-workflows-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: 16.x
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:

--- a/workflow-templates/check-yaml-task.yml
+++ b/workflow-templates/check-yaml-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:
@@ -13,7 +13,8 @@ on:
       - ".yamllint*"
       - "poetry.lock"
       - "pyproject.toml"
-      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
+      # (used by Prettier)
       - "**/.clang-format"
       - "**/.clang-tidy"
       - "**/.gemrc"
@@ -29,7 +30,8 @@ on:
       - ".yamllint*"
       - "poetry.lock"
       - "pyproject.toml"
-      # Source: https://github.com/ikatyang/linguist-languages/blob/master/data/YAML.json (used by Prettier)
+      # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
+      # (used by Prettier)
       - "**/.clang-format"
       - "**/.clang-tidy"
       - "**/.gemrc"

--- a/workflow-templates/deploy-mkdocs-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-poetry.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     branches:

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -11,7 +11,7 @@ env:
   AWS_REGION: "us-east-1"
   ARTIFACT_PREFIX: dist-
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   schedule:
     # run every day at 1AM

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/publish-go-tester-task.md
 name: Publish Tester Build
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/release-go-crosscompile-task.md
+++ b/workflow-templates/release-go-crosscompile-task.md
@@ -27,7 +27,7 @@ The following project-specific variables must be set in `Taskfile.yml`:
 - `PROJECT_NAME`
 - `CONFIGURATION_PACKAGE`
 
-`CONFIGURATION_PACKAGE` must be set to the golang package containing the version metadata for the project. For example for the following file: https://github.com/arduino/mdns-discovery/blob/master/version/version.go the `CONFIGURATION_PACKAGE` field must be set to the value: `github.com/arduino/mdns-discovery/version`.
+`CONFIGURATION_PACKAGE` must be set to the golang package containing the version metadata for the project. For example for the following file: https://github.com/arduino/mdns-discovery/blob/main/version/version.go the `CONFIGURATION_PACKAGE` field must be set to the value: `github.com/arduino/mdns-discovery/version`.
 
 #### Workflow
 

--- a/workflow-templates/release-go-task.md
+++ b/workflow-templates/release-go-task.md
@@ -27,7 +27,7 @@ The following project-specific variables must be set in `Taskfile.yml`:
 - `PROJECT_NAME`
 - `CONFIGURATION_PACKAGE`
 
-`CONFIGURATION_PACKAGE` must be set to the golang package containing the version metadata for the project. For example for the following file: https://github.com/arduino/mdns-discovery/blob/master/version/version.go the `CONFIGURATION_PACKAGE` field must be set to the value: `github.com/arduino/mdns-discovery/version`.
+`CONFIGURATION_PACKAGE` must be set to the golang package containing the version metadata for the project. For example for the following file: https://github.com/arduino/mdns-discovery/blob/main/version/version.go the `CONFIGURATION_PACKAGE` field must be set to the value: `github.com/arduino/mdns-discovery/version`.
 
 #### Workflow
 

--- a/workflow-templates/release-tag.yml
+++ b/workflow-templates/release-tag.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "CHANGELOG_PATH=${{ runner.temp }}/CHANGELOG.md" >> "$GITHUB_ENV"
           echo "SEMVER_TOOL_PATH=${{ runner.temp }}/semver" >> "$GITHUB_ENV"
 

--- a/workflow-templates/spell-check-task.yml
+++ b/workflow-templates/spell-check-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/sync-labels-npm.yml
+++ b/workflow-templates/sync-labels-npm.yml
@@ -7,7 +7,7 @@ env:
   CONFIGURATIONS_FOLDER: .github/label-configuration-files
   CONFIGURATIONS_ARTIFACT_PREFIX: label-configuration-file-
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:
@@ -101,7 +101,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
 
       - name: Determine whether to dry run

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -1,7 +1,7 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md
 name: Sync Labels
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   push:
     paths:
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: Set environment variables
         run: |
-          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
 
       - name: Determine whether to dry run

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -7,7 +7,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:

--- a/workflow-templates/test-python-poetry-task.yml
+++ b/workflow-templates/test-python-poetry-task.yml
@@ -5,7 +5,7 @@ env:
   # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
-# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:
   create:
   push:


### PR DESCRIPTION
The templates and documentation contain reference links to provide additional information to the users and maintainers.

The targets of some of these links have moved since the time they were added. Although the user could still reach the intended content via a redirect, it is best not to rely on redirects continuing to work indefinitely. So the URLs are hereby updated to point directly to the target content.