### PR TITLE
Update redirecting URL in reference link

### DIFF
--- a/workflow-templates/check-javascript-task.md
+++ b/workflow-templates/check-javascript-task.md
@@ -89,5 +89,5 @@ https://eslint.org/docs/latest/use/configure/configuration-files
 On every push and pull request that affects relevant files, and periodically, run [**ESLint**](https://eslint.org/) on the repository's JavaScript files.
 
 **ESLint** is configured via the `.eslintrc.yml` file:
-https://eslint.org/docs/latest/user-guide/configuring/configuration-files
+https://eslint.org/docs/latest/use/configure/configuration-files
 ```


### PR DESCRIPTION
The templates and documentation contain reference links to provide additional information to the users and maintainers.

The targets of this link has moved since the time they were added. Although the user could still reach the intended content via a redirect, it is best not to rely on redirects continuing to work indefinitely. So the URL is hereby updated to point directly to the target content.