### PR TITLE
Use explicit filename source in config file artifact upload step of "Sync Labels" workflows

### DIFF
--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -85,9 +85,7 @@ jobs:
       - name: Pass configuration files to next job via workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          path: |
-            *.yaml
-            *.yml
+          path: ${{ matrix.filename }}
           if-no-files-found: error
           name: ${{ env.CONFIGURATIONS_ARTIFACT_PREFIX }}${{ matrix.filename }}
 

--- a/workflow-templates/sync-labels-npm.yml
+++ b/workflow-templates/sync-labels-npm.yml
@@ -85,9 +85,7 @@ jobs:
       - name: Pass configuration files to next job via workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          path: |
-            *.yaml
-            *.yml
+          path: ${{ matrix.filename }}
           if-no-files-found: error
           name: ${{ env.CONFIGURATIONS_ARTIFACT_PREFIX }}${{ matrix.filename }}
 

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -75,9 +75,7 @@ jobs:
       - name: Pass configuration files to next job via workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          path: |
-            *.yaml
-            *.yml
+          path: ${{ matrix.filename }}
           if-no-files-found: error
           name: ${{ env.CONFIGURATIONS_ARTIFACT_PREFIX }}${{ matrix.filename }}
 


### PR DESCRIPTION
Starting from version 3.2.0 of the [**actions/upload-artifact**](https://github.com/actions/upload-artifact) action, "hidden" files are not uploaded by default (https://github.com/actions/upload-artifact/issues/602). The action considers a file "hidden" if any component of the path starts with `.`.

The `download` job of the "Sync Labels" workflow downloads each of the shared label configuration files from and uploads them to GitHub Actions [workflow artifacts](https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow#about-workflow-artifacts) for use by the subsequent job. Since the names of the configuration files don't start with `.` and they aren't located in a subfolder that starts with `.`, we would not expect that this job could be impacted by the new hidden file handling behavior. However, it was impacted after all under certain conditions. Previously, wildcard patterns were used in the `path` input of the job's **actions/upload-artifact** action step. It turns out that in the case of wildcards, the entire absolute path to the file is considered in the determination of whether it is "hidden". The "workspace" in which the workflow's steps are performed is under a path that includes the repository name. So if the repository name starts with a `.` (e.g., [`.github`](https://docs.github.com/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile#adding-a-public-organization-profile-readme), then the **actions/upload-artifact** action step failed spuriously:

```
Run actions/upload-artifact@v3
Error: No files were found with the provided path: *.yaml
*.yml. No artifacts will be uploaded.
```

Although this could be fixed by setting the **actions/upload-artifact** action's [`include-hidden-files` input](https://github.com/actions/upload-artifact#uploading-hidden-files) to `true`, it actually doesn't make sense to use a wildcard in the `path` input when the name of the single file is already available (the wildcard approach is a vestigial remnant of a previous version of the workflow that downloaded all configuration files in a single job, before it was changed to using a job matrix). By changing the `path` input value to the file's explicit relative path, it is ensured that the file will never be treated as "hidden", regardless of the repository name.