### PR TITLE
Use more efficient workflow artifact replacement approach

### DIFF
--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -196,7 +196,7 @@ jobs:
           path: ${{ env.DIST_DIR }}
 
       - name: Create checksum file
-        working-directory: ${{ env.DIST_DIR}}
+        working-directory: ${{ env.DIST_DIR }}
         run: |
           TAG="nightly-$(date -u +"%Y%m%d")"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -120,11 +120,6 @@ jobs:
           name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
           path: ${{ env.DIST_DIR }}
 
-      - name: Remove non-notarized artifact
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
-
       - name: Import Code-Signing Certificates
         env:
           KEYCHAIN: "sign.keychain"
@@ -192,11 +187,12 @@ jobs:
           -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
 
-      - name: Upload notarized artifact
+      - name: Replace artifact with notarized build
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
+          overwrite: true
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   create-release:

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -216,7 +216,7 @@ jobs:
           pattern: ${{ env.ARTIFACT_PREFIX }}*
 
       - name: Create checksum file
-        working-directory: ${{ env.DIST_DIR}}
+        working-directory: ${{ env.DIST_DIR }}
         run: |
           TAG="${GITHUB_REF/refs\/tags\//}"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -203,7 +203,7 @@ jobs:
           path: ${{ env.DIST_DIR }}
 
       - name: Create checksum file
-        working-directory: ${{ env.DIST_DIR}}
+        working-directory: ${{ env.DIST_DIR }}
         run: |
           TAG="${GITHUB_REF/refs\/tags\//}"
           sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt


### PR DESCRIPTION
The **"Release" workflow (Go, Task, Crosscompile)** template uses a GitHub Actions workflow to automatically generate releases of a project. This is done for a range of host architectures, including macOS. The macOS builds are then put through a notarization process in a dedicated workflow job.

The builds are transferred between jobs by GitHub Actions workflow artifacts. The `create-release-artifacts` job produces macOS workflow artifacts containing non-notarized builds, which must then be replaced after the builds are notarized by the `notarize-macos` job.

Previously, the approach chosen to accomplish this replacement was to use the community created **geekyeggo/delete-artifact** action to delete each artifact after it had been downloaded by the `notarize-macos` job, then replacing it by uploading the notarized version using the **actions/upload-artifact** action. It turns out that the ability to overwrite workflows was recently added to the **actions/upload-artifact** action, in 4.2.0: https://github.com/actions/upload-artifact/commit/11ff42c7b1b52130283d8a02bc960d1e1de95000. This behavior is enabled by setting the action's `overwrite` input to `true`. By using this feature, the dependence on the **geekyeggo/delete-artifact** action can be avoided, making the workflow more simple, easier to maintain, and more secure.