### PR TITLE
Bump "Licensed" version in dependency license check workflow

### DIFF
--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -82,7 +82,7 @@ jobs:
         uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 5.x
 
       - name: Install Go
         uses: actions/setup-go@v5
@@ -141,7 +141,7 @@ jobs:
         uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 5.x
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/workflow-templates/check-npm-dependencies-task.yml
+++ b/workflow-templates/check-npm-dependencies-task.yml
@@ -82,7 +82,7 @@ jobs:
         uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 5.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -141,7 +141,7 @@ jobs:
         uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 5.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The version of the [**Licensed**](https://github.com/licensee/licensed) tool for use in the GitHub Actions workflow is defined via the **github/setup-licensed** action's `version` input.

Previously the action was configured to install version 3.x of the action. That version is significantly outdated. The workflow is hereby updated to use the latest version of **Licensed**.