### PR TITLE
Configure Dependabot to check for updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     directory: /.github/workflows/
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 12 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"
     assignees:
@@ -20,7 +21,8 @@ updates:
     directory: /workflow-templates/
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 13 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"
     assignees:
@@ -30,7 +32,8 @@ updates:
     directory: /
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 14 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"
     assignees:
@@ -40,7 +43,8 @@ updates:
     directory: /
     open-pull-requests-limit: 100
     schedule:
-      interval: daily
+      cronjob: 0 15 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"
     assignees:

--- a/workflow-templates/assets/dependabot/dependabot.yml
+++ b/workflow-templates/assets/dependabot/dependabot.yml
@@ -8,6 +8,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /.github/workflows/
     schedule:
-      interval: daily
+      cronjob: 0 12 * * *
+      interval: cron
     labels:
       - "topic: infrastructure"


### PR DESCRIPTION
Dependabot is used to keep the project dependencies updated. Dependabot periodically checks for available updates, and if found submits a pull request.

The frequency of the update checks is configurable. Despite the name, the "daily" schedule configuration previously used actually only runs on weekdays. Maintenance of open source software projects is not necessarily limited to weekdays (and in the case of volunteer projects, is more likely to occur on weekends). So the weekday-ly update checks tended to result in a concentration of Dependabot pull requests on Mondays. This unnecessarily added to the busyness of an already busy day.