### PR TITLE
Use project version of ajv-cli in all validation tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -357,6 +357,8 @@ tasks:
 
   dependabot:validate:
     desc: Validate Dependabot configuration files against their JSON schema
+    deps:
+      - task: npm:install-deps
     vars:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/dependabot-2.0.json
       SCHEMA_URL: https://json.schemastore.org/dependabot-2.0
@@ -370,25 +372,29 @@ tasks:
       DATA_PATH: ".github/dependabot.yml"
       # The asset Dependabot configuration files.
       ASSETS_DATA_PATH: "workflow-templates/assets/dependabot/**/dependabot.yml"
-      WORKING_FOLDER:
-        sh: task utility:mktemp-folder TEMPLATE="dependabot-validate-XXXXXXXXXX"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.BASE_SCHEMA_PATH}}" {{.BASE_SCHEMA_URL}}
       - |
-        npx ajv-cli validate \
-          --all-errors \
-          --strict=false \
-          -s "{{.SCHEMA_PATH}}" \
-          -r "{{.BASE_SCHEMA_PATH}}" \
-          -d "{{.DATA_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -s "{{.SCHEMA_PATH}}" \
+            -r "{{.BASE_SCHEMA_PATH}}" \
+            -d "{{.DATA_PATH}}"
       - |
-        npx ajv-cli validate \
-          --all-errors \
-          --strict=false \
-          -s "{{.SCHEMA_PATH}}" \
-          -r "{{.BASE_SCHEMA_PATH}}" \
-          -d "{{.ASSETS_DATA_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -s "{{.SCHEMA_PATH}}" \
+            -r "{{.BASE_SCHEMA_PATH}}" \
+            -d "{{.ASSETS_DATA_PATH}}"
 
   docs:generate:
     desc: Create all generated documentation content
@@ -397,6 +403,8 @@ tasks:
 
   eslint:validate:
     desc: Validate ESLint configuration file against its JSON schema
+    deps:
+      - task: npm:install-deps
     vars:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/eslintrc.json
       SCHEMA_URL: https://json.schemastore.org/eslintrc.json
@@ -409,20 +417,19 @@ tasks:
       DATA_PATH: workflow-templates/assets/check-javascript/.eslintrc.yml
       # ajv-cli identifies YAML-format data files by their file extension, so renaming is required:
       # https://github.com/ajv-validator/ajv-cli/issues/117
-      PROJECT_FOLDER:
-        sh: pwd
-      WORKING_FOLDER:
-        sh: task utility:mktemp-folder TEMPLATE="eslintrc-validate-XXXXXXXXXX"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.PARTIAL_ESLINT_PLUGINS_PATH}}" {{.PARTIAL_ESLINT_PLUGINS_SCHEMA_URL}}
       - |
-        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
-        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
-          --all-errors \
-          -s "{{.SCHEMA_PATH}}" \
-          -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
-          -d "{{.PROJECT_FOLDER}}/{{.DATA_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -s "{{.SCHEMA_PATH}}" \
+            -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
+            -d "{{.DATA_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-files-task/Taskfile.yml
   general:check-filenames:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,8 +9,6 @@ vars:
   CLANG_FORMAT_GOLDEN_TEST_DATA_FOLDER: "{{.CLANG_FORMAT_TEST_DATA_FOLDER}}/golden"
   # See: https://github.com/arduino/arduino-ide/blob/main/arduino-ide-extension/package.json
   DEFAULT_CLANG_FORMAT_VERSION: 14.0.0
-  # Last version of ajv-cli with support for the JSON schema "Draft 4" specification
-  SCHEMA_DRAFT_4_AJV_CLI_VERSION: 3.3.0
 
 tasks:
   check:
@@ -729,6 +727,8 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-npm-task/Taskfile.yml
   npm:validate:
     desc: Validate npm configuration files against their JSON schema
+    deps:
+      - task: npm:install-deps
     vars:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json
       SCHEMA_URL: https://json.schemastore.org/package.json
@@ -772,10 +772,6 @@ tasks:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
       INSTANCE_PATH: >-
         {{default "." .PROJECT_PATH}}/package.json
-      PROJECT_FOLDER:
-        sh: pwd
-      WORKING_FOLDER:
-        sh: task utility:mktemp-folder TEMPLATE="dependabot-validate-XXXXXXXXXX"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}
@@ -788,20 +784,23 @@ tasks:
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
-        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
-        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
-          --all-errors \
-          -s "{{.SCHEMA_PATH}}" \
-          -r "{{.AVA_SCHEMA_PATH}}" \
-          -r "{{.BASE_SCHEMA_PATH}}" \
-          -r "{{.ESLINTRC_SCHEMA_PATH}}" \
-          -r "{{.JSCPD_SCHEMA_PATH}}" \
-          -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
-          -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
-          -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
-          -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
-          -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
-          -d "{{.PROJECT_FOLDER}}/{{.INSTANCE_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -s "{{.SCHEMA_PATH}}" \
+            -r "{{.AVA_SCHEMA_PATH}}" \
+            -r "{{.BASE_SCHEMA_PATH}}" \
+            -r "{{.ESLINTRC_SCHEMA_PATH}}" \
+            -r "{{.JSCPD_SCHEMA_PATH}}" \
+            -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
+            -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
+            -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
+            -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
+            -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
+            -d "{{.INSTANCE_PATH}}"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:
@@ -907,7 +906,6 @@ tasks:
           RAW_PATH: "{{.RAW_PATH}}"
 
   # Make a temporary folder named according to the passed TEMPLATE variable and print the path passed to stdout
-  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
   utility:mktemp-folder:
     vars:
       RAW_PATH:

--- a/workflow-templates/assets/check-npm-task/Taskfile.yml
+++ b/workflow-templates/assets/check-npm-task/Taskfile.yml
@@ -1,16 +1,14 @@
 # See: https://taskfile.dev/#/usage
 version: "3"
 
-vars:
-  # Last version of ajv-cli with support for the JSON schema "Draft 4" specification
-  SCHEMA_DRAFT_4_AJV_CLI_VERSION: 3.3.0
-
 tasks:
   # Parameter variables:
   # - PROJECT_PATH: path of the npm-managed project. Default value: "./"
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-npm-task/Taskfile.yml
   npm:validate:
     desc: Validate npm configuration files against their JSON schema
+    deps:
+      - task: npm:install-deps
     vars:
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/package.json
       SCHEMA_URL: https://json.schemastore.org/package.json
@@ -54,10 +52,6 @@ tasks:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
       INSTANCE_PATH: >-
         {{default "." .PROJECT_PATH}}/package.json
-      PROJECT_FOLDER:
-        sh: pwd
-      WORKING_FOLDER:
-        sh: task utility:mktemp-folder TEMPLATE="dependabot-validate-XXXXXXXXXX"
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}
@@ -70,17 +64,20 @@ tasks:
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
-        cd "{{.WORKING_FOLDER}}"  # Workaround for https://github.com/npm/cli/issues/3210
-        npx ajv-cli@{{.SCHEMA_DRAFT_4_AJV_CLI_VERSION}} validate \
-          --all-errors \
-          -s "{{.SCHEMA_PATH}}" \
-          -r "{{.AVA_SCHEMA_PATH}}" \
-          -r "{{.BASE_SCHEMA_PATH}}" \
-          -r "{{.ESLINTRC_SCHEMA_PATH}}" \
-          -r "{{.JSCPD_SCHEMA_PATH}}" \
-          -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
-          -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
-          -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
-          -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
-          -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
-          -d "{{.PROJECT_FOLDER}}/{{.INSTANCE_PATH}}"
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -s "{{.SCHEMA_PATH}}" \
+            -r "{{.AVA_SCHEMA_PATH}}" \
+            -r "{{.BASE_SCHEMA_PATH}}" \
+            -r "{{.ESLINTRC_SCHEMA_PATH}}" \
+            -r "{{.JSCPD_SCHEMA_PATH}}" \
+            -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
+            -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
+            -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
+            -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
+            -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
+            -d "{{.INSTANCE_PATH}}"

--- a/workflow-templates/assets/windows-task/Taskfile.yml
+++ b/workflow-templates/assets/windows-task/Taskfile.yml
@@ -13,17 +13,6 @@ tasks:
         vars:
           RAW_PATH: "{{.RAW_PATH}}"
 
-  # Make a temporary folder named according to the passed TEMPLATE variable and print the path passed to stdout
-  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
-  utility:mktemp-folder:
-    vars:
-      RAW_PATH:
-        sh: mktemp --directory --tmpdir "{{.TEMPLATE}}"
-    cmds:
-      - task: utility:normalize-path
-        vars:
-          RAW_PATH: "{{.RAW_PATH}}"
-
   # Print a normalized version of the path passed via the RAW_PATH variable to stdout
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
   utility:normalize-path:


### PR DESCRIPTION
The [**ajv-cli** command line tool](https://github.com/ajv-validator/ajv-cli) is used for validating data files against their [JSON schema](https://json-schema.org/). The tool is used to validate the project's Dependabot, ESLint, and npm configuration files.

In general, it is preferable (and for some schemas even mandatory) to use the modern versions of **ajv-cli**. However, support for the ["Draft-04" schema specification](https://json-schema.org/specification-links.html#draft-4) was dropped in **ajv-cli** version 4.0.0. So when working with JSON schemas that specify that draft, it is necessary to use **ajv-cli** 3.3.0, the last compatible version.

Previously, the Dependabot, ESLint, and npm schemas specified the "Draft-04" specification. For this reason, the `dependabot:validate`, `eslint:validate`, and `npm:validate` tasks were configured to use `ajv-cli@3.3.0`.

The schemas have now been updated to use "Draft-07" (https://github.com/SchemaStore/schemastore/commit/11e62f6fde72bab69d31a5d4274fd20e08a7d87f). So the code for using `ajv-cli@3.3.0` is removed from these tasks, and they will now use the standard project level version of **ajv-cli**.