### PR TITLE
Bump standardized Node.js version to 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "prettier": "^3.5.3"
       },
       "engines": {
-        "node": "16.x"
+        "node": "22.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "js-yaml": "^4.1.0"
   },
   "engines": {
-    "node": "16.x"
+    "node": "22.x"
   }
 }

--- a/workflow-templates/check-action-metadata-task.md
+++ b/workflow-templates/check-action-metadata-task.md
@@ -46,7 +46,7 @@ Add the following to [`/.gitignore`](https://git-scm.com/docs/gitignore):
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 ### Readme badge

--- a/workflow-templates/check-javascript-task.md
+++ b/workflow-templates/check-javascript-task.md
@@ -52,7 +52,7 @@ Add the following to [`/.gitignore`](https://git-scm.com/docs/gitignore):
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 ### Readme badge

--- a/workflow-templates/check-markdown-task.md
+++ b/workflow-templates/check-markdown-task.md
@@ -49,7 +49,7 @@ Commit the resulting changes to the `package.json` and `package-lock.json` files
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 #### Taskfile

--- a/workflow-templates/check-npm-dependencies-task.md
+++ b/workflow-templates/check-npm-dependencies-task.md
@@ -97,7 +97,7 @@ ignore: |
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 ### Documentation

--- a/workflow-templates/check-npm-task.md
+++ b/workflow-templates/check-npm-task.md
@@ -26,7 +26,7 @@ Install the [check-npm-task.yml](check-npm-task.yml) GitHub Actions workflow to 
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 If the project contains **npm**-managed projects (i.e., a folder containing a `package.json` file) in paths other than the root of the repository, run the command again from each of those paths.

--- a/workflow-templates/check-prettier-formatting-task.md
+++ b/workflow-templates/check-prettier-formatting-task.md
@@ -46,7 +46,7 @@ Commit the resulting changes to the `package.json` and `package-lock.json` files
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 #### Prettier

--- a/workflow-templates/check-taskfiles.md
+++ b/workflow-templates/check-taskfiles.md
@@ -27,7 +27,7 @@ Commit the resulting changes to the `package.json` and `package-lock.json` files
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 #### Workflow

--- a/workflow-templates/check-toc-task.md
+++ b/workflow-templates/check-toc-task.md
@@ -38,7 +38,7 @@ Commit the resulting changes to the `package.json` and `package-lock.json` files
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 #### Workflow

--- a/workflow-templates/check-workflows-task.md
+++ b/workflow-templates/check-workflows-task.md
@@ -46,7 +46,7 @@ Add the following to [`/.gitignore`](https://git-scm.com/docs/gitignore):
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 ### Readme badge

--- a/workflow-templates/sync-labels-npm.md
+++ b/workflow-templates/sync-labels-npm.md
@@ -90,7 +90,7 @@ Add the following to `.gitignore`:
 Configure the version of [**Node.js**](https://nodejs.org) used for development of the project by running the following command from a terminal in the project repository folder:
 
 ```text
-npm pkg set engines.node=16.x
+npm pkg set engines.node=22.x
 ```
 
 ### Readme badge


### PR DESCRIPTION
**npm** package-based tools are used for various development and maintenance operations for this project and the templates. In order to ensure these operations work as expected, the a specific major version of **Node.js** is configured for use by the infrastructure systems and collaborators.

For the sake of stability, [a version of **Node.js** that has LTS status should be used](https://nodejs.org/en/about/previous-releases). Previously, **Node.js** 16 was used. That version is EOL. The current active LTS version is 22, so that is the new standard version of **Node.js** for use in this project, and the projects where the templates are installed.