### PR TITLE
Use standard Node.js version in validation workflows

### DIFF
--- a/.github/workflows/check-dependabot.yml
+++ b/.github/workflows/check-dependabot.yml
@@ -5,11 +5,15 @@ on:
   push:
     paths:
       - ".github/workflows/check-dependabot.yml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
       - "**/dependabot.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-dependabot.yml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
       - "**/dependabot.ya?ml"
   schedule:
@@ -26,6 +30,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-issue-templates.yml
+++ b/.github/workflows/check-issue-templates.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - ".github/workflows/check-issue-templates.yml"
       - "issue-templates/forms/**.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-issue-templates.yml"
       - "issue-templates/forms/**.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
   schedule:
     # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
@@ -26,6 +30,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -7,12 +7,16 @@ on:
       - ".github/workflows/check-labels.yml"
       - "workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json"
       - "workflow-templates/assets/sync-labels/*.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
   pull_request:
     paths:
       - ".github/workflows/check-labels.yml"
       - "workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json"
       - "workflow-templates/assets/sync-labels/*.ya?ml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
   schedule:
     # Run periodically to catch breakage caused by external changes.
@@ -28,6 +32,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-markdownlint.yml
+++ b/.github/workflows/check-markdownlint.yml
@@ -5,11 +5,15 @@ on:
   push:
     paths:
       - ".github/workflows/check-markdownlint.yml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
       - "**/.markdownlint*"
   pull_request:
     paths:
       - ".github/workflows/check-markdownlint.yml"
+      - "package.json"
+      - "package-lock.json"
       - "Taskfile.ya?ml"
       - "**/.markdownlint*"
   schedule:
@@ -26,6 +30,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2


### PR DESCRIPTION
These GitHub Actions workflows use the ajv-cli JSON schema validation tool to validate data files against their JSON schema. ajv-cli is an npm package-based tool.

A standard major version of Node.js, and thus its bundled npm should be used for all development and maintenance operations. Previously, these workflows did not explicitly configure the version of Node.js that should be used in the runner machine, so whatever version happened to be installed in the runner by default was used. That version doesn't necessarily match with the intended version, and the version could change at any moment, so this risked instability in the project infrastructure.