### PR TITLE
Update YAML filename matching pattern reference link

### DIFF
--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -13,8 +13,7 @@ on:
       - ".yamllint*"
       - "poetry.lock"
       - "pyproject.toml"
-      # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
-      # (used by Prettier)
+      # Source: https://github.com/ikatyang-collab/linguist-languages/blob/main/data/YAML.js (used by Prettier)
       - "**/.clang-format"
       - "**/.clang-tidy"
       - "**/.gemrc"
@@ -30,8 +29,7 @@ on:
       - ".yamllint*"
       - "poetry.lock"
       - "pyproject.toml"
-      # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
-      # (used by Prettier)
+      # Source: https://github.com/ikatyang-collab/linguist-languages/blob/main/data/YAML.js (used by Prettier)
       - "**/.clang-format"
       - "**/.clang-tidy"
       - "**/.gemrc"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -53,8 +53,7 @@ rules:
     check-keys: true
 
 yaml-files:
-  # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
-  # (used by Prettier)
+  # Source: https://github.com/ikatyang-collab/linguist-languages/blob/main/data/YAML.js (used by Prettier)
   - ".clang-format"
   - ".clang-tidy"
   - ".gemrc"

--- a/workflow-templates/assets/check-yaml/.yamllint.yml
+++ b/workflow-templates/assets/check-yaml/.yamllint.yml
@@ -53,8 +53,7 @@ rules:
     check-keys: true
 
 yaml-files:
-  # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
-  # (used by Prettier)
+  # Source: https://github.com/ikatyang-collab/linguist-languages/blob/main/data/YAML.js (used by Prettier)
   - ".clang-format"
   - ".clang-tidy"
   - ".gemrc"

--- a/workflow-templates/check-yaml-task.yml
+++ b/workflow-templates/check-yaml-task.yml
@@ -13,8 +13,7 @@ on:
       - ".yamllint*"
       - "poetry.lock"
       - "pyproject.toml"
-      # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
-      # (used by Prettier)
+      # Source: https://github.com/ikatyang-collab/linguist-languages/blob/main/data/YAML.js (used by Prettier)
       - "**/.clang-format"
       - "**/.clang-tidy"
       - "**/.gemrc"
@@ -30,8 +29,7 @@ on:
       - ".yamllint*"
       - "poetry.lock"
       - "pyproject.toml"
-      # Source: https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L8237-L8260
-      # (used by Prettier)
+      # Source: https://github.com/ikatyang-collab/linguist-languages/blob/main/data/YAML.js (used by Prettier)
       - "**/.clang-format"
       - "**/.clang-tidy"
       - "**/.gemrc"


### PR DESCRIPTION
Several significant files use the YAML language, but not the standard `.yml` or `.yaml` file extensions. In order to provide full coverage, "yamllint" and the paths filter of the "Check YAML" workflow must be configured with the patterns for these files.

A list of filename patterns for the YAML language is maintained in the "Linguist" project. Even though Linguist is not used by this infrastructure, the data from the Linguist source code serves as a reference from which the list of patterns was derived. In order to facilitate maintenance of the list of file patterns, comments were added to the yamllint configuration file and the "Check YAML" workflow providing a link to the reference.

In the Linguist project, the data for all programming languages is stored in a single data file, which makes that file less useful as a reference for a specific language, as is needed here.

The linguist-languages package is generated from the Linguist language data file, with a separate file for each language, so it serves as a more convenient reference. The linguist-languages package is automatically generated, and is used by Prettier, so it is likely to be actively maintained. For these reasons, previously that package was used in the reference link. However, during a recent review of the reference links it was found that it no longer worked. For this reason, it was replaced with a link to the less useful Linguist source code.

I have now performed an investigation into the situation with the linguist-languages package and found the new location of the content. So it is now possible to go back to using this superior reference. Several factors have resulted in the reference URL being different than before:

* Repository transferred to a new owner
* Default branch renamed
* Data format changed from JSON to JavaScript