### PR TITLE
Add reference link comment for Prettier filename matching patterns

### DIFF
--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -90,6 +90,13 @@ on:
       - "**.mkdn?"
       - "**.ronn"
       - "**.workbook"
+      # TOML
+      - "**/Cargo.lock"
+      - "**/Cargo.toml.orig"
+      - "**/Gopkg.lock"
+      - "**/Pipfile"
+      - "**/pdm.lock"
+      - "**.toml"
       # YAML
       - "**/.clang-format"
       - "**/.clang-tidy"
@@ -189,6 +196,13 @@ on:
       - "**.mkdn?"
       - "**.ronn"
       - "**.workbook"
+      # TOML
+      - "**/Cargo.lock"
+      - "**/Cargo.toml.orig"
+      - "**/Gopkg.lock"
+      - "**/Pipfile"
+      - "**/pdm.lock"
+      - "**.toml"
       # YAML
       - "**/.clang-format"
       - "**/.clang-tidy"

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ node_modules/
 /other/clang-format-configuration/testdata/golden/samples/
 /other/clang-format-configuration/testdata/input/samples/
 /other/clang-format-configuration/.clang-format
+poetry.lock

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,3 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-prettier-formatting/toml/.prettierrc.yml
+plugins:
+  - prettier-plugin-toml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -351,6 +351,7 @@ tasks:
       - |
         cp \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-javascript/.eslintrc.yml" \
+          "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-prettier-formatting/toml/.prettierrc.yml" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/general/.editorconfig" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-python/.flake8" \
           "{{.WORKFLOW_TEMPLATE_ASSETS_PATH}}/check-markdown/.markdownlint.yml" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "github-label-sync": "3.0.0",
         "markdown-link-check": "^3.13.7",
         "markdownlint-cli": "^0.45.0",
-        "prettier": "^3.5.3"
+        "prettier": "^3.5.3",
+        "prettier-plugin-toml": "^2.0.5"
       },
       "engines": {
         "node": "22.x"
@@ -380,6 +381,23 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/@taplo/core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@taplo/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-r8bl54Zj1In3QLkiW/ex694bVzpPJ9EhwqT9xkcUVODnVUGirdB1JTsmiIv0o1uwqZiwhi8xNnTOQBRQCpizrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@taplo/lib": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@taplo/lib/-/lib-0.5.0.tgz",
+      "integrity": "sha512-+xIqpQXJco3T+VGaTTwmhxLa51qpkQxCjRwezjFZgr+l21ExlywJFcDfTrNmL6lG6tqb0h8GyJKO3UPGPtSCWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@taplo/core": "^0.2.0"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -4605,6 +4623,25 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-toml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-toml/-/prettier-plugin-toml-2.0.5.tgz",
+      "integrity": "sha512-WjXXKQyY4TdXWHU1v73UJxK/oDLSppf+b9KrSVl2kC4ZOr9CIVPKTQ/JxttgbYMaH8r3ihw7WYhMpI1EFa1obg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@taplo/lib": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.3"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -6084,6 +6121,21 @@
       "dev": true,
       "requires": {
         "defer-to-connect": "^2.0.1"
+      }
+    },
+    "@taplo/core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@taplo/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-r8bl54Zj1In3QLkiW/ex694bVzpPJ9EhwqT9xkcUVODnVUGirdB1JTsmiIv0o1uwqZiwhi8xNnTOQBRQCpizrQ==",
+      "dev": true
+    },
+    "@taplo/lib": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@taplo/lib/-/lib-0.5.0.tgz",
+      "integrity": "sha512-+xIqpQXJco3T+VGaTTwmhxLa51qpkQxCjRwezjFZgr+l21ExlywJFcDfTrNmL6lG6tqb0h8GyJKO3UPGPtSCWg==",
+      "dev": true,
+      "requires": {
+        "@taplo/core": "^0.2.0"
       }
     },
     "@tootallnate/quickjs-emscripten": {
@@ -9017,6 +9069,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true
+    },
+    "prettier-plugin-toml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-toml/-/prettier-plugin-toml-2.0.5.tgz",
+      "integrity": "sha512-WjXXKQyY4TdXWHU1v73UJxK/oDLSppf+b9KrSVl2kC4ZOr9CIVPKTQ/JxttgbYMaH8r3ihw7WYhMpI1EFa1obg==",
+      "dev": true,
+      "requires": {
+        "@taplo/lib": "^0.5.0"
+      }
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "github-label-sync": "3.0.0",
     "markdown-link-check": "^3.13.7",
     "markdownlint-cli": "^0.45.0",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "prettier-plugin-toml": "^2.0.5"
   },
   "dependencies": {
     "js-yaml": "^4.1.0"

--- a/workflow-templates/assets/check-prettier-formatting/.prettierignore
+++ b/workflow-templates/assets/check-prettier-formatting/.prettierignore
@@ -1,3 +1,4 @@
 .licenses/
 __pycache__/
 node_modules/
+poetry.lock

--- a/workflow-templates/assets/check-prettier-formatting/toml/.prettierrc.yml
+++ b/workflow-templates/assets/check-prettier-formatting/toml/.prettierrc.yml
@@ -1,0 +1,3 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-prettier-formatting/toml/.prettierrc.yml
+plugins:
+  - prettier-plugin-toml

--- a/workflow-templates/check-prettier-formatting-task.md
+++ b/workflow-templates/check-prettier-formatting-task.md
@@ -8,6 +8,7 @@ Use [Prettier](https://prettier.io/docs/en/index.html) to check formatting. Supp
 - HTML
 - JSON
 - Markdown
+- TOML ([via plugin](#toml-support-optional))
 - YAML
 
 This is the version of the workflow for projects using the [Task](https://taskfile.dev/#/) task runner tool.
@@ -71,6 +72,25 @@ Add the following to [`/.gitignore`](https://git-scm.com/docs/gitignore):
 ```
 /node_modules/
 ```
+
+### TOML Support (Optional)
+
+If the project contains manually maintained [TOML](https://toml.io/) language files, some additional configuration is needed to add support to Prettier for this language.
+
+#### Assets
+
+- [`.prettierrc.yml`](assets/check-prettier-formatting/toml/.prettierrc.yml) - Prettier configuration file
+  - Install to: repository root.
+
+#### Dependencies
+
+Add the TOML support dependencies by running this command:
+
+```text
+npm install --save-dev prettier-plugin-toml@^2.0.2
+```
+
+Commit the resulting changes to the `package.json` and `package-lock.json` files.
 
 ### Readme badge
 

--- a/workflow-templates/check-prettier-formatting-task.yml
+++ b/workflow-templates/check-prettier-formatting-task.yml
@@ -90,6 +90,13 @@ on:
       - "**.mkdn?"
       - "**.ronn"
       - "**.workbook"
+      # TOML
+      - "**/Cargo.lock"
+      - "**/Cargo.toml.orig"
+      - "**/Gopkg.lock"
+      - "**/Pipfile"
+      - "**/pdm.lock"
+      - "**.toml"
       # YAML
       - "**/.clang-format"
       - "**/.clang-tidy"
@@ -189,6 +196,13 @@ on:
       - "**.mkdn?"
       - "**.ronn"
       - "**.workbook"
+      # TOML
+      - "**/Cargo.lock"
+      - "**/Cargo.toml.orig"
+      - "**/Gopkg.lock"
+      - "**/Pipfile"
+      - "**/pdm.lock"
+      - "**.toml"
       # YAML
       - "**/.clang-format"
       - "**/.clang-tidy"


### PR DESCRIPTION
Projects may use data files written in the [TOML](https://toml.io/) language. A common example of such is the [`pyproject.toml`](https://packaging.python.org/en/latest/specifications/pyproject-toml/) file present in projects that use the [**Poetry**](https://python-poetry.org/) Python package management tool (either for project code dependencies, or development tools).

In cases where the TOML content is edited directly by human contributors, it will be useful to provide code formatting infrastructure for TOML files, and to enforce consistent formatting. This is easily accomplished by adding TOML support to the existing code formatting infrastructure via the **prettier-plugin-toml** plugin for the **Prettier** formatting tool.

**Poetry**'s `poetry.lock` file is also written in the TOML language. This file is automatically generated and never manually edited. In this case, the automatically generated content is accepted as-is. So Prettier is [configured to exclude](https://prettier.io/docs/ignore) the `poetry.lock` file from formatting.