### PR TITLE
Remove obsolete instructions re: setting framework versions in workflows

### DIFF
--- a/workflow-templates/check-go-task.md
+++ b/workflow-templates/check-go-task.md
@@ -19,8 +19,6 @@ Install the [`check-go-task.yml`](check-go-task.yml) GitHub Actions workflow to 
 
 ### Configuration
 
-Configure the version of Go used for development of the project in the `env.GO_VERSION` field of `check-go-task.yml`.
-
 If the project contains Go modules in paths other than the root of the repository, add their paths to the [job matrices](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) of `check-go-task.yml` at:
 
 - `jobs.check-errors.strategy.matrix.module[].path`

--- a/workflow-templates/check-python-task.md
+++ b/workflow-templates/check-python-task.md
@@ -45,10 +45,6 @@ Commit the resulting `pyproject.toml` and `poetry.lock` files.
 
 ### Configuration
 
-#### Workflow
-
-Set the version of Python used by the project in the `env.PYTHON_VERSION` field of `check-python-task.yml`.
-
 #### black
 
 Add the following to `pyproject.toml`:

--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
@@ -27,6 +27,8 @@ Install the [`deploy-cobra-mkdocs-versioned-poetry.yml`](deploy-cobra-mkdocs-ver
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`Taskfile.yml`](assets/check-prettier-formatting-task/Taskfile.yml) - documentation formatting task.
   - Merge into `Taskfile.yml`
+- [`Taskfile.yml`](assets/poetry-task/Taskfile.yml) - Python package dependency management tasks.
+  - Merge into `Taskfile.yml`
 - [`docsgen`](assets/cobra/docsgen) - command line reference generator.
   - Install to: `docsgen/`
 

--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.md
@@ -38,8 +38,6 @@ See the ["Deploy Website" workflow (versioned, MkDocs, Poetry) documentation](de
 
 #### Workflow
 
-Configure the version of Go used for development of the project in the `env.GO_VERSION` field of `deploy-cobra-mkdocs-versioned-poetry.yml`.
-
 #### Taskfile
 
 Set the `PROJECT_NAME` variable to the project name.

--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -82,8 +82,10 @@ jobs:
       - name: Create all generated documentation content
         run: task docs:generate
 
-      - name: Install Python dependencies
-        run: poetry install --no-root
+      - name: Install Dependencies
+        run: |
+          task \
+            poetry:install-deps
 
       - name: Determine versioning parameters
         id: determine-versioning

--- a/workflow-templates/deploy-mkdocs-poetry.md
+++ b/workflow-templates/deploy-mkdocs-poetry.md
@@ -12,6 +12,8 @@ Install the [`deploy-mkdocs-poetry.yml`](deploy-mkdocs-poetry.yml) GitHub Action
 
 ### Assets
 
+- [`Taskfile.yml`](assets/poetry-task/Taskfile.yml) - Python package dependency management tasks.
+  - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`mkdocs.yml`](assets/mkdocs/mkdocs.yml) - base MkDocs configuration file.
   - Install to: repository root
 - [`icon_mac_light.png`](assets/mkdocs/icon_mac_light.png) - Arduino logo for the website. **NOTE**: only for use in official Arduino projects. Community projects should use [the Community Logo](https://www.arduino.cc/en/Trademark/CommunityLogo).

--- a/workflow-templates/deploy-mkdocs-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-poetry.yml
@@ -12,6 +12,7 @@ on:
       - "mkdocs.ya?ml"
       - "poetry.lock"
       - "pyproject.toml"
+      - "Taskfile.ya?ml"
       - "docs/**"
   workflow_dispatch:
   repository_dispatch:
@@ -31,11 +32,19 @@ jobs:
         with:
           python-version-file: pyproject.toml
 
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
       - name: Install Poetry
         run: pip install poetry
 
       - name: Install Dependencies
-        run: poetry install --no-root
+        run: |
+          task \
+            poetry:install-deps
 
       - name: Deploy website
         run: poetry run mkdocs gh-deploy

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.yml
@@ -13,6 +13,7 @@ on:
       - ".github/workflows/deploy-mkdocs-versioned-poetry.ya?ml"
       - "mkdocs.ya?ml"
       - "poetry.lock"
+      - "Taskfile.ya?ml"
       - "pyproject.toml"
   # Run on branch or tag creation (will be filtered by the publish-determination job).
   create:
@@ -58,13 +59,21 @@ jobs:
         with:
           python-version-file: pyproject.toml
 
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
 
-      - name: Install Python dependencies
-        run: poetry install --no-root
+      - name: Install Dependencies
+        run: |
+          task \
+            poetry:install-deps
 
       - name: Determine versioning parameters
         id: determine-versioning

--- a/workflow-templates/release-go-crosscompile-task.md
+++ b/workflow-templates/release-go-crosscompile-task.md
@@ -35,7 +35,6 @@ The following project-specific variables must be set/configured in `release-go-c
 
 - `PROJECT_NAME`
 - `AWS_PLUGIN_TARGET`
-- `GO_VERSION`: version of Go used for development of the project, use at least [GO 1.16 to be able to use 64-bit ARM architecture on macOS](https://tip.golang.org/doc/go1.16#ports)
 
 #### AWS IAM Role
 

--- a/workflow-templates/test-go-integration-task.md
+++ b/workflow-templates/test-go-integration-task.md
@@ -49,12 +49,6 @@ Commit the resulting `pyproject.toml` and `poetry.lock` files.
 
 ### Configuration
 
-#### Workflow
-
-Configure the version of Go used for development of the project in the `env.GO_VERSION` field of `test-go-integration-task.yml`.
-
-Configure the version of Python used for development of the project in the `env.PYTHON_VERSION` field of `test-go-integration-task.yml`.
-
 #### Test helpers
 
 Define the project's executable filename in the `executable_path` variable in `test_all.py`.

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -21,8 +21,6 @@ Install the [`test-go-task.yml`](test-go-task.yml) GitHub Actions workflow to `.
 
 #### Workflow
 
-Configure the version of Go used for development of the project in the `env.GO_VERSION` field of `test-go-task.yml`.
-
 If the project contains Go modules in paths other than the root of the repository, add their paths to the [job matrix](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) in `check-go-task.yml` at `jobs.test.strategy.matrix.module[].path` and the [Codecov flag](https://docs.codecov.com/docs/flags) to group their data under at `jobs.test.strategy.matrix.module[].codecov-flags`
 
 Replace `TODO_REPO_OWNER/TODO_REPO_NAME` with the repository's name (e.g., `arduino/arduino-cli`) in the `codecov/codecov-action` action's `fail_ci_if_error` input in `test-go-task.yml`.

--- a/workflow-templates/test-python-poetry-task.md
+++ b/workflow-templates/test-python-poetry-task.md
@@ -45,10 +45,6 @@ poetry add --dev "pytest@^8.4.1"
 
 Commit the resulting `pyproject.toml` and `poetry.lock` files.
 
-### Configuration
-
-Configure the version of Python used for development of the project in the `env.PYTHON_VERSION` field of `test-go-integration-task.yml`.
-
 ### Readme badge
 
 Markdown badge:


### PR DESCRIPTION
The [**Task** task runner tool](https://taskfile.dev/) is used to perform common development and maintenance operations in Arduino tooling projects.

One such operation is the installation of Python package dependencies using [**Poetry**](https://python-poetry.org/). The project website deployment workflows rely on Python packages, and so contain a step to install them. Previously, this was done by invoking [the **Poetry** command](https://python-poetry.org/docs/cli/#install) directly from the workflow. That is problematic because it means multiple copies of the command must be maintained, and the maintainer might easily overlook the need to do so for these workflows since we expect there to be only one instance of the command.

The workflows are hereby changed to use the standardized approach to installing Python package dependencies.