### PR TITLE
Correct constraint extraction code for Python not installed error message

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -827,9 +827,10 @@ tasks:
             -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
             -d "{{.INSTANCE_PATH}}"
 
-  # Print the version constraint for the project's Poetry tool dependency.
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
-  poetry:get-version:
+  poetry:install:
+    desc: Install Poetry
+    run: once
     cmds:
       - |
         if ! which yq &>/dev/null; then
@@ -838,24 +839,17 @@ tasks:
           exit 1
         fi
       - |
-        yq \
-          --input-format toml \
-          --output-format yaml \
-          '.tool.poetry.group.pipx.dependencies.poetry' \
-          < pyproject.toml
-
-  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
-  poetry:install:
-    desc: Install Poetry
-    run: once
-    vars:
-      POETRY_VERSION:
-        sh: task poetry:get-version
-    cmds:
-      - |
         if ! which python &>/dev/null; then
+        python_constraint="$( \
+            yq \
+              --input-format toml \
+              --output-format yaml \
+              '.tool.poetry.dependencies.python' \
+              < pyproject.toml
+          )"
+
           echo "Python not found or not in PATH."
-          echo "Please install a version of Python meeting the constraint {{.POETRY_VERSION}}:"
+          echo "Please install a version of Python satisfying the constraint ${python_constraint}:"
           echo "https://wiki.python.org/moin/BeginnersGuide/Download"
           exit 1
         fi
@@ -870,9 +864,18 @@ tasks:
           task utility:normalize-path \
             RAW_PATH="$(which python)" \
         )"
+
+        poetry_constraint="$( \
+            yq \
+              --input-format toml \
+              --output-format yaml \
+              '.tool.poetry.group.pipx.dependencies.poetry' \
+              < pyproject.toml
+          )"
+
         pipx install \
           --force \
-          "poetry=={{.POETRY_VERSION}}"
+          "poetry==$poetry_constraint"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:

--- a/workflow-templates/assets/poetry-task/Taskfile.yml
+++ b/workflow-templates/assets/poetry-task/Taskfile.yml
@@ -2,9 +2,10 @@
 version: "3"
 
 tasks:
-  # Print the version constraint for the project's Poetry tool dependency.
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
-  poetry:get-version:
+  poetry:install:
+    desc: Install Poetry
+    run: once
     cmds:
       - |
         if ! which yq &>/dev/null; then
@@ -13,24 +14,17 @@ tasks:
           exit 1
         fi
       - |
-        yq \
-          --input-format toml \
-          --output-format yaml \
-          '.tool.poetry.group.pipx.dependencies.poetry' \
-          < pyproject.toml
-
-  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
-  poetry:install:
-    desc: Install Poetry
-    run: once
-    vars:
-      POETRY_VERSION:
-        sh: task poetry:get-version
-    cmds:
-      - |
         if ! which python &>/dev/null; then
+        python_constraint="$( \
+            yq \
+              --input-format toml \
+              --output-format yaml \
+              '.tool.poetry.dependencies.python' \
+              < pyproject.toml
+          )"
+
           echo "Python not found or not in PATH."
-          echo "Please install a version of Python meeting the constraint {{.POETRY_VERSION}}:"
+          echo "Please install a version of Python satisfying the constraint ${python_constraint}:"
           echo "https://wiki.python.org/moin/BeginnersGuide/Download"
           exit 1
         fi
@@ -45,9 +39,18 @@ tasks:
           task utility:normalize-path \
             RAW_PATH="$(which python)" \
         )"
+
+        poetry_constraint="$( \
+            yq \
+              --input-format toml \
+              --output-format yaml \
+              '.tool.poetry.group.pipx.dependencies.poetry' \
+              < pyproject.toml
+          )"
+
         pipx install \
           --force \
-          "poetry=={{.POETRY_VERSION}}"
+          "poetry==$poetry_constraint"
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:


### PR DESCRIPTION
Some of the templates make use of Python packages. These dependencies are managed by the "Poetry" tool.

The templates provide a task for automatically installing the project's managed version of Poetry (https://github.com/arduino/tooling-project-assets/pull/604). Python is required to install Poetry (and to use it after installation), so this is a prerequisite for project contributors using the template locally. In order to make the project infrastructure more friendly for contributors, instead of failing with a cryptic error if Python is not installed, the task starts by checking whether Python is installed, and if not displays a friendly error message explaining the need to install it.

The project's standard Python version must later be available for use by Poetry, so it makes sense for the contributor to install that version of Python in this case, rather than installing an arbitrary version and then needing to install yet another copy later. For this reason, the task contains code to determine the version constraint for the Python dependency and include that information in the error message.

Previously that code extracted the version constraint for Poetry instead of for Python as intended, resulting in incorrect information in the error message. The code is hereby corrected to get the correct data.