### PR TITLE
Only install Python package dependencies from relevant group

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -520,6 +520,8 @@ tasks:
     desc: Check for commonly misspelled words
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run codespell
 
@@ -555,6 +557,8 @@ tasks:
     desc: Correct commonly misspelled words where possible
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run codespell --write-changes
 
@@ -898,6 +902,8 @@ tasks:
     desc: Format Python files
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run black .
 
@@ -906,6 +912,8 @@ tasks:
     desc: Lint Python code
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run flake8 --show-source
 
@@ -1012,5 +1020,7 @@ tasks:
     desc: Check for problems with YAML files
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run yamllint --format {{default "colored" .YAMLLINT_FORMAT}} .

--- a/workflow-templates/assets/check-mkdocs-task/Taskfile.yml
+++ b/workflow-templates/assets/check-mkdocs-task/Taskfile.yml
@@ -13,6 +13,8 @@ tasks:
     deps:
       - task: docs:generate
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run mkdocs build --strict
 
@@ -22,5 +24,7 @@ tasks:
     deps:
       - task: docs:generate
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run mkdocs serve

--- a/workflow-templates/assets/check-python-task/Taskfile.yml
+++ b/workflow-templates/assets/check-python-task/Taskfile.yml
@@ -7,6 +7,8 @@ tasks:
     desc: Format Python files
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run black .
 
@@ -15,5 +17,7 @@ tasks:
     desc: Lint Python code
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run flake8 --show-source

--- a/workflow-templates/assets/check-yaml-task/Taskfile.yml
+++ b/workflow-templates/assets/check-yaml-task/Taskfile.yml
@@ -7,5 +7,7 @@ tasks:
     desc: Check for problems with YAML files
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run yamllint --format {{default "colored" .YAMLLINT_FORMAT}} .

--- a/workflow-templates/assets/poetry-task/Taskfile.yml
+++ b/workflow-templates/assets/poetry-task/Taskfile.yml
@@ -54,11 +54,17 @@ tasks:
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:
-    desc: Install dependencies managed by Poetry
+    desc: |
+      Install dependencies managed by Poetry.
+      Environment variable parameters:
+      - POETRY_GROUPS: Poetry dependency groups to install (default: install all dependencies).
+    run: when_changed
     deps:
       - task: poetry:install
     cmds:
-      - poetry install --no-root
+      - |
+        poetry install \
+          {{if .POETRY_GROUPS}} --only {{.POETRY_GROUPS}} {{end}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:update-deps:

--- a/workflow-templates/assets/spell-check-task/Taskfile.yml
+++ b/workflow-templates/assets/spell-check-task/Taskfile.yml
@@ -7,6 +7,8 @@ tasks:
     desc: Check for commonly misspelled words
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run codespell
 
@@ -15,5 +17,7 @@ tasks:
     desc: Correct commonly misspelled words where possible
     deps:
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run codespell --write-changes

--- a/workflow-templates/assets/test-go-integration-task/Taskfile.yml
+++ b/workflow-templates/assets/test-go-integration-task/Taskfile.yml
@@ -8,5 +8,7 @@ tasks:
     deps:
       - task: go:build
       - task: poetry:install-deps
+        vars:
+          POETRY_GROUPS: dev
     cmds:
       - poetry run pytest tests


### PR DESCRIPTION
The [**Poetry**](https://python-poetry.org/) tool is used to manage the project's Python package dependencies.

Dependencies might be classified into distinct categories. The most basic classification would be:

- **Application dependencies**: used by the project's applications
- **Development dependencies**: tools used in the development and maintenance of the project, but not by the application

By default, **Poetry** installs all non-optional dependencies. This can be inefficient in a case where a specific operation is being performed, since a given operation might only require the dependencies from one category and so the installation of dependencies from the other is pointless for that operation.

For this reason, **Poetry** allows the user to organize dependencies into arbitrary "groups", and to specify which groups should be installed:

https://python-poetry.org/docs/managing-dependencies/#dependency-groups

The Python package installation task is hereby updated to allow dependency groups to be specified, and the calls to that task updated to specify the groups they require.

## Related

- https://github.com/arduino/arduinoOTA/pull/144