### PR TITLE
Only install Python package dependencies from relevant group

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -883,11 +883,16 @@ tasks:
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:
-    desc: Install dependencies managed by Poetry
+    desc: |
+      Install dependencies managed by Poetry.
+      Environment variable parameters:
+      - POETRY_GROUPS: Poetry dependency groups to install (default: install all dependencies).
     deps:
       - task: poetry:install
     cmds:
-      - poetry install --no-root
+      - |
+        poetry install \
+          {{if .POETRY_GROUPS}} --only {{.POETRY_GROUPS}} {{end}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:update-deps:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,6 +143,7 @@ tasks:
 
   # Check if ClangFormat is installed and the expected version
   clang-format:check-installed:
+    run: when_changed
     vars:
       EXPECTED_CLANG_FORMAT_VERSION: "{{default .DEFAULT_CLANG_FORMAT_VERSION .CLANG_FORMAT_VERSION}}"
     cmds:
@@ -731,6 +732,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:
     desc: Install dependencies managed by npm
+    run: when_changed
     dir: |
       "{{default "./" .PROJECT_PATH}}"
     cmds:
@@ -834,7 +836,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install:
     desc: Install Poetry
-    run: once
+    run: when_changed
     cmds:
       - |
         if ! which yq &>/dev/null; then
@@ -887,6 +889,7 @@ tasks:
       Install dependencies managed by Poetry.
       Environment variable parameters:
       - POETRY_GROUPS: Poetry dependency groups to install (default: install all dependencies).
+    run: when_changed
     deps:
       - task: poetry:install
     cmds:

--- a/workflow-templates/assets/check-markdown-task/Taskfile.yml
+++ b/workflow-templates/assets/check-markdown-task/Taskfile.yml
@@ -4,6 +4,7 @@ version: "3"
 tasks:
   docs:generate:
     desc: Create all generated documentation content
+    run: when_changed
     # This is an "umbrella" task used to call any documentation generation processes the project has.
     # It can be left empty if there are none.
 

--- a/workflow-templates/assets/check-mkdocs-task/Taskfile.yml
+++ b/workflow-templates/assets/check-mkdocs-task/Taskfile.yml
@@ -4,6 +4,7 @@ version: "3"
 tasks:
   docs:generate:
     desc: Create all generated documentation content
+    run: when_changed
     # This is an "umbrella" task used to call any documentation generation processes the project has.
     # It can be left empty if there are none.
 

--- a/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
+++ b/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
@@ -7,6 +7,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
   docs:generate:
     desc: Create all generated documentation content
+    run: when_changed
     deps:
       - task: go:cli-docs
     cmds:

--- a/workflow-templates/assets/npm-task/Taskfile.yml
+++ b/workflow-templates/assets/npm-task/Taskfile.yml
@@ -7,6 +7,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:
     desc: Install dependencies managed by npm
+    run: when_changed
     dir: |
       "{{default "./" .PROJECT_PATH}}"
     cmds:

--- a/workflow-templates/assets/poetry-task/Taskfile.yml
+++ b/workflow-templates/assets/poetry-task/Taskfile.yml
@@ -5,7 +5,7 @@ tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install:
     desc: Install Poetry
-    run: once
+    run: when_changed
     cmds:
       - |
         if ! which yq &>/dev/null; then


### PR DESCRIPTION
The [**Task** task runner tool](https://taskfile.dev/) is used to perform common development operations for the project.

[Tasks may call other tasks](https://taskfile.dev/usage/#calling-another-task). Under certain conditions (most commonly when running a convenience "umbrella" which calls all tasks of a general type), this can result in the same task being called redundantly, which is inefficient. Worse, since task calls specified via [the `deps` mapping](https://taskfile.dev/usage/#task-dependencies) of a task definition are executed concurrently, the multiple executions can conflict with each other and cause problems such as a spurious failure.

This can be avoided by configuring tasks which may be called multiple times, and for which it never makes sense to execute multiple times with the same conditions, so that all but the first call will be ignored:

https://taskfile.dev/usage/#limiting-when-tasks-run