### PR TITLE
Add source link for Go taskfile variables

### DIFF
--- a/workflow-templates/assets/go-task/Taskfile.yml
+++ b/workflow-templates/assets/go-task/Taskfile.yml
@@ -2,6 +2,7 @@
 version: "3"
 
 vars:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   # Path of the project's primary Go module:
   DEFAULT_GO_MODULE_PATH: ./
   DEFAULT_GO_PACKAGES:


### PR DESCRIPTION
Some of the tasks for Go-related templates rely on taskfile variables, which are provided by the "asset" taskfile. The `DEFAULT_GO_PACKAGES` variable is defined via some relatively complex code.

Documenting its source will facilitate project maintainers pulling in changes from development in this upstream repository, and also pushing back upstream fixes or enhancements that are made in the downstream project.