### PR TITLE
Update reference links in documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file
+# See: https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference#about-the-dependabotyml-file
 version: 2
 
 updates:

--- a/workflow-templates/assets/check-dependencies-task/Taskfile.yml
+++ b/workflow-templates/assets/check-dependencies-task/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
             echo "Please use Linux/macOS or download the dependencies cache from the GitHub Actions workflow artifact."
           else
             echo "licensed not found or not in PATH."
-            echo "Please install: https://github.com/github/licensed#as-an-executable"
+            echo "Please install: https://github.com/licensee/licensed#installation"
           fi
           exit 1
         fi

--- a/workflow-templates/assets/check-dependencies/AGPL-3.0/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/AGPL-3.0/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/main/docs/configuration.md
+# See: https://github.com/licensee/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/AGPL-3.0/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-dependencies/AGPL-3.0/README.md
+++ b/workflow-templates/assets/check-dependencies/AGPL-3.0/README.md
@@ -2,4 +2,4 @@
 
 This is a suggested list of allowed license types for dependencies of projects licensed under [`AGPL-3.0-only`](https://spdx.org/licenses/AGPL-3.0-only.html) or [`AGPL-3.0-or-later`](https://spdx.org/licenses/AGPL-3.0-or-later.html) license types.
 
-It is formatted for use in the configuration file of the [**Licensed**](https://github.com/github/licensed) dependency license checker tool.
+It is formatted for use in the configuration file of the [**Licensed**](https://github.com/licensee/licensed) dependency license checker tool.

--- a/workflow-templates/assets/check-dependencies/Apache-2.0/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/Apache-2.0/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/main/docs/configuration.md
+# See: https://github.com/licensee/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/Apache-2.0/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-dependencies/Apache-2.0/README.md
+++ b/workflow-templates/assets/check-dependencies/Apache-2.0/README.md
@@ -2,4 +2,4 @@
 
 This is a suggested list of allowed license types for dependencies of projects licensed under the [`Apache-2.0`](https://spdx.org/licenses/Apache-2.0.html) license.
 
-It is formatted for use in the configuration file of the [**Licensed**](https://github.com/github/licensed) dependency license checker tool.
+It is formatted for use in the configuration file of the [**Licensed**](https://github.com/licensee/licensed) dependency license checker tool.

--- a/workflow-templates/assets/check-dependencies/GPL-2.0/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/GPL-2.0/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/main/docs/configuration.md
+# See: https://github.com/licensee/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/GPL-2.0/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-dependencies/GPL-2.0/README.md
+++ b/workflow-templates/assets/check-dependencies/GPL-2.0/README.md
@@ -2,4 +2,4 @@
 
 This is a suggested list of allowed license types for dependencies of projects licensed under [`GPL-2.0-only`](https://spdx.org/licenses/GPL-2.0-only.html) or [`GPL-2.0-or-later`](https://spdx.org/licenses/GPL-2.0-or-later.html) license types.
 
-It is formatted for use in the configuration file of the [**Licensed**](https://github.com/github/licensed) dependency license checker tool.
+It is formatted for use in the configuration file of the [**Licensed**](https://github.com/licensee/licensed) dependency license checker tool.

--- a/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/main/docs/configuration.md
+# See: https://github.com/licensee/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/GPL-3.0/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-dependencies/GPL-3.0/README.md
+++ b/workflow-templates/assets/check-dependencies/GPL-3.0/README.md
@@ -2,4 +2,4 @@
 
 This is a suggested list of allowed license types for dependencies of projects licensed under [`GPL-3.0-only`](https://spdx.org/licenses/GPL-3.0-only.html) or [`GPL-3.0-or-later`](https://spdx.org/licenses/GPL-3.0-or-later.html) license types.
 
-It is formatted for use in the configuration file of the [**Licensed**](https://github.com/github/licensed) dependency license checker tool.
+It is formatted for use in the configuration file of the [**Licensed**](https://github.com/licensee/licensed) dependency license checker tool.

--- a/workflow-templates/assets/check-dependencies/LGPL-2.1/.licensed.yml
+++ b/workflow-templates/assets/check-dependencies/LGPL-2.1/.licensed.yml
@@ -1,4 +1,4 @@
-# See: https://github.com/github/licensed/blob/main/docs/configuration.md
+# See: https://github.com/licensee/licensed/blob/main/docs/configuration.md
 
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies/LGPL-2.1/.licensed.yml
 allowed:

--- a/workflow-templates/assets/check-dependencies/LGPL-2.1/README.md
+++ b/workflow-templates/assets/check-dependencies/LGPL-2.1/README.md
@@ -2,4 +2,4 @@
 
 This is a suggested list of allowed license types for dependencies of projects licensed under [`LGPL-2.1-only`](https://spdx.org/licenses/LGPL-2.1-only.html) or [`LGPL-2.1-or-later`](https://spdx.org/licenses/LGPL-2.1-or-later.html) license types.
 
-It is formatted for use in the configuration file of the [**Licensed**](https://github.com/github/licensed) dependency license checker tool.
+It is formatted for use in the configuration file of the [**Licensed**](https://github.com/licensee/licensed) dependency license checker tool.

--- a/workflow-templates/assets/check-dependencies/README.md
+++ b/workflow-templates/assets/check-dependencies/README.md
@@ -2,7 +2,7 @@
 
 This is a collection of suggested allowed license types for dependencies of projects licensed under a each common license type.
 
-They are formatted for use in the configuration file of the [**Licensed**](https://github.com/github/licensed) dependency license checker tool.
+They are formatted for use in the configuration file of the [**Licensed**](https://github.com/licensee/licensed) dependency license checker tool.
 
 ## Related information
 

--- a/workflow-templates/assets/dependabot/dependabot.yml
+++ b/workflow-templates/assets/dependabot/dependabot.yml
@@ -1,4 +1,4 @@
-# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file
+# See: https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference#about-the-dependabotyml-file
 version: 2
 
 updates:

--- a/workflow-templates/check-go-dependencies-task.md
+++ b/workflow-templates/check-go-dependencies-task.md
@@ -1,13 +1,13 @@
 # "Check Go Dependencies" workflow (Task)
 
-Use [**Licensed**](https://github.com/github/licensed) to check if the Go project has dependencies with incompatible licenses.
+Use [**Licensed**](https://github.com/licensee/licensed) to check if the Go project has dependencies with incompatible licenses.
 
 **Licensed** detects all dependencies of the project, detects their license types, and then checks them against a dependency license approval configuration.
 
 There are several options for configuring approvals. The most useful being:
 
-- [Allowed licenses](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md) - allow any dependency that has this license type.
-- [Reviewed dependency](https://github.com/github/licensed/blob/main/docs/configuration/reviewing_dependencies.md) - allow specific dependencies that don't pass the global allowed license configuration, but have been individually reviewed and found acceptable.
+- [Allowed licenses](https://github.com/licensee/licensed/blob/main/docs/configuration/allowed_licenses.md) - allow any dependency that has this license type.
+- [Reviewed dependency](https://github.com/licensee/licensed/blob/main/docs/configuration/reviewing_dependencies.md) - allow specific dependencies that don't pass the global allowed license configuration, but have been individually reviewed and found acceptable.
 
 ## Installation
 
@@ -28,15 +28,15 @@ Install the [`check-go-dependencies-task.yml`](check-go-dependencies-task.yml) G
 
 The **Licensed** tool is configured via `.licensed.yml` configuration file, located in the repository root folder:
 
-https://github.com/github/licensed/blob/main/docs/configuration.md
+https://github.com/licensee/licensed/blob/main/docs/configuration.md
 
 #### Project paths
 
-By default, the project in the root of the repository will be checked. If the project is in a subfolder of the repository or if the repository contains multiple projects with dependencies that should be checked then the path to each project should be defined via [`apps[*].source_path` keys](https://github.com/github/licensed/blob/main/docs/configuration/application_source.md#application-source-path) in `.licensed.yml`.
+By default, the project in the root of the repository will be checked. If the project is in a subfolder of the repository or if the repository contains multiple projects with dependencies that should be checked then the path to each project should be defined via [`apps[*].source_path` keys](https://github.com/licensee/licensed/blob/main/docs/configuration/application_source.md#application-source-path) in `.licensed.yml`.
 
 #### Allowed licenses
 
-A list of [allowed license types](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md) can be defined in the `.licensed.yml` configuration file under:
+A list of [allowed license types](https://github.com/licensee/licensed/blob/main/docs/configuration/allowed_licenses.md) can be defined in the `.licensed.yml` configuration file under:
 
 - The `allowed` key to apply to all projects.
 - The `apps[*].allowed` key to apply to a specific project.
@@ -102,7 +102,7 @@ Metadata about the license types of all dependencies is cached in the repository
 task general:cache-dep-licenses
 ```
 
-The necessary **Licensed** tool can be installed by following [these instructions](https://github.com/github/licensed#as-an-executable).
+The necessary **Licensed** tool can be installed by following [these instructions](https://github.com/licensee/licensed#installation).
 
 Unfortunately, **Licensed** does not have Windows support.
 
@@ -132,13 +132,13 @@ Approval can be based on:
 ```markdown
 A task and GitHub Actions workflow are provided here for checking the license types of Go project dependencies.
 
-On every push and pull request that affects relevant files, the CI workflow will use [**Licensed**](https://github.com/github/licensed) to check:
+On every push and pull request that affects relevant files, the CI workflow will use [**Licensed**](https://github.com/licensee/licensed) to check:
 
 - If the dependency licenses cache is up to date
 - If any of the project's dependencies have an unapproved license type.
 
 Approval can be based on:
 
-- [Allowed license type](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md)
-- [Individual dependency](https://github.com/github/licensed/blob/main/docs/configuration/reviewing_dependencies.md)
+- [Allowed license type](https://github.com/licensee/licensed/blob/main/docs/configuration/allowed_licenses.md)
+- [Individual dependency](https://github.com/licensee/licensed/blob/main/docs/configuration/reviewing_dependencies.md)
 ```

--- a/workflow-templates/check-npm-dependencies-task.md
+++ b/workflow-templates/check-npm-dependencies-task.md
@@ -1,13 +1,13 @@
 # "Check npm Dependencies" workflow (Task)
 
-Use [**Licensed**](https://github.com/github/licensed) to check if the project has [**npm**](https://www.npmjs.com/)-managed dependencies with incompatible licenses.
+Use [**Licensed**](https://github.com/licensee/licensed) to check if the project has [**npm**](https://www.npmjs.com/)-managed dependencies with incompatible licenses.
 
 **Licensed** detects all dependencies of the project, detects their license types, and then checks them against a dependency license approval configuration.
 
 There are several options for configuring approvals. The most useful being:
 
-- [Allowed licenses](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md) - allow any dependency that has this license type.
-- [Reviewed dependency](https://github.com/github/licensed/blob/main/docs/configuration/reviewing_dependencies.md) - allow specific dependencies that don't pass the global allowed license configuration, but have been individually reviewed and found acceptable.
+- [Allowed licenses](https://github.com/licensee/licensed/blob/main/docs/configuration/allowed_licenses.md) - allow any dependency that has this license type.
+- [Reviewed dependency](https://github.com/licensee/licensed/blob/main/docs/configuration/reviewing_dependencies.md) - allow specific dependencies that don't pass the global allowed license configuration, but have been individually reviewed and found acceptable.
 
 ## Installation
 
@@ -34,15 +34,15 @@ Install the [`check-npm-dependencies-task.yml`](check-npm-dependencies-task.yml)
 
 The **Licensed** tool is configured via `.licensed.yml` configuration file, located in the repository root folder:
 
-https://github.com/github/licensed/blob/main/docs/configuration.md
+https://github.com/licensee/licensed/blob/main/docs/configuration.md
 
 ##### Project paths
 
-By default, the project in the root of the repository will be checked. If the project is in a subfolder of the repository or if the repository contains multiple projects with dependencies that should be checked then the path to each project should be defined via [`apps[*].source_path` keys](https://github.com/github/licensed/blob/main/docs/configuration/application_source.md#application-source-path) in `.licensed.yml`.
+By default, the project in the root of the repository will be checked. If the project is in a subfolder of the repository or if the repository contains multiple projects with dependencies that should be checked then the path to each project should be defined via [`apps[*].source_path` keys](https://github.com/licensee/licensed/blob/main/docs/configuration/application_source.md#application-source-path) in `.licensed.yml`.
 
 ##### Allowed licenses
 
-A list of [allowed license types](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md) can be defined in the `.licensed.yml` configuration file under:
+A list of [allowed license types](https://github.com/licensee/licensed/blob/main/docs/configuration/allowed_licenses.md) can be defined in the `.licensed.yml` configuration file under:
 
 - The `allowed` key to apply to all projects.
 - The `apps[*].allowed` key to apply to a specific project.
@@ -137,7 +137,7 @@ Metadata about the license types of all dependencies is cached in the repository
 task general:cache-dep-licenses
 ```
 
-The necessary **Licensed** tool can be installed by following [these instructions](https://github.com/github/licensed#as-an-executable).
+The necessary **Licensed** tool can be installed by following [these instructions](https://github.com/licensee/licensed#installation).
 
 Unfortunately, **Licensed** does not have Windows support.
 
@@ -167,13 +167,13 @@ Approval can be based on:
 ```markdown
 A task and GitHub Actions workflow are provided here for checking the license types of [**npm**](https://www.npmjs.com/)-managed project dependencies.
 
-On every push and pull request that affects relevant files, the CI workflow will use [**Licensed**](https://github.com/github/licensed) to check:
+On every push and pull request that affects relevant files, the CI workflow will use [**Licensed**](https://github.com/licensee/licensed) to check:
 
 - If the dependency licenses cache is up to date
 - If any of the project's dependencies have an unapproved license type.
 
 Approval can be based on:
 
-- [Allowed license type](https://github.com/github/licensed/blob/main/docs/configuration/allowed_licenses.md)
-- [Individual dependency](https://github.com/github/licensed/blob/main/docs/configuration/reviewing_dependencies.md)
+- [Allowed license type](https://github.com/licensee/licensed/blob/main/docs/configuration/allowed_licenses.md)
+- [Individual dependency](https://github.com/licensee/licensed/blob/main/docs/configuration/reviewing_dependencies.md)
 ```


### PR DESCRIPTION
The documentation contains links to relevant information. Some of that information has been moved to a different location on the Internet since the time the comments were added.

The URLs are hereby updated to point to the current location of that content.