### PR TITLE
Make default npm project path configurable via taskfile variable

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,6 +9,9 @@ vars:
   CLANG_FORMAT_GOLDEN_TEST_DATA_FOLDER: "{{.CLANG_FORMAT_TEST_DATA_FOLDER}}/golden"
   # See: https://github.com/arduino/arduino-ide/blob/main/arduino-ide-extension/package.json
   DEFAULT_CLANG_FORMAT_VERSION: 14.0.0
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
+  # Path of the project's primary npm-managed project:
+  DEFAULT_NPM_PROJECT_PATH: ./
 
 tasks:
   check:
@@ -91,6 +94,8 @@ tasks:
       TEMPLATE_WORKFLOWS_DATA_PATH: "./workflow-templates/*.{yml,yaml}"
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - |
         wget \
@@ -571,6 +576,8 @@ tasks:
     desc: Format all supported files with Prettier
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - npx prettier --write .
 
@@ -684,6 +691,8 @@ tasks:
     deps:
       - task: docs:generate
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - |
         npx \
@@ -695,6 +704,8 @@ tasks:
     desc: Automatically correct linting violations in Markdown files where possible
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - npx markdownlint-cli --fix "**/*.md"
 
@@ -703,6 +714,8 @@ tasks:
     desc: Check for problems in Markdown files
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - npx markdownlint-cli "**/*.md"
 
@@ -735,10 +748,10 @@ tasks:
     desc: |
       Install dependencies managed by npm.
       Environment variable parameters:
-      - PROJECT_PATH: Path of the npm-managed project (default: "./").
+      - PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
     run: when_changed
     dir: |
-      "{{default "./" .PROJECT_PATH}}"
+      "{{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}"
     cmds:
       - npm install
 
@@ -749,7 +762,7 @@ tasks:
       Environment variable parameters:
       - PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
     dir: |
-      "{{default "./" .PROJECT_PATH}}"
+      "{{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}"
     cmds:
       - |
         npm \
@@ -762,7 +775,7 @@ tasks:
     desc: |
       Validate npm configuration files against their JSON schema.
       Environment variable parameters:
-      - PROJECT_PATH: Path of the npm-managed project (default: "./").
+      - PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
     deps:
       - task: npm:install-deps
     vars:
@@ -807,7 +820,7 @@ tasks:
       STYLELINTRC_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
       INSTANCE_PATH: >-
-        {{default "." .PROJECT_PATH}}/package.json
+        {{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}/package.json
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}

--- a/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
+++ b/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
@@ -10,6 +10,8 @@ tasks:
         sh: task utility:mktemp-file TEMPLATE="github-action-schema-XXXXXXXXXX.json"
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - |
         wget \

--- a/workflow-templates/assets/check-markdown-task/Taskfile.yml
+++ b/workflow-templates/assets/check-markdown-task/Taskfile.yml
@@ -39,6 +39,8 @@ tasks:
     deps:
       - task: docs:generate
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - |
         npx \
@@ -50,6 +52,8 @@ tasks:
     desc: Automatically correct linting violations in Markdown files where possible
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - npx markdownlint-cli --fix "**/*.md"
 
@@ -58,5 +62,7 @@ tasks:
     desc: Check for problems in Markdown files
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - npx markdownlint-cli "**/*.md"

--- a/workflow-templates/assets/check-npm-task/Taskfile.yml
+++ b/workflow-templates/assets/check-npm-task/Taskfile.yml
@@ -7,9 +7,9 @@ tasks:
     desc: |
       Fix problems with the npm configuration file.
       Environment variable parameters:
-      - PROJECT_PATH: Path of the npm-managed project (default: ./).
+      - PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
     dir: |
-      "{{default "./" .PROJECT_PATH}}"
+      "{{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}"
     cmds:
       - |
         npm \
@@ -22,7 +22,7 @@ tasks:
     desc: |
       Validate npm configuration files against their JSON schema.
       Environment variable parameters:
-      - PROJECT_PATH: Path of the npm-managed project (default: "./").
+      - PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
     deps:
       - task: npm:install-deps
     vars:
@@ -67,7 +67,7 @@ tasks:
       STYLELINTRC_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="stylelintrc-schema-XXXXXXXXXX.json"
       INSTANCE_PATH: >-
-        {{default "." .PROJECT_PATH}}/package.json
+        {{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}/package.json
     cmds:
       - wget --quiet --output-document="{{.SCHEMA_PATH}}" {{.SCHEMA_URL}}
       - wget --quiet --output-document="{{.AVA_SCHEMA_PATH}}" {{.AVA_SCHEMA_URL}}

--- a/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
+++ b/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
@@ -7,5 +7,7 @@ tasks:
     desc: Format all supported files with Prettier
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - npx prettier --write .

--- a/workflow-templates/assets/check-toc-task/Taskfile.yml
+++ b/workflow-templates/assets/check-toc-task/Taskfile.yml
@@ -11,6 +11,8 @@ tasks:
       - FILE_PATH: path to the file that contains the ToC.
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - |
         npx markdown-toc \

--- a/workflow-templates/assets/check-workflows-task/Taskfile.yml
+++ b/workflow-templates/assets/check-workflows-task/Taskfile.yml
@@ -13,6 +13,8 @@ tasks:
       WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
     deps:
       - task: npm:install-deps
+        vars:
+          PROJECT_PATH: ./
     cmds:
       - |
         wget \

--- a/workflow-templates/assets/npm-task/Taskfile.yml
+++ b/workflow-templates/assets/npm-task/Taskfile.yml
@@ -1,15 +1,20 @@
 # See: https://taskfile.dev/#/usage
 version: "3"
 
+vars:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
+  # Path of the project's primary npm-managed project:
+  DEFAULT_NPM_PROJECT_PATH: ./
+
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:
     desc: |
       Install dependencies managed by npm.
       Environment variable parameters:
-      - PROJECT_PATH: Path of the npm-managed project (default: "./").
+      - PROJECT_PATH: Path of the npm-managed project (default: {{.DEFAULT_NPM_PROJECT_PATH}}).
     run: when_changed
     dir: |
-      "{{default "./" .PROJECT_PATH}}"
+      "{{default .DEFAULT_NPM_PROJECT_PATH .PROJECT_PATH}}"
     cmds:
       - npm install

--- a/workflow-templates/assets/test-go-task/Taskfile.yml
+++ b/workflow-templates/assets/test-go-task/Taskfile.yml
@@ -9,7 +9,11 @@ vars:
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
   go:test:
-    desc: Run unit tests
+    desc: |
+      Run unit tests.
+      Environment variable parameters:
+      - GO_MODULE_PATH: Path of the Go module root (default: {{.DEFAULT_GO_MODULE_PATH}}).
+      - GO_PACKAGES: List of Go packages to test (default: all packages of the module).
     dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
     cmds:
       - |


### PR DESCRIPTION
A repository might contain multiple npm-managed projects. For this reason, the appropriate npm-managed tasks have a parameter environment variable that allows it to be configured for an arbitrary path, with the "Check npm" workflow having a job matrix of paths to pass.

Generally, even if there are multiple npm-managed projects, there will be one primary project that is most often the target of contributor operation. Since it would be inconvenient for the contributor to pass the environment variable path every time they want to run a task for that primary project, the tasks are configured to have a default path which is used if the variable is not defined by the user.

Since the primary npm-managed project would typically be in the root of the repository, the default value is set to the root. In the case where the primary npm-managed project is not in the root of the repository, the template installer will need to adjust this. Previously the default was hard coded in each individual task. The template will be made easier to install by defining the default in a single place via a friendly taskfile variable, following the convention already established by the templates for Go-based projects.