### PR TITLE
Increase timeout duration for link check

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -8,6 +8,7 @@
     }
   ],
   "retryOn429": true,
+  "timeout": "30s",
   "retryCount": 3,
   "aliveStatusCodes": [200, 206],
   "ignorePatterns": [

--- a/workflow-templates/assets/check-markdown/.markdown-link-check.json
+++ b/workflow-templates/assets/check-markdown/.markdown-link-check.json
@@ -8,6 +8,7 @@
     }
   ],
   "retryOn429": true,
+  "timeout": "30s",
   "retryCount": 3,
   "aliveStatusCodes": [200, 206]
 }


### PR DESCRIPTION
The "markdown-link-check" tool is used to check for broken links in the project's Markdown files.

In addition to the obvious case where a broken link is indicated by an HTTP response status code, the case where the server does not respond must also be covered. By default, "markdown-link-check" waits 10 s for a response, and considers the link broken if one was not received in that time. It has been found that it occasionally takes more than 10 s to receive a response from some functional links, and thus the default timeout value was resulting in disruptive false positives from the link check.

This is a pull from the downstream asset enhancement/fix: https://github.com/arduino/arduino-lint/pull/765

Related: https://github.com/arduino/arduino-cli/pull/1764