### PR TITLE
Print instructions for false positive resolution when spell check fails

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -599,7 +599,16 @@ tasks:
         vars:
           POETRY_GROUPS: dev
     cmds:
-      - poetry run codespell
+      - |
+        if
+          ! poetry run \
+            codespell
+        then
+          echo
+          echo "If this was a false positive, add the word to the ignore list. See:"
+          echo "https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md#false-positives"
+          exit 1
+        fi
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-files-task/Taskfile.yml
   general:check-symlinks:

--- a/workflow-templates/assets/spell-check-task/Taskfile.yml
+++ b/workflow-templates/assets/spell-check-task/Taskfile.yml
@@ -10,7 +10,16 @@ tasks:
         vars:
           POETRY_GROUPS: dev
     cmds:
-      - poetry run codespell
+      - |
+        if
+          ! poetry run \
+            codespell
+        then
+          echo
+          echo "If this was a false positive, add the word to the ignore list:"
+          echo "https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md#false-positives"
+          exit 1
+        fi
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
   general:correct-spelling:

--- a/workflow-templates/spell-check-task.md
+++ b/workflow-templates/spell-check-task.md
@@ -45,6 +45,8 @@ Commit the resulting changes to the `pyproject.toml` and `poetry.lock` files.
 
 If the repository contains generated or vendored files, they can be excluded from the check by adding them to the `skip` field in the `.codespellrc` configuration file.
 
+#### False positives
+
 In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.
 
 Reference:


### PR DESCRIPTION
The assets include infrastructure to check for commonly misspelled words in the project files.

Although the system is designed to reduce the incidence of false positives, they are still relatively common. For this reason, it is important to clearly communicate to the contributor how such false positives can be resolved. This can be accomplished effectively by printing instructions when the spell check fails.

In order to avoid excessive verbosity of the output (note that the failure could just as well be a true positive), the description of the procedure is maintained in the asset documentation and the output message simply provides the URL of that documentation.