### PR TITLE
Improve precomposed asset installation commit and PR messages

### DIFF
--- a/workflow-templates/check-action-metadata-task.md
+++ b/workflow-templates/check-action-metadata-task.md
@@ -76,17 +76,17 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ```text
 Add CI workflow to validate action.yml
 
-A task and GitHub Actions workflow are provided here for validating the action.yml metadata file of GitHub Actions
-actions.
+A task and GitHub Actions workflow are provided here to check for problems in the `action.yml` metadata file of GitHub Actions actions by validating it against the JSON schema.
 
-On every push or pull request that affects the metadata file, and periodically, validate action.yml against its JSON
-schema.
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-A task and GitHub Actions workflow are provided here for validating the [`action.yml`](https://docs.github.com/actions/creating-actions/metadata-syntax-for-github-actions) metadata file of [GitHub Actions actions](https://docs.github.com/actions/learn-github-actions/understanding-github-actions#actions).
+A task and GitHub Actions workflow are provided here to check for problems in the [`action.yml`](https://docs.github.com/actions/creating-actions/metadata-syntax-for-github-actions) metadata file of [GitHub Actions actions](https://docs.github.com/actions/learn-github-actions/understanding-github-actions#actions) by validating it against [the JSON schema](https://json.schemastore.org/github-action.json).
 
-On every push or pull request that affects the metadata file, and periodically, validate `action.yml` against [its JSON schema](https://json.schemastore.org/github-action.json).
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-files-task.md
+++ b/workflow-templates/check-files-task.md
@@ -61,9 +61,9 @@ Tasks are also added to check for problems with symbolic links ("symlinks") cont
 - Broken symlinks
 - Circular symlinks
 
-A GitHub Actions workflow is included to run the tasks on any change to the project files in order to avoid the
-introduction of problems with the project filesystem, and periodically in order to catch breakage caused by external
-changes.
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
@@ -81,5 +81,5 @@ Tasks are also added to check for problems with symbolic links ("symlinks") cont
 - Broken symlinks
 - Circular symlinks
 
-A GitHub Actions workflow is included to run the tasks on any change to the project files in order to avoid the introduction of problems with the project filesystem, and periodically in order to catch breakage caused by external changes.
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-general-formatting-task.md
+++ b/workflow-templates/check-general-formatting-task.md
@@ -49,14 +49,23 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to check general file formatting
+Add infrastructure for checking general file formatting
 
-On every push, pull request, and periodically, check whether the repository's files are formatted according to
-.editorconfig.
+The project's .editorconfig file defines the fundamental formatting style for use in the project files.
+
+A task is added to use the "editorconfig-checker" tool to verify the formatting of the project files is compliant.
+
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push, pull request, and periodically, use [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) check whether the repository's files are formatted according to [`.editorconfig`](https://editorconfig.org/).
+The project's [`.editorconfig`](https://editorconfig.org/) file defines the fundamental formatting style for use in the project files.
+
+A task is added to use the [**editorconfig-checker**](https://github.com/editorconfig-checker/editorconfig-checker) tool to verify the formatting of the project files is compliant.
+
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-go-dependencies-task.md
+++ b/workflow-templates/check-go-dependencies-task.md
@@ -112,11 +112,11 @@ An updated cache is also generated whenever the cache is found to be outdated by
 ## Commit message
 
 ```
-Add CI workflow to check for unapproved Go dependency licenses
+Add infrastructure to check for unapproved Go dependency licenses
 
-A task and GitHub Actions workflow are provided here for checking the license types of Go project dependencies.
+Tasks and a GitHub Actions workflow are added for checking the license types of Go project dependencies.
 
-On every push and pull request that affects relevant files, the CI workflow will check:
+On every push and pull request that affects relevant files, the CI workflow will run the tasks to check:
 
 - If the dependency licenses cache is up to date
 - If any of the project's dependencies have an unapproved license type.

--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           submodules: recursive
 
-      # This is required to allow licensee/setup-licensed to install licensed via Ruby gem.
+      # This is required to allow licensee/setup-licensed to install Licensed via Ruby gem.
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -135,7 +135,7 @@ jobs:
         with:
           submodules: recursive
 
-      # This is required to allow licensee/setup-licensed to install licensed via Ruby gem.
+      # This is required to allow licensee/setup-licensed to install Licensed via Ruby gem.
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/workflow-templates/check-go-task.md
+++ b/workflow-templates/check-go-task.md
@@ -50,25 +50,19 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to lint and check formatting of Go code
+Add infrastructure to lint and format Go code
 
-On every push and pull request that affects relevant files, check the Go module for:
+Tasks are provided to format and check for problems in the project's Go modules.
 
-- Common detectable errors in the code.
-- Use of outdated APIs
-- Code style violations
-- Code formatting inconsistency
-- Misconfiguration
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push and pull request that affects relevant files, check the repository's [Go](https://golang.org/) module for:
+Tasks are provided to format and check for problems in the project's [Go](https://golang.org/) modules.
 
-- Common detectable errors in the code.
-- Use of outdated APIs
-- Code style violations
-- Code formatting inconsistency
-- Misconfiguration
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-go-task.md
+++ b/workflow-templates/check-go-task.md
@@ -14,7 +14,7 @@ Install the [`check-go-task.yml`](check-go-task.yml) GitHub Actions workflow to 
   - Install to: repository root (or merge into the existing `Taskfile.yml`).
 - [`.golangci.yml`](assets/go/.golangci.yml) - Contains all the go-linting configurations.
   - Install to: repository root as `.golangci.yml`
-- [`Taskfile.yml`](assets/go-task/Taskfile.yml) - `DEFAULT_GO_MODULE_PATH` and `DEFAULT_GO_PACKAGES` variables
+- [`Taskfile.yml`](assets/go-task/Taskfile.yml) - `DEFAULT_GO_MODULE_PATH` and `DEFAULT_GO_PACKAGES` variables.
   - Merge into `Taskfile.yml`
 
 ### Configuration

--- a/workflow-templates/check-javascript-task.md
+++ b/workflow-templates/check-javascript-task.md
@@ -80,20 +80,21 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to lint JavaScript code
+Add infrastructure to lint JavaScript code
 
-On every push and pull request that affects relevant files, and periodically, run ESLint on the repository's JavaScript
-files.
+A task is provided to run ESLint on the project's JavaScript files.
 
-ESLint is configured via the .eslintrc.yml file:
-https://eslint.org/docs/latest/use/configure/configuration-files
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push and pull request that affects relevant files, and periodically, run [**ESLint**](https://eslint.org/) on the repository's JavaScript files.
+A task is provided to run [**ESLint**](https://eslint.org/) on the project's JavaScript files.
 
-**ESLint** is configured via the `.eslintrc.yml` file:
-https://eslint.org/docs/latest/use/configure/configuration-files
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-markdown-task.md
+++ b/workflow-templates/check-markdown-task.md
@@ -99,38 +99,27 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to check Markdown files for problems
+Add infrastructure to check for problems in Markdown files
 
-On every push and pull request that affects relevant files, and periodically, check the repository's Markdown files for
-problems:
+Tasks are provided to check for problems in the project's Markdown files:
 
 - Use markdownlint to check for common problems and formatting.
 - Use markdown-link-check to check for broken links.
 
-The Arduino tooling Markdown style is defined by the `.markdownlint.yml` file.
-
-In the event the repository contains externally maintained Markdown files, markdownlint can be configured to ignore them
-via a `.markdownlintignore` file:
-https://github.com/igorshubovych/markdownlint-cli#ignoring-files
-
-markdown-link-check is configured via the `.markdown-link-check.json` file:
-https://github.com/tcort/markdown-link-check#config-file-format
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push and pull request that affects relevant files, and periodically, check the repository's Markdown files for
-problems:
+Add infrastructure to check for problems in Markdown files
+
+Tasks are provided to check for problems in the project's Markdown files:
 
 - Use [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) to check for common problems and formatting.
 - Use [markdown-link-check](https://github.com/tcort/markdown-link-check) to check for broken links.
 
-The Arduino tooling Markdown style is defined by the `.markdownlint.yml` file.
-
-In the event the repository contains externally maintained Markdown files, markdownlint can be configured to ignore them via a `.markdownlintignore` file:
-https://github.com/igorshubovych/markdownlint-cli#ignoring-files
-
-markdown-link-check is configured via the `.markdown-link-check.json` file:
-https://github.com/tcort/markdown-link-check#config-file-format
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-npm-task.md
+++ b/workflow-templates/check-npm-task.md
@@ -63,19 +63,25 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to check for problems with npm configuration files
+Add infrastructure to check for problems with npm configuration files
 
-On every push and pull request that affects relevant files, and periodically:
+Tasks are provided to check for problems in the project's npm configuration files:
 
-- Validate package.json against its JSON schema.
-- Check for forgotten package-lock.json syncs.
+* Validate package.json against its JSON schema.
+* Check for forgotten package-lock.json syncs.
+
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push and pull request that affects relevant files, and periodically:
+Tasks are provided to check for problems in the project's npm configuration files:
 
 - Validate [`package.json`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json) against [its JSON schema](https://json.schemastore.org/package.json).
 - Check for forgotten [`package-lock.json`](https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json) syncs.
+
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-poetry-task.md
+++ b/workflow-templates/check-poetry-task.md
@@ -52,8 +52,9 @@ The tasks provide the following operations:
 * Update the `poetry.lock` file as may be required following manual modifications to `pyproject.toml`, or update of the
   "Poetry" application
 
-These tasks are executed by the GitHub Actions workflow on any push or pull request that modifies relevant files, and
-periodically to check for breakage caused by external changes.
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
@@ -68,5 +69,5 @@ The tasks provide the following operations:
 - Check for problems with the data structure of the [`pyproject.toml`](https://python-poetry.org/docs/pyproject/) Python project file
 - Update the `poetry.lock` file as may be required following manual modifications to `pyproject.toml`, or update of the **Poetry** application
 
-These tasks are executed by the GitHub Actions workflow on any push or pull request that modifies relevant files, and periodically to check for breakage caused by external changes.
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-prettier-formatting-task.md
+++ b/workflow-templates/check-prettier-formatting-task.md
@@ -115,14 +115,19 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to check for Prettier formatting compliance
+Add infrastructure for code formatting via Prettier
 
-On every push and pull request that affects relevant files, check whether the formatting of supported
-files is compliant with the Prettier style.
+A task is provided to format project files using the Prettier code formatting tool.
+
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push and pull request that affects relevant files, check whether the formatting of supported files is compliant with the [Prettier](https://prettier.io/docs/en/index.html) style.
+A task is provided to format project files using the [**Prettier**](https://prettier.io/docs/en/index.html) code formatting tool.
+
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-shell-task.md
+++ b/workflow-templates/check-shell-task.md
@@ -70,23 +70,29 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to check for problems with shell scripts
+Add infrastructure to check for problems with shell scripts
 
-On every push or pull request that modifies one of the shell scripts in the repository, and periodically, the workflow:
+Tasks are provided to facilitate the development of the project's shell scripts:
 
-- Runs ShellCheck to detect common problems.
-- Runs shfmt to check formatting.
-- Checks for forgotten executable script file permissions.
+- Detect common problems using ShellCheck.
+- Format using shfmt.
+- Check for forgotten executable script file permissions.
+
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push or pull request that modifies one of the shell scripts in the repository, and periodically, the workflow:
+Tasks are provided to facilitate the development of the project's shell scripts:
 
-- Runs [ShellCheck](https://github.com/koalaman/shellcheck) to detect common problems.
-- Runs [`shfmt`](https://github.com/mvdan/sh) to check formatting.
-- Checks for forgotten executable script file permissions.
+- Detect common problems using [**ShellCheck**](https://github.com/koalaman/shellcheck).
+- Format using [**shfmt**](https://github.com/mvdan/sh).
+- Check for forgotten executable script file permissions.
+
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## Usage

--- a/workflow-templates/check-taskfiles.md
+++ b/workflow-templates/check-taskfiles.md
@@ -76,12 +76,18 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ```
 Add CI workflow to validate Taskfiles
 
-On every push or pull request that affects the repository's Taskfiles, and periodically, validate them
-against the JSON schema.
+A GitHub Actions workflow is provided to automatically validate the project's Taskfiles against the JSON schema.
+
+The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external
+changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push or pull request that affects the repository's [Taskfiles](https://taskfile.dev/#/usage), and periodically, validate them against the JSON schema.
+A GitHub Actions workflow is provided to automatically validate the project's [Taskfiles](https://taskfile.dev/#/usage) against the JSON schema.
+
+The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
+
+On every push or pull request that affects the repository's [Taskfiles](https://taskfile.dev/#/usage), and periodically, validate them against [the JSON schema](https://taskfile.dev/schema.json).
 ```

--- a/workflow-templates/check-toc-task.md
+++ b/workflow-templates/check-toc-task.md
@@ -82,14 +82,19 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to check for missed updates to generated ToC
+Add infrastructure to generate a ToC
 
-On every push or pull request that affects the repository's Markdown files that contain a generated table of contents,
-check whether the table of contents matches the file structure.
+A task is provided to use the "markdown-toc" tool to generate a table of contents for Markdown files in the project.
+
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push or pull request that affects the repository's Markdown files that contain a generated table of contents, use [markdown-toc](https://github.com/jonschlinkert/markdown-toc) to check whether the table of contents matches the file structure.
+A task is provided to use the [**markdown-toc**](https://github.com/jonschlinkert/markdown-toc) tool to generate a table of contents for Markdown files in the project.
+
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-workflows-task.md
+++ b/workflow-templates/check-workflows-task.md
@@ -74,14 +74,20 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to validate GitHub Actions workflows
+Add infrastructure to validate GitHub Actions workflows
 
-On every push or pull request that affects the repository's GitHub Actions workflows, and periodically, validate them
-against the JSON schema.
+A task is provided to check for problems in the project's GitHub Actions workflows by validating them against the JSON
+schema.
+
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push or pull request that affects the repository's GitHub Actions workflows, and periodically, validate them against the JSON schema.
+A task is provided to check for problems in the project's GitHub Actions workflows by validating them against [the JSON schema](https://json.schemastore.org/github-workflow).
+
+A GitHub Actions workflow is included to automatically run the tasks. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/check-yaml-task.md
+++ b/workflow-templates/check-yaml-task.md
@@ -65,20 +65,19 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to lint YAML files
+Add infrastructure for linting YAML files
 
-On every push and pull request that affects relevant files, run yamllint to check the YAML files of
-the repository for issues.
+A task is provided to check for problems in the project's YAML files.
 
-The .yamllint.yml file is used to configure yamllint:
-https://yamllint.readthedocs.io/en/stable/configuration.html
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push and pull request that affects relevant files, run [`yamllint`](https://github.com/adrienverge/yamllint) to check the YAML files of the repository for issues.
+A task is provided to check for problems in the project's YAML files.
 
-The `.yamllint.yml` file is used to configure `yamllint`:
-https://yamllint.readthedocs.io/en/stable/configuration.html
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```

--- a/workflow-templates/spell-check-task.md
+++ b/workflow-templates/spell-check-task.md
@@ -75,20 +75,21 @@ Define the `{repository-owner}` and `{repository-name}` attributes and use them 
 ## Commit message
 
 ```
-Add CI workflow to check for commonly misspelled words
+Add infrastructure to check spelling
 
-On every push, pull request, and periodically, use codespell to check for commonly
-misspelled words.
+Tasks are provided to check for commonly misspelled words in the project files, and correct those misspellings.
 
-In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list`
-field of `.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the
-ignore list. The ignore list is comma-separated with no spaces.
+A GitHub Actions workflow is included to automatically run the spell check task. The workflow is triggered on any push
+or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem.
+It is also triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push, pull request, and periodically, use [codespell](https://github.com/codespell-project/codespell) to check for commonly misspelled words.
+Tasks are provided to check for commonly misspelled words in the project files, and correct those misspellings.
+
+A GitHub Actions workflow is included to automatically run the spell check task. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 
 In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.
 ```

--- a/workflow-templates/test-go-task.md
+++ b/workflow-templates/test-go-task.md
@@ -63,13 +63,19 @@ image:https://codecov.io/gh/{repository-owner}/{repository-name}/branch/main/gra
 ## Commit message
 
 ```
-Add CI workflow to test Go code
+Add infrastructure to test Go code
 
-On every push and pull request that affects relevant files, run the project's Go code tests.
+A task is provided to run the project's Go code tests.
+
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that
+changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also
+triggered periodically, in order to catch breakage caused by external changes.
 ```
 
 ## PR message
 
 ```markdown
-On every push and pull request that affects relevant files, run the project's [Go](https://golang.org/) code tests.
+A task is provided to run the project's [Go](https://golang.org/) code tests.
+
+A GitHub Actions workflow is included to automatically run the task. The workflow is triggered on any push or pull that changes relevant project files, in order to avoid the introduction of problems with the project filesystem. It is also triggered periodically, in order to catch breakage caused by external changes.
 ```


### PR DESCRIPTION
In order to facilitate asset installation, the installation instructions include precomposed commit and pull request messages, which can be copy and pasted by the installer.

The primordial origin of this repository was a collection of reusable GitHub Actions workflows for use in the repositories of Arduino libraries. In those projects, it is not common to make provisions for running the checks locally. For this reason, the precomposed messages in the original installation instructions focused exclusively on the GitHub Actions workflow. The installation instructions in this repository inherited that same focus. However, that approach makes less sense in this context where the primary assets are typically general purpose infrastructure, which may be used locally by the contributor in addition to its used by the companion GitHub Actions workflow.

The precomposed commit and PR messages are adjusted to more accurately communicate the true nature of the infrastructure being installed.