### PR TITLE
Remove trailing slash from path variable values

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
   # See: https://docs.github.com/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: github-actions
-    directory: /.github/workflows/
+    directory: /.github/workflows
     open-pull-requests-limit: 100
     schedule:
       cronjob: 0 12 * * *
@@ -18,7 +18,7 @@ updates:
 
   # Configure check for outdated GitHub Actions actions in workflow templates.
   - package-ecosystem: github-actions
-    directory: /workflow-templates/
+    directory: /workflow-templates
     open-pull-requests-limit: 100
     schedule:
       cronjob: 0 13 * * *

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -66,7 +66,7 @@ jobs:
       matrix:
         check-license:
           # TODO: Add additional paths where license files should be
-          - path: ./
+          - path: .
             # TODO: Define the project's license file name here:
             expected-filename: LICENSE.txt
             # SPDX identifier: https://spdx.org/licenses/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,7 +11,7 @@ vars:
   DEFAULT_CLANG_FORMAT_VERSION: 14.0.0
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   # Path of the project's primary npm-managed project:
-  DEFAULT_NPM_PROJECT_PATH: ./
+  DEFAULT_NPM_PROJECT_PATH: .
 
 tasks:
   check:
@@ -95,7 +95,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         wget \
@@ -396,7 +396,7 @@ tasks:
   config:sync:
     desc: Sync configuration files from templates
     vars:
-      REPOSITORY_ROOT_PATH: "./"
+      REPOSITORY_ROOT_PATH: "."
       WORKFLOW_TEMPLATE_ASSETS_PATH: "./workflow-templates/assets"
     cmds:
       - |
@@ -656,7 +656,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         npx \
@@ -788,7 +788,7 @@ tasks:
       - task: docs:generate
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         npx \
@@ -801,7 +801,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         npx \
@@ -815,7 +815,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         npx \

--- a/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
+++ b/workflow-templates/assets/check-action-metadata-task/Taskfile.yml
@@ -13,7 +13,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         wget \

--- a/workflow-templates/assets/check-markdown-task/Taskfile.yml
+++ b/workflow-templates/assets/check-markdown-task/Taskfile.yml
@@ -40,7 +40,7 @@ tasks:
       - task: docs:generate
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         npx \
@@ -53,7 +53,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         npx \
@@ -67,7 +67,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         npx \

--- a/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
+++ b/workflow-templates/assets/check-prettier-formatting-task/Taskfile.yml
@@ -8,7 +8,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         npx \

--- a/workflow-templates/assets/check-toc-task/Taskfile.yml
+++ b/workflow-templates/assets/check-toc-task/Taskfile.yml
@@ -12,7 +12,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         npx \

--- a/workflow-templates/assets/check-workflows-task/Taskfile.yml
+++ b/workflow-templates/assets/check-workflows-task/Taskfile.yml
@@ -14,7 +14,7 @@ tasks:
     deps:
       - task: npm:install-deps
         vars:
-          PROJECT_PATH: ./
+          PROJECT_PATH: .
     cmds:
       - |
         wget \

--- a/workflow-templates/assets/dependabot/dependabot.yml
+++ b/workflow-templates/assets/dependabot/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
   # See: https://docs.github.com/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: github-actions
-    directory: /.github/workflows/
+    directory: /.github/workflows
     open-pull-requests-limit: 100
     schedule:
       cronjob: 0 12 * * *

--- a/workflow-templates/assets/go-task/Taskfile.yml
+++ b/workflow-templates/assets/go-task/Taskfile.yml
@@ -4,7 +4,7 @@ version: "3"
 vars:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/go-task/Taskfile.yml
   # Path of the project's primary Go module:
-  DEFAULT_GO_MODULE_PATH: ./
+  DEFAULT_GO_MODULE_PATH: .
   DEFAULT_GO_PACKAGES:
     sh: |
       echo $(

--- a/workflow-templates/assets/npm-task/Taskfile.yml
+++ b/workflow-templates/assets/npm-task/Taskfile.yml
@@ -4,7 +4,7 @@ version: "3"
 vars:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   # Path of the project's primary npm-managed project:
-  DEFAULT_NPM_PROJECT_PATH: ./
+  DEFAULT_NPM_PROJECT_PATH: .
 
 tasks:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -65,7 +65,7 @@ jobs:
       matrix:
         module:
           # TODO: add paths of all Go modules here
-          - path: ./
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -107,7 +107,7 @@ jobs:
       matrix:
         module:
           # TODO: add paths of all Go modules here
-          - path: ./
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -151,7 +151,7 @@ jobs:
       matrix:
         module:
           # TODO: add paths of all Go modules here
-          - path: ./
+          - path: .
 
     steps:
       - name: Checkout repository
@@ -193,7 +193,7 @@ jobs:
       matrix:
         module:
           # TODO: add paths of all Go modules here
-          - path: ./
+          - path: .
 
     steps:
       - name: Checkout repository

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -66,7 +66,7 @@ jobs:
       matrix:
         check-license:
           # TODO: Add additional paths where license files should be
-          - path: ./
+          - path: .
             # TODO: Define the project's license file name here:
             expected-filename: LICENSE.txt
             # SPDX identifier: https://spdx.org/licenses/

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -74,7 +74,7 @@ jobs:
           - macos-latest
         module:
           # TODO: add paths of all Go modules here
-          - path: ./
+          - path: .
             codecov-flags: unit
 
     runs-on: ${{ matrix.operating-system }}


### PR DESCRIPTION
Paths in some workflows and tasks are configured via variables. Previously, when a value specified a folder path, a trailing slash was added. The intent behind this was to make it slightly more clear that the value was referring to a folder (e.g., `./` vs. `.`). However, this practice can be harmful in the case where the value is used as a base component in a path, as then it is most appropriate to omit the path separator in the concatenation code, which is at all clear (e.g., `FOO_PATH: foo/`, `{{.FOO_PATH}}bar` -> `foo/bar`). And if the separator is used in the concatenation
code, it results in a confusing double separator in the resulting path (e.g., `FOO_PATH: foo/`, `{{.FOO_PATH}}/bar` ->
`foo//bar`). The benefit of the trailing slash on the variable definition is miniscule at most, since the variable name, documentation, and other context should make it obvious that the value is a folder path. So the harm of this approach outweighs the benefit.

For this reason, it is better to omit the trailing slash in the variable definition (e.g., `FOO_PATH: foo`, `{{.FOO_PATH}}/bar` -> `foo/bar`). Even though this approach is not relevant in cases where the path is not used as a base component, it is best to be consistent in this practice.