### PR TITLE
Standardize formatting of shell code in tasks and workflows

### DIFF
--- a/.github/workflows/check-clang-format.yml
+++ b/.github/workflows/check-clang-format.yml
@@ -78,14 +78,14 @@ jobs:
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           if [[ "${{ github.event.inputs.clang-format-version }}" == "" ]]; then
-            echo "CLANG_FORMAT_VERSION=$(task clang-format:get-version)" >> "$GITHUB_ENV"
+            echo "CLANG_FORMAT_VERSION=$(task clang-format:get-version)" >>"$GITHUB_ENV"
           else
-            echo "CLANG_FORMAT_VERSION=${{ github.event.inputs.clang-format-version }}" >> "$GITHUB_ENV"
+            echo "CLANG_FORMAT_VERSION=${{ github.event.inputs.clang-format-version }}" >>"$GITHUB_ENV"
           fi
 
-          echo "CLANG_FORMAT_INSTALL_PATH=${{ runner.temp }}/clang-format" >> "$GITHUB_ENV"
-          echo "YQ_INSTALL_PATH=${{ runner.temp }}/yq" >> "$GITHUB_ENV"
-          echo "WORKING_FOLDER=${{ runner.temp }}" >> "$GITHUB_ENV"
+          echo "CLANG_FORMAT_INSTALL_PATH=${{ runner.temp }}/clang-format" >>"$GITHUB_ENV"
+          echo "YQ_INSTALL_PATH=${{ runner.temp }}/yq" >>"$GITHUB_ENV"
+          echo "WORKING_FOLDER=${{ runner.temp }}" >>"$GITHUB_ENV"
 
       - name: Download ClangFormat
         id: download-clang-format
@@ -106,7 +106,7 @@ jobs:
 
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.CLANG_FORMAT_INSTALL_PATH }}/clang_Linux_64bit" >> "$GITHUB_PATH"
+          echo "${{ env.CLANG_FORMAT_INSTALL_PATH }}/clang_Linux_64bit" >>"$GITHUB_PATH"
 
       - name: Download yq
         id: download-yq
@@ -126,7 +126,7 @@ jobs:
 
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.YQ_INSTALL_PATH }}/yq" >> "$GITHUB_PATH"
+          echo "${{ env.YQ_INSTALL_PATH }}/yq" >>"$GITHUB_PATH"
 
       - name: Check ClangFormat configuration file
         id: check
@@ -164,13 +164,13 @@ jobs:
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           if [[ "${{ github.event.inputs.clang-format-version }}" == "" ]]; then
-            echo "CLANG_FORMAT_VERSION=$(task clang-format:get-version)" >> "$GITHUB_ENV"
+            echo "CLANG_FORMAT_VERSION=$(task clang-format:get-version)" >>"$GITHUB_ENV"
           else
-            echo "CLANG_FORMAT_VERSION=${{ github.event.inputs.clang-format-version }}" >> "$GITHUB_ENV"
+            echo "CLANG_FORMAT_VERSION=${{ github.event.inputs.clang-format-version }}" >>"$GITHUB_ENV"
           fi
 
-          echo "CLANG_FORMAT_INSTALL_PATH=${{ runner.temp }}/clang-format" >> "$GITHUB_ENV"
-          echo "WORKING_FOLDER=${{ runner.temp }}" >> "$GITHUB_ENV"
+          echo "CLANG_FORMAT_INSTALL_PATH=${{ runner.temp }}/clang-format" >>"$GITHUB_ENV"
+          echo "WORKING_FOLDER=${{ runner.temp }}" >>"$GITHUB_ENV"
 
       - name: Download ClangFormat
         id: download
@@ -191,7 +191,7 @@ jobs:
 
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.CLANG_FORMAT_INSTALL_PATH }}/clang_Linux_64bit" >> "$GITHUB_PATH"
+          echo "${{ env.CLANG_FORMAT_INSTALL_PATH }}/clang_Linux_64bit" >>"$GITHUB_PATH"
 
       - name: Check ClangFormat output
         id: check
@@ -239,7 +239,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "CONVERSION_OUTPUT_PATH=${{ runner.temp }}/clang-format-js-object.txt" >> "$GITHUB_ENV"
+          echo "CONVERSION_OUTPUT_PATH=${{ runner.temp }}/clang-format-js-object.txt" >>"$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/check-files-task.yml
+++ b/.github/workflows/check-files-task.yml
@@ -35,7 +35,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check-filenames:
     needs: run-determination

--- a/.github/workflows/check-general-formatting-task.yml
+++ b/.github/workflows/check-general-formatting-task.yml
@@ -35,7 +35,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     needs: run-determination
@@ -48,7 +48,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >> "$GITHUB_ENV"
+          echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >>"$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -83,7 +83,7 @@ jobs:
 
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
+          echo "${{ env.EC_INSTALL_PATH }}/bin" >>"$GITHUB_PATH"
 
       - name: Check formatting
         run: |

--- a/.github/workflows/check-javascript-task.yml
+++ b/.github/workflows/check-javascript-task.yml
@@ -50,7 +50,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     needs: run-determination

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -50,7 +50,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check-license:
     name: ${{ matrix.check-license.path }}

--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -59,7 +59,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   lint:
     needs: run-determination

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -47,7 +47,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   validate:
     name: validate (${{ matrix.project.path }})

--- a/.github/workflows/check-poetry-task.yml
+++ b/.github/workflows/check-poetry-task.yml
@@ -44,7 +44,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   validate:
     needs: run-determination

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -244,7 +244,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     needs: run-determination

--- a/.github/workflows/check-python-task.yml
+++ b/.github/workflows/check-python-task.yml
@@ -53,7 +53,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   lint:
     needs: run-determination

--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -47,7 +47,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   lint:
     name: ${{ matrix.configuration.name }} (${{ matrix.script }})
@@ -82,7 +82,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >> "$GITHUB_ENV"
+          echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >>"$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -118,7 +118,7 @@ jobs:
 
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
+          echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >>"$GITHUB_PATH"
 
       - name: Run ShellCheck
         uses: liskin/gh-problem-matcher-wrap@v3
@@ -146,7 +146,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >> "$GITHUB_ENV"
+          echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >>"$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -180,7 +180,7 @@ jobs:
 
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.SHFMT_INSTALL_PATH }}" >> "$GITHUB_PATH"
+          echo "${{ env.SHFMT_INSTALL_PATH }}" >>"$GITHUB_PATH"
 
       - name: Format shell scripts
         run: |

--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -47,7 +47,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   validate:
     name: Validate ${{ matrix.file }}

--- a/.github/workflows/check-yaml-task.yml
+++ b/.github/workflows/check-yaml-task.yml
@@ -65,7 +65,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     name: ${{ matrix.configuration.name }}

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -35,7 +35,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   spellcheck:
     needs: run-determination

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
+          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >>"$GITHUB_ENV"
 
       - name: Determine whether to dry run
         id: dry-run
@@ -116,7 +116,7 @@ jobs:
         run: |
           # Use of this flag in the github-label-sync command will cause it to only check the validity of the
           # configuration.
-          echo "flag=--dry-run" >> $GITHUB_OUTPUT
+          echo "flag=--dry-run" >>$GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -142,7 +142,7 @@ jobs:
         run: |
           # Merge all configuration files
           shopt -s extglob
-          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) > "${{ env.MERGED_CONFIGURATION_PATH }}"
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) >"${{ env.MERGED_CONFIGURATION_PATH }}"
 
       - name: Install github-label-sync
         run: npm install

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "BINDIR=${{ runner.temp }}/custom-installation-folder" >> "$GITHUB_ENV"
+          echo "BINDIR=${{ runner.temp }}/custom-installation-folder" >>"$GITHUB_ENV"
 
       - name: Download script artifact
         uses: actions/download-artifact@v5
@@ -253,11 +253,11 @@ jobs:
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           FIRST_INSTALLATION_FOLDER="first-installation-folder"
-          echo "FIRST_INSTALLATION_FOLDER=${FIRST_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
-          echo "FIRST_BINDIR=${{ runner.temp }}/${FIRST_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
+          echo "FIRST_INSTALLATION_FOLDER=${FIRST_INSTALLATION_FOLDER}" >>"$GITHUB_ENV"
+          echo "FIRST_BINDIR=${{ runner.temp }}/${FIRST_INSTALLATION_FOLDER}" >>"$GITHUB_ENV"
           SECOND_INSTALLATION_FOLDER="second-installation-folder"
-          echo "SECOND_INSTALLATION_FOLDER=${SECOND_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
-          echo "SECOND_BINDIR=${{ runner.temp }}/${SECOND_INSTALLATION_FOLDER}" >> "$GITHUB_ENV"
+          echo "SECOND_INSTALLATION_FOLDER=${SECOND_INSTALLATION_FOLDER}" >>"$GITHUB_ENV"
+          echo "SECOND_BINDIR=${{ runner.temp }}/${SECOND_INSTALLATION_FOLDER}" >>"$GITHUB_ENV"
 
       - name: Download script artifact
         uses: actions/download-artifact@v5
@@ -290,7 +290,7 @@ jobs:
         shell: bash
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.FIRST_BINDIR }}" >> "$GITHUB_PATH"
+          echo "${{ env.FIRST_BINDIR }}" >>"$GITHUB_PATH"
 
       - name: Check script output with previous installation in PATH (non-Windows)
         if: runner.os != 'Windows'

--- a/.github/workflows/test-python-poetry-task.yml
+++ b/.github/workflows/test-python-poetry-task.yml
@@ -49,7 +49,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   test:
     needs: run-determination

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -270,13 +270,13 @@ tasks:
         # Add source comment
         echo \
           "# Source: https://github.com/arduino/tooling-project-assets/tree/main/other/clang-format-configuration" \
-        > "{{.TARGET_PATH}}"
+        >"{{.TARGET_PATH}}"
 
         # Dump the effective configuration to the target file
         clang-format \
           --dump-config \
           --style=file:"{{.CLANG_FORMAT_CONFIGURATION_PATH}}" \
-        >> "{{.TARGET_PATH}}"
+        >>"{{.TARGET_PATH}}"
 
       - |
         # Correct invalid `BasedOnStyle` key value
@@ -518,17 +518,16 @@ tasks:
           -type d -name 'node_modules' -prune -o \
           -exec \
             sh \
-              -c \
-                ' \
-                  basename "$0" \
-                  | \
-                  grep \
-                    --extended-regexp \
-                    --regexp='"'"'([<>:"/\\|?*'"'"'"$(printf "\001-\037")"'"'"'])|(.+\.$)'"'"' \
-                    --silent \
-                  && \
-                  echo "$0"
-                ' \
+              -c ' \
+                basename "$0" \
+                | \
+                grep \
+                  --extended-regexp \
+                  --regexp='"'"'([<>:"/\\|?*'"'"'"$(printf "\001-\037")"'"'"'])|(.+\.$)'"'"' \
+                  --silent \
+                && \
+                echo "$0"
+              ' \
               '{}' \
             \; \
           -execdir \
@@ -551,18 +550,17 @@ tasks:
           -type d -name 'node_modules' -prune -o \
           -exec \
             sh \
-              -c \
-                ' \
-                  basename "$0" \
-                  | \
-                  grep \
-                    --ignore-case \
-                    --extended-regexp \
-                    --regexp='"'"'^(con|prn|aux|nul|com[0-9]+|lpt[0-9]+)$'"'"' \
-                    --silent \
-                  && \
-                  echo "$0"
-                ' \
+              -c ' \
+                basename "$0" \
+                | \
+                grep \
+                  --ignore-case \
+                  --extended-regexp \
+                  --regexp='"'"'^(con|prn|aux|nul|com[0-9]+|lpt[0-9]+)$'"'"' \
+                  --silent \
+                && \
+                echo "$0"
+              ' \
               '{}' \
             \; \
           -execdir \
@@ -978,12 +976,12 @@ tasks:
           ! which python \
           &>/dev/null
         then
-        python_constraint="$( \
+          python_constraint="$( \
             yq \
               --input-format toml \
               --output-format yaml \
               '.tool.poetry.dependencies.python' \
-            < pyproject.toml
+            <pyproject.toml
           )"
 
           echo "Python not found or not in PATH."
@@ -1007,12 +1005,12 @@ tasks:
         )"
 
         poetry_constraint="$( \
-            yq \
-              --input-format toml \
-              --output-format yaml \
-              '.tool.poetry.group.pipx.dependencies.poetry' \
-            < pyproject.toml
-          )"
+          yq \
+            --input-format toml \
+            --output-format yaml \
+            '.tool.poetry.group.pipx.dependencies.poetry' \
+          <pyproject.toml
+        )"
 
         pipx install \
           --force \

--- a/workflow-templates/assets/check-files-task/Taskfile.yml
+++ b/workflow-templates/assets/check-files-task/Taskfile.yml
@@ -14,17 +14,16 @@ tasks:
           -type d -name 'node_modules' -prune -o \
           -exec \
             sh \
-              -c \
-                ' \
-                  basename "$0" \
-                  | \
-                  grep \
-                    --extended-regexp \
-                    --regexp='"'"'([<>:"/\\|?*'"'"'"$(printf "\001-\037")"'"'"'])|(.+\.$)'"'"' \
-                    --silent \
-                  && \
-                  echo "$0"
-                ' \
+              -c ' \
+                basename "$0" \
+                | \
+                grep \
+                  --extended-regexp \
+                  --regexp='"'"'([<>:"/\\|?*'"'"'"$(printf "\001-\037")"'"'"'])|(.+\.$)'"'"' \
+                  --silent \
+                && \
+                echo "$0"
+              ' \
               '{}' \
             \; \
           -execdir \
@@ -47,18 +46,17 @@ tasks:
           -type d -name 'node_modules' -prune -o \
           -exec \
             sh \
-              -c \
-                ' \
-                  basename "$0" \
-                  | \
-                  grep \
-                    --ignore-case \
-                    --extended-regexp \
-                    --regexp='"'"'^(con|prn|aux|nul|com[0-9]+|lpt[0-9]+)$'"'"' \
-                    --silent \
-                  && \
-                  echo "$0"
-                ' \
+              -c ' \
+                basename "$0" \
+                | \
+                grep \
+                  --ignore-case \
+                  --extended-regexp \
+                  --regexp='"'"'^(con|prn|aux|nul|com[0-9]+|lpt[0-9]+)$'"'"' \
+                  --silent \
+                && \
+                echo "$0"
+              ' \
               '{}' \
             \; \
           -execdir \

--- a/workflow-templates/assets/poetry-task/Taskfile.yml
+++ b/workflow-templates/assets/poetry-task/Taskfile.yml
@@ -21,12 +21,12 @@ tasks:
           ! which python \
           &>/dev/null
         then
-        python_constraint="$( \
+          python_constraint="$( \
             yq \
               --input-format toml \
               --output-format yaml \
               '.tool.poetry.dependencies.python' \
-            < pyproject.toml
+            <pyproject.toml
           )"
 
           echo "Python not found or not in PATH."
@@ -50,12 +50,12 @@ tasks:
         )"
 
         poetry_constraint="$( \
-            yq \
-              --input-format toml \
-              --output-format yaml \
-              '.tool.poetry.group.pipx.dependencies.poetry' \
-            < pyproject.toml
-          )"
+          yq \
+            --input-format toml \
+            --output-format yaml \
+            '.tool.poetry.group.pipx.dependencies.poetry' \
+          <pyproject.toml
+        )"
 
         pipx install \
           --force \

--- a/workflow-templates/check-action-metadata-task.yml
+++ b/workflow-templates/check-action-metadata-task.yml
@@ -49,7 +49,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   validate:
     needs: run-determination

--- a/workflow-templates/check-certificates.yml
+++ b/workflow-templates/check-certificates.yml
@@ -60,7 +60,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check-certificates:
     name: ${{ matrix.certificate.identifier }}
@@ -83,7 +83,7 @@ jobs:
       - name: Set certificate path environment variable
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "CERTIFICATE_PATH=${{ runner.temp }}/certificate.p12" >> "$GITHUB_ENV"
+          echo "CERTIFICATE_PATH=${{ runner.temp }}/certificate.p12" >>"$GITHUB_ENV"
 
       - name: Decode certificate
         env:
@@ -181,7 +181,7 @@ jobs:
           echo "Certificate expiration date: $EXPIRATION_DATE"
           echo "Days remaining before expiration: $DAYS_BEFORE_EXPIRATION"
 
-          echo "days=$DAYS_BEFORE_EXPIRATION" >> $GITHUB_OUTPUT
+          echo "days=$DAYS_BEFORE_EXPIRATION" >>$GITHUB_OUTPUT
 
       - name: Check if expiration notification period has been reached
         id: check-expiration

--- a/workflow-templates/check-files-task.yml
+++ b/workflow-templates/check-files-task.yml
@@ -35,7 +35,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check-filenames:
     needs: run-determination

--- a/workflow-templates/check-general-formatting-task.yml
+++ b/workflow-templates/check-general-formatting-task.yml
@@ -35,7 +35,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     needs: run-determination
@@ -48,7 +48,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >> "$GITHUB_ENV"
+          echo "EC_INSTALL_PATH=${{ runner.temp }}/editorconfig-checker" >>"$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -83,7 +83,7 @@ jobs:
 
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.EC_INSTALL_PATH }}/bin" >> "$GITHUB_PATH"
+          echo "${{ env.EC_INSTALL_PATH }}/bin" >>"$GITHUB_PATH"
 
       - name: Check formatting
         run: |

--- a/workflow-templates/check-go-dependencies-task.yml
+++ b/workflow-templates/check-go-dependencies-task.yml
@@ -53,7 +53,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check-cache:
     needs: run-determination

--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -49,7 +49,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check-outdated:
     name: check-outdated (${{ matrix.module.path }})

--- a/workflow-templates/check-javascript-task.yml
+++ b/workflow-templates/check-javascript-task.yml
@@ -50,7 +50,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     needs: run-determination

--- a/workflow-templates/check-license.yml
+++ b/workflow-templates/check-license.yml
@@ -50,7 +50,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check-license:
     name: ${{ matrix.check-license.path }}

--- a/workflow-templates/check-markdown-task.yml
+++ b/workflow-templates/check-markdown-task.yml
@@ -59,7 +59,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   lint:
     needs: run-determination

--- a/workflow-templates/check-mkdocs-task.yml
+++ b/workflow-templates/check-mkdocs-task.yml
@@ -49,7 +49,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     needs: run-determination

--- a/workflow-templates/check-npm-dependencies-task.yml
+++ b/workflow-templates/check-npm-dependencies-task.yml
@@ -55,7 +55,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check-cache:
     needs: run-determination

--- a/workflow-templates/check-npm-task.yml
+++ b/workflow-templates/check-npm-task.yml
@@ -47,7 +47,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   validate:
     name: validate (${{ matrix.project.path }})

--- a/workflow-templates/check-poetry-task.yml
+++ b/workflow-templates/check-poetry-task.yml
@@ -44,7 +44,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   validate:
     needs: run-determination

--- a/workflow-templates/check-prettier-formatting-task.yml
+++ b/workflow-templates/check-prettier-formatting-task.yml
@@ -244,7 +244,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     needs: run-determination

--- a/workflow-templates/check-python-task.yml
+++ b/workflow-templates/check-python-task.yml
@@ -53,7 +53,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   lint:
     needs: run-determination

--- a/workflow-templates/check-shell-task.yml
+++ b/workflow-templates/check-shell-task.yml
@@ -47,7 +47,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   lint:
     name: ${{ matrix.configuration.name }} (${{ matrix.script }})
@@ -83,7 +83,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >> "$GITHUB_ENV"
+          echo "INSTALL_PATH=${{ runner.temp }}/shellcheck" >>"$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -119,7 +119,7 @@ jobs:
 
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >> "$GITHUB_PATH"
+          echo "${{ env.INSTALL_PATH }}/$EXTRACTION_FOLDER" >>"$GITHUB_PATH"
 
       - name: Run ShellCheck
         uses: liskin/gh-problem-matcher-wrap@v3
@@ -148,7 +148,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >> "$GITHUB_ENV"
+          echo "SHFMT_INSTALL_PATH=${{ runner.temp }}/shfmt" >>"$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -182,7 +182,7 @@ jobs:
 
           # Add installation to PATH:
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-system-path
-          echo "${{ env.SHFMT_INSTALL_PATH }}" >> "$GITHUB_PATH"
+          echo "${{ env.SHFMT_INSTALL_PATH }}" >>"$GITHUB_PATH"
 
       - name: Format shell scripts
         run: |

--- a/workflow-templates/check-taskfiles.yml
+++ b/workflow-templates/check-taskfiles.yml
@@ -47,7 +47,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   validate:
     name: Validate ${{ matrix.file }}

--- a/workflow-templates/check-toc-task.yml
+++ b/workflow-templates/check-toc-task.yml
@@ -49,7 +49,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     name: ${{ matrix.file.name }}

--- a/workflow-templates/check-yaml-task.yml
+++ b/workflow-templates/check-yaml-task.yml
@@ -65,7 +65,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   check:
     name: ${{ matrix.configuration.name }}

--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -45,7 +45,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   publish:
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
 
       - name: Determine versioning parameters
         id: determine-versioning
-        run: echo "data=$(poetry run python docs/siteversion/siteversion.py)" >> $GITHUB_OUTPUT
+        run: echo "data=$(poetry run python docs/siteversion/siteversion.py)" >>$GITHUB_OUTPUT
 
       - name: Publish documentation
         if: fromJson(steps.determine-versioning.outputs.data).version != null

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.yml
@@ -41,7 +41,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   publish:
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
 
       - name: Determine versioning parameters
         id: determine-versioning
-        run: echo "data=$(poetry run python docs/siteversion/siteversion.py)" >> $GITHUB_OUTPUT
+        run: echo "data=$(poetry run python docs/siteversion/siteversion.py)" >>$GITHUB_OUTPUT
 
       - name: Publish documentation
         if: fromJson(steps.determine-versioning.outputs.data).version != null

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >>"$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -225,7 +225,7 @@ jobs:
         working-directory: ${{ env.DIST_DIR }}
         run: |
           TAG="nightly-$(date -u +"%Y%m%d")"
-          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt
+          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >${TAG}-checksums.txt
 
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -54,7 +54,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   package-name-prefix:
     needs: run-determination
@@ -73,7 +73,7 @@ jobs:
           fi
           PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.sha }}-"
 
-          echo "prefix=$PACKAGE_NAME_PREFIX" >> $GITHUB_OUTPUT
+          echo "prefix=$PACKAGE_NAME_PREFIX" >>$GITHUB_OUTPUT
 
   build:
     needs: package-name-prefix
@@ -156,12 +156,11 @@ jobs:
             -a \
             artifacts=($(ls -d */))
 
-          for artifact in ${artifacts[@]}
-          do
+          for artifact in ${artifacts[@]}; do
             cd $artifact
             checksum=$(sha256sum ${{ env.PROJECT_NAME }}_${TAG}*)
             cd ..
-            echo $checksum >> ${TAG}-checksums.txt
+            echo $checksum >>${TAG}-checksums.txt
           done
 
       - name: Upload checksum artifact

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -105,10 +105,10 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >>"$GITHUB_ENV"
 
           TAG="${GITHUB_REF/refs\/tags\//}"
-          echo "PACKAGE_FILENAME=${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}" >> $GITHUB_ENV
+          echo "PACKAGE_FILENAME=${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}" >>$GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -234,7 +234,7 @@ jobs:
         working-directory: ${{ env.DIST_DIR }}
         run: |
           TAG="${GITHUB_REF/refs\/tags\//}"
-          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt
+          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >${TAG}-checksums.txt
 
       - name: Identify Prerelease
         # This is a workaround while waiting for create-release action

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -100,9 +100,10 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >>"$GITHUB_ENV"
+
           TAG="${GITHUB_REF/refs\/tags\//}"
-          echo "PACKAGE_FILENAME=${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}" >> $GITHUB_ENV
+          echo "PACKAGE_FILENAME=${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}" >>$GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -120,7 +121,8 @@ jobs:
           # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
           KEYCHAIN_PASSWORD: keychainpassword
         run: |
-          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
+          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode >"${{ env.INSTALLER_CERT_MAC_PATH }}"
+
           security create-keychain \
             -p "${{ env.KEYCHAIN_PASSWORD }}" \
             "${{ env.KEYCHAIN }}"
@@ -227,7 +229,7 @@ jobs:
         working-directory: ${{ env.DIST_DIR }}
         run: |
           TAG="${GITHUB_REF/refs\/tags\//}"
-          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt
+          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* >${TAG}-checksums.txt
 
       - name: Identify Prerelease
         # This is a workaround while waiting for create-release action
@@ -256,7 +258,7 @@ jobs:
             )" != \
             "" \
           ]]; then
-            echo "IS_PRE=true" >> $GITHUB_OUTPUT
+            echo "IS_PRE=true" >>$GITHUB_OUTPUT
           fi
 
       - name: Create Github Release and upload artifacts

--- a/workflow-templates/release-tag.yml
+++ b/workflow-templates/release-tag.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "CHANGELOG_PATH=${{ runner.temp }}/CHANGELOG.md" >> "$GITHUB_ENV"
-          echo "SEMVER_TOOL_PATH=${{ runner.temp }}/semver" >> "$GITHUB_ENV"
+          echo "CHANGELOG_PATH=${{ runner.temp }}/CHANGELOG.md" >>"$GITHUB_ENV"
+          echo "SEMVER_TOOL_PATH=${{ runner.temp }}/semver" >>"$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -65,7 +65,7 @@ jobs:
             )" != \
             "" \
           ]]; then
-            echo "IS_PRE=true" >> $GITHUB_OUTPUT
+            echo "IS_PRE=true" >>$GITHUB_OUTPUT
           fi
 
       - name: Create Github release

--- a/workflow-templates/spell-check-task.yml
+++ b/workflow-templates/spell-check-task.yml
@@ -35,7 +35,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   spellcheck:
     needs: run-determination

--- a/workflow-templates/sync-labels-npm.yml
+++ b/workflow-templates/sync-labels-npm.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
+          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >>"$GITHUB_ENV"
 
       - name: Determine whether to dry run
         id: dry-run
@@ -116,7 +116,7 @@ jobs:
         run: |
           # Use of this flag in the github-label-sync command will cause it to only check the validity of the
           # configuration.
-          echo "flag=--dry-run" >> $GITHUB_OUTPUT
+          echo "flag=--dry-run" >>$GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -142,7 +142,7 @@ jobs:
         run: |
           # Merge all configuration files
           shopt -s extglob
-          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) > "${{ env.MERGED_CONFIGURATION_PATH }}"
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) >"${{ env.MERGED_CONFIGURATION_PATH }}"
 
       - name: Install github-label-sync
         run: npm install

--- a/workflow-templates/sync-labels.yml
+++ b/workflow-templates/sync-labels.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set environment variables
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
-          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
+          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >>"$GITHUB_ENV"
 
       - name: Determine whether to dry run
         id: dry-run
@@ -106,7 +106,7 @@ jobs:
         run: |
           # Use of this flag in the github-label-sync command will cause it to only check the validity of the
           # configuration.
-          echo "flag=--dry-run" >> $GITHUB_OUTPUT
+          echo "flag=--dry-run" >>$GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -127,7 +127,7 @@ jobs:
         run: |
           # Merge all configuration files
           shopt -s extglob
-          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) > "${{ env.MERGED_CONFIGURATION_PATH }}"
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) >"${{ env.MERGED_CONFIGURATION_PATH }}"
 
       - name: Install github-label-sync
         run: sudo npm install --global github-label-sync

--- a/workflow-templates/test-go-integration-task.yml
+++ b/workflow-templates/test-go-integration-task.yml
@@ -53,7 +53,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   test:
     needs: run-determination

--- a/workflow-templates/test-go-task.yml
+++ b/workflow-templates/test-go-task.yml
@@ -55,7 +55,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   test:
     name: test (${{ matrix.module.path }} - ${{ matrix.operating-system }})

--- a/workflow-templates/test-python-poetry-task.yml
+++ b/workflow-templates/test-python-poetry-task.yml
@@ -49,7 +49,7 @@ jobs:
             RESULT="false"
           fi
 
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "result=$RESULT" >>$GITHUB_OUTPUT
 
   test:
     needs: run-determination


### PR DESCRIPTION
Shell scripts in Arduino tooling projects are formatted according to the style implemented by the shfmt formatting tool.

In addition to standalone script files, significant quantities of complex shell code is also found in the asset tasks and workflows. shfmt can not be used to format this code (both due to the fact it is in the form of strings in YAML documents, and due to the fact that it is actually templates of shell code (making use of the templating features of Task and GitHub Actions) rather than complete shell code). However, it still makes sense to align the formatting of this code with the standardized shell code style where doing so is feasible.