### PR TITLE
Only install Python package dependencies from relevant group

### DIFF
--- a/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -79,8 +79,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          task \
-            poetry:install-deps
+          task poetry:install-deps \
+            POETRY_GROUPS=dev
 
       - name: Determine versioning parameters
         id: determine-versioning

--- a/workflow-templates/deploy-mkdocs-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-poetry.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          task \
-            poetry:install-deps
+          task poetry:install-deps \
+            POETRY_GROUPS=dev
 
       - name: Deploy website
         run: |

--- a/workflow-templates/deploy-mkdocs-versioned-poetry.yml
+++ b/workflow-templates/deploy-mkdocs-versioned-poetry.yml
@@ -67,8 +67,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          task \
-            poetry:install-deps
+          task poetry:install-deps \
+            POETRY_GROUPS=dev
 
       - name: Determine versioning parameters
         id: determine-versioning


### PR DESCRIPTION
The "Poetry" tool is used to manage the Python package dependencies of the website deployment workflows.

Dependencies might be classified into distinct categories. The most basic classification would be:

- Application dependencies: used by the project's applications
- Development dependencies: tools used in the development and maintenance of the project, but not by the application

By default, Poetry installs all non-optional dependencies. This can be inefficient in a case where a specific operation is being performed, since a given operation might only require the dependencies from one category and so the installation of dependencies from the other is pointless for that operation.

For this reason, Poetry allows the user to organize dependencies into arbitrary "groups", and to specify which groups should be installed.

The calls to the Python package installation task in the workflows is hereby updated specify the `dev` group of the required dependencies.