### PR TITLE
Add source comments to asset task variables

### DIFF
--- a/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
+++ b/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
@@ -1,6 +1,7 @@
 version: "3"
 
 vars:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/deploy-cobra-mkdocs-versioned-poetry/Taskfile.yml
   PROJECT_NAME: TODO
 
 tasks:

--- a/workflow-templates/assets/test-go-task/Taskfile.yml
+++ b/workflow-templates/assets/test-go-task/Taskfile.yml
@@ -2,6 +2,7 @@
 version: "3"
 
 vars:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
   # `-ldflags` flag to use for `go test` command
   # TODO: define flag if required by the project, or leave empty if not needed.
   TEST_LDFLAGS:


### PR DESCRIPTION
This will facilitate the maintenance of the assets by making it easy for the maintainers of downstream projects to find the canonical source of the variables, whether to pull upstream changes, or push changes back upstream.