### PR TITLE
Add comment to workflow re: unexpected behavior of "liskin/gh-problem-matcher-wrap" action

### DIFF
--- a/.github/workflows/check-shell-task.yml
+++ b/.github/workflows/check-shell-task.yml
@@ -125,6 +125,8 @@ jobs:
         continue-on-error: ${{ matrix.configuration.continue-on-error }}
         with:
           linters: gcc
+          # Due to a quirk of the "liskin/gh-problem-matcher-wrap" action, the entire command must be on a single line
+          # (instead of being broken into multiple lines for readability).
           run: task --silent shell:check SCRIPT_PATH="${{ matrix.script }}" SHELLCHECK_FORMAT=${{ matrix.configuration.format }}
 
   formatting:

--- a/workflow-templates/check-shell-task.yml
+++ b/workflow-templates/check-shell-task.yml
@@ -126,6 +126,8 @@ jobs:
         continue-on-error: ${{ matrix.configuration.continue-on-error }}
         with:
           linters: gcc
+          # Due to a quirk of the "liskin/gh-problem-matcher-wrap" action, the entire command must be on a single line
+          # (instead of being broken into multiple lines for readability).
           run: task --silent shell:check SCRIPT_PATH="${{ matrix.script }}" SHELLCHECK_FORMAT=${{ matrix.configuration.format }}
 
   formatting:


### PR DESCRIPTION
The "liskin/gh-problem-matcher-wrap" action is used in the "Check Shell" workflow to enhance the workflow run results summary by applying a "problem matcher" to the output of the shellcheck tool.

This action is a wrapper around shell commands, so we would expect its `run` input to work the same as the `jobs.<job_id>.steps[*].run` key of the GitHub Actions workflow. However, this is not the case. The commands specified via the `jobs.<job_id>.steps[*].run` key can be split into multiple lines using the standard shell line continuation operator. That is useful in the case of long/complex shell commands such as the one used to execute the `shell:check` task in this workflow step. This is not possible when using "liskin/gh-problem-matcher-wrap".

A comment is added to explain this behavior.