### PR TITLE
Remove superfluous `build-system` section from Python project file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,3 @@ optional = true
 
 [tool.poetry.group.pipx.dependencies]
 poetry = "2.1.3"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"

--- a/workflow-templates/assets/poetry/README.md
+++ b/workflow-templates/assets/poetry/README.md
@@ -22,5 +22,7 @@ No configuration is needed.
    ```toml
    package-mode = false
    ```
+1. Add a `build-system` section to the `pyproject.toml` file:<br />
+   https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
 1. Define the package metadata under the `tool.poetry` section of the `pyproject.toml` file:<br />
    https://python-poetry.org/docs/pyproject#the-toolpoetry-section

--- a/workflow-templates/assets/poetry/pyproject.toml
+++ b/workflow-templates/assets/poetry/pyproject.toml
@@ -1,9 +1,5 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry/pyproject.toml
 
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
-
 [tool.poetry]
 package-mode = false
 


### PR DESCRIPTION
The `build-system` section of the `pyproject.toml` Python project file provides information about the build system used by a Python project.

The assets use Python-based tool dependencies, and `pyproject.toml` is used to define those dependencies. This is applicable to projects of any type. For projects which do not have a Python codebase, the `build-system` section is completely irrelevant. So the section should not be included in the assets. It can be added as needed in project that do have a Python codebase.