### PR TITLE
Explicitly define names for build jobs in Go release workflows

### DIFF
--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   create-nightly-artifacts:
+    name: Build ${{ matrix.os.artifact-suffix }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/workflow-templates/release-go-crosscompile-task.yml
+++ b/workflow-templates/release-go-crosscompile-task.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   create-release-artifacts:
+    name: Build ${{ matrix.os.artifact-suffix }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   create-release-artifacts:
+    name: Build ${{ matrix.os.artifact-suffix }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The release workflows for Go-based projects use a matrix job to perform the build for each target host architecture. The matrix data is defined by a mapping.

When a job name is not explicitly defined in the workflow GitHub Actions automatically generates the job name from the job ID and the matrix data. In cases where there is no matrix, or when the matrix data is a simple sequence of strings, that job name is often adequate. However, when the matrix data is more complex, the automatically generated name becomes overly verbose and cryptic (e.g., "create-nightly-artifacts (macOS_ARM64, macOS_ARM64, ubuntu-24.04-arm)"), harming the readability of the logs. In this case, an explicit human-friendly job name should be defined in the workflow.