### PR TITLE
Remove donation links from contributor guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,20 +6,18 @@ Thanks for your interest in contributing to this project!
 
 There are several ways you can get involved:
 
-| Type of contribution                      | Contribution method                                                              |
-| ----------------------------------------- | -------------------------------------------------------------------------------- |
-| - Support<br/>- Question<br/>- Discussion | Post on the [**Arduino Forum**][forum]                                           |
-| - Bug report<br/>- Feature request        | Issue report (see the guide [**here**][issues])                                  |
-| Testing                                   | Beta testing, PR review (see the guide [**here**][beta-testing])                 |
-| - Bug fix<br/>- Enhancement               | Pull request (see the guide [**here**][prs])                                     |
-| Monetary                                  | - [Donate][donate]<br/>- [Sponsor][sponsor]<br/>- [Buy official products][store] |
+| Type of contribution                      | Contribution method                                              |
+| ----------------------------------------- | ---------------------------------------------------------------- |
+| - Support<br/>- Question<br/>- Discussion | Post on the [**Arduino Forum**][forum]                           |
+| - Bug report<br/>- Feature request        | Issue report (see the guide [**here**][issues])                  |
+| Testing                                   | Beta testing, PR review (see the guide [**here**][beta-testing]) |
+| - Bug fix<br/>- Enhancement               | Pull request (see the guide [**here**][prs])                     |
+| Monetary                                  | [Buy official products][store]                                   |
 
 [forum]: https://forum.arduino.cc
 [issues]: contributor-guide/issues.md#issue-report-guide
 [beta-testing]: contributor-guide/beta-testing.md#beta-testing-guide
 [prs]: contributor-guide/pull-requests.md#pull-request-guide
-[donate]: https://www.arduino.cc/en/donate/
-[sponsor]: https://github.com/sponsors/arduino
 [store]: https://store.arduino.cc
 
 ## Resources

--- a/documentation-templates/contributor-guide/general/CONTRIBUTING.md
+++ b/documentation-templates/contributor-guide/general/CONTRIBUTING.md
@@ -6,20 +6,18 @@ Thanks for your interest in contributing to this project!
 
 There are several ways you can get involved:
 
-| Type of contribution                      | Contribution method                                                              |
-| ----------------------------------------- | -------------------------------------------------------------------------------- |
-| - Support<br/>- Question<br/>- Discussion | Post on the [**Arduino Forum**][forum]                                           |
-| - Bug report<br/>- Feature request        | Issue report (see the guide [**here**][issues])                                  |
-| Testing                                   | Beta testing, PR review (see the guide [**here**][beta-testing])                 |
-| - Bug fix<br/>- Enhancement               | Pull request (see the guide [**here**][prs])                                     |
-| Monetary                                  | - [Donate][donate]<br/>- [Sponsor][sponsor]<br/>- [Buy official products][store] |
+| Type of contribution                      | Contribution method                                              |
+| ----------------------------------------- | ---------------------------------------------------------------- |
+| - Support<br/>- Question<br/>- Discussion | Post on the [**Arduino Forum**][forum]                           |
+| - Bug report<br/>- Feature request        | Issue report (see the guide [**here**][issues])                  |
+| Testing                                   | Beta testing, PR review (see the guide [**here**][beta-testing]) |
+| - Bug fix<br/>- Enhancement               | Pull request (see the guide [**here**][prs])                     |
+| Monetary                                  | [Buy official products][store]                                   |
 
 [forum]: https://forum.arduino.cc
 [issues]: contributor-guide/issues.md#issue-report-guide
 [beta-testing]: contributor-guide/beta-testing.md#beta-testing-guide
 [prs]: contributor-guide/pull-requests.md#pull-request-guide
-[donate]: https://www.arduino.cc/en/donate/
-[sponsor]: https://github.com/sponsors/arduino
 [store]: https://store.arduino.cc
 
 ## Resources


### PR DESCRIPTION
The Arduino company is no longer soliciting monetary donations. Community members who wish to contribute to the project still have opportunities to do so via the other options listed here.