### PR TITLE
Update go DistTask.yml to support  golang 1.25.2 and Windows/ARM64 build.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arduino/tooling-project-assets
 
-go 1.25.0
+go 1.25.2
 
 tool (
 	github.com/go-task/task/v3/cmd/task

--- a/other/installation-script/installation.md
+++ b/other/installation-script/installation.md
@@ -41,13 +41,14 @@ in your [`PATH`](https://wikipedia.org/wiki/PATH%5F%28variable%29) or add the TO
 
 ### Latest release
 
-| Platform  |                      |                      |
-| --------- | -------------------- | -------------------- |
-| Linux     | [32 bit][linux32]    | [64 bit][linux64]    |
-| Linux ARM | [32 bit][linuxarm32] | [64 bit][linuxarm64] |
-| Windows   | [32 bit][windows32]  | [64 bit][windows64]  |
-| macOS     |                      | [64 bit][macos64]    |
-| macOS ARM |                      | [64 bit][macosarm64] |
+| Platform    |                      |                        |
+| ----------- | -------------------- | ---------------------- |
+| Linux       | [32 bit][linux32]    | [64 bit][linux64]      |
+| Linux ARM   | [32 bit][linuxarm32] | [64 bit][linuxarm64]   |
+| Windows     | [32 bit][windows32]  | [64 bit][windows64]    |
+| Windows ARM |                      | [64 bit][windowsarm64] |
+| macOS       |                      | [64 bit][macos64]      |
+| macOS ARM   |                      | [64 bit][macosarm64]   |
 
 [linux64]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Linux_64bit.tar.gz
 [linux32]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Linux_32bit.tar.gz
@@ -55,6 +56,7 @@ in your [`PATH`](https://wikipedia.org/wiki/PATH%5F%28variable%29) or add the TO
 [linuxarm32]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Linux_ARMv7.tar.gz
 [windows64]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Windows_64bit.zip
 [windows32]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Windows_32bit.zip
+[windowsarm64]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_Windows_ARM64.zip
 [macos64]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_macOS_64bit.tar.gz
 [macosarm64]: https://downloads.arduino.cc/TODO_REPO_NAME/TODO_REPO_NAME_latest_macOS_ARM64.tar.gz
 
@@ -67,13 +69,14 @@ These are available from the "Assets" sections on the [releases page](https://gi
 These builds are generated every day at 01:00 GMT from the `main` branch and should be considered unstable. In order to
 get the latest nightly build available for the supported platform, use the following links:
 
-| Platform  |                              |                              |
-| --------- | ---------------------------- | ---------------------------- |
-| Linux     | [32 bit][linux32-nightly]    | [64 bit][linux64-nightly]    |
-| Linux ARM | [32 bit][linuxarm32-nightly] | [64 bit][linuxarm64-nightly] |
-| Windows   | [32 bit][windows32-nightly]  | [64 bit][windows64-nightly]  |
-| macOS     |                              | [64 bit][macos64-nightly]    |
-| macOS ARM |                              | [64 bit][macosarm64-nightly] |
+| Platform    |                              |                                |
+| ----------- | ---------------------------- | ------------------------------ |
+| Linux       | [32 bit][linux32-nightly]    | [64 bit][linux64-nightly]      |
+| Linux ARM   | [32 bit][linuxarm32-nightly] | [64 bit][linuxarm64-nightly]   |
+| Windows     | [32 bit][windows32-nightly]  | [64 bit][windows64-nightly]    |
+| Windows ARM |                              | [64 bit][windowsarm64-nightly] |
+| macOS       |                              | [64 bit][macos64-nightly]      |
+| macOS ARM   |                              | [64 bit][macosarm64-nightly]   |
 
 [linux64-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Linux_64bit.tar.gz
 [linux32-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Linux_32bit.tar.gz
@@ -81,6 +84,7 @@ get the latest nightly build available for the supported platform, use the follo
 [linuxarm32-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Linux_ARMv7.tar.gz
 [windows64-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Windows_64bit.zip
 [windows32-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Windows_32bit.zip
+[windowsarm64-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_Windows_ARM64.zip
 [macos64-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_macOS_64bit.tar.gz
 [macosarm64-nightly]: https://downloads.arduino.cc/TODO_REPO_NAME/nightly/TODO_REPO_NAME_nightly-latest_macOS_ARM64.tar.gz
 

--- a/workflow-templates/assets/release-go-task/DistTasks.yml
+++ b/workflow-templates/assets/release-go-task/DistTasks.yml
@@ -28,6 +28,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -35,11 +37,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        zip \
-          {{.PACKAGE_NAME}} \
-          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt \
-          -j
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}} -r
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
@@ -54,6 +52,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -61,11 +61,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        zip \
-          {{.PACKAGE_NAME}} \
-          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt \
-          -j
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}} -r
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_amd64"
@@ -80,6 +76,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -87,11 +85,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        zip \
-          {{.PACKAGE_NAME}} \
-          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt \
-          -j
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}} -r
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_arm64"
@@ -106,6 +100,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -113,13 +109,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
@@ -134,6 +124,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -141,13 +133,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd64"
@@ -162,6 +148,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -169,13 +157,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
@@ -190,6 +172,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -197,13 +181,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
@@ -218,6 +196,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -225,13 +205,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
@@ -246,6 +220,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -253,13 +229,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
@@ -287,6 +257,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -294,13 +266,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"

--- a/workflow-templates/assets/release-go-task/DistTasks.yml
+++ b/workflow-templates/assets/release-go-task/DistTasks.yml
@@ -85,7 +85,7 @@ tasks:
           -w /home/build \
           -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-          --build-cmd "{{.BUILD_COMMAND}}" \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
 
         zip \
@@ -95,7 +95,7 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_arm64"
-      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}"
       BUILD_PLATFORM: "windows/arm64"
       CONTAINER_TAG: "{{.GO_VERSION}}-windows-arm64-debian12"
       PACKAGE_PLATFORM: "Windows_ARM64"
@@ -167,7 +167,7 @@ tasks:
           -w /home/build \
           -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-          --build-cmd "{{.BUILD_COMMAND}}" \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
 
         tar cz \
@@ -179,7 +179,7 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
-      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/armv7"
       CONTAINER_TAG: "{{.GO_VERSION}}-armhf-debian10"
       PACKAGE_PLATFORM: "Linux_ARMv7"
@@ -195,7 +195,7 @@ tasks:
           -w /home/build \
           -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-          --build-cmd "{{.BUILD_COMMAND}}" \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
 
         tar cz \
@@ -207,7 +207,7 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
-      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/armv6"
       CONTAINER_TAG: "{{.GO_VERSION}}-armel-debian12"
       PACKAGE_PLATFORM: "Linux_ARMv6"
@@ -223,7 +223,7 @@ tasks:
           -w /home/build \
           -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-          --build-cmd "{{.BUILD_COMMAND}}" \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
 
         tar cz \
@@ -235,7 +235,7 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
-      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/arm64"
       CONTAINER_TAG: "{{.GO_VERSION}}-base-arm-debian10"
       PACKAGE_PLATFORM: "Linux_ARM64"
@@ -251,7 +251,7 @@ tasks:
           -w /home/build \
           -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-          --build-cmd "{{.BUILD_COMMAND}}" \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
 
         tar cz \
@@ -263,7 +263,7 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
-      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "darwin/amd64"
       # We are experiencing the following error with macOS_64bit build:
       #
@@ -292,7 +292,7 @@ tasks:
           -w /home/build \
           -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-          --build-cmd "{{.BUILD_COMMAND}}" \
+          --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
 
         tar cz \
@@ -304,7 +304,7 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"
-      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "darwin/arm64"
       CONTAINER_TAG: "{{.GO_VERSION}}-darwin-arm64-debian10"
       PACKAGE_PLATFORM: "macOS_ARM64"

--- a/workflow-templates/assets/release-go-task/DistTasks.yml
+++ b/workflow-templates/assets/release-go-task/DistTasks.yml
@@ -74,6 +74,32 @@ tasks:
       PACKAGE_PLATFORM: "Windows_64bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
 
+  Windows_ARM64:
+    desc: Builds Windows ARM64 binaries
+    dir: "{{.DIST_DIR}}"
+    cmds:
+      - |
+        docker run \
+          -v `pwd`/..:/home/build \
+          -w /home/build \
+          -e CGO_ENABLED=1 \
+          {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+          --build-cmd "{{.BUILD_COMMAND}}" \
+          -p "{{.BUILD_PLATFORM}}"
+
+        zip \
+          {{.PACKAGE_NAME}} \
+          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt \
+          -j
+
+    vars:
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_arm64"
+      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}"
+      BUILD_PLATFORM: "windows/arm64"
+      CONTAINER_TAG: "{{.GO_VERSION}}-windows-arm64-debian12"
+      PACKAGE_PLATFORM: "Windows_ARM64"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
+
   Linux_32bit:
     desc: Builds Linux 32 bit binaries
     dir: "{{.DIST_DIR}}"

--- a/workflow-templates/assets/release-go-task/DistTasks.yml
+++ b/workflow-templates/assets/release-go-task/DistTasks.yml
@@ -20,6 +20,7 @@ version: "3"
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
   GO_VERSION: "1.25.2"
+  CGO_ENABLED: "1"
 
 tasks:
   Windows_32bit:
@@ -30,7 +31,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
@@ -56,7 +57,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
@@ -82,7 +83,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
@@ -108,7 +109,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
@@ -136,7 +137,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
@@ -164,7 +165,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
@@ -192,7 +193,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
@@ -220,7 +221,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
@@ -248,7 +249,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
@@ -289,7 +290,7 @@ tasks:
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
-          -e CGO_ENABLED=1 \
+          -e CGO_ENABLED={{.CGO_ENABLED}} \
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"

--- a/workflow-templates/assets/release-go-task/DistTasks.yml
+++ b/workflow-templates/assets/release-go-task/DistTasks.yml
@@ -19,7 +19,7 @@ version: "3"
 
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
-  GO_VERSION: "1.17.8"
+  GO_VERSION: "1.25.2"
 
 tasks:
   Windows_32bit:
@@ -152,9 +152,9 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
-      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/armv7"
-      CONTAINER_TAG: "{{.GO_VERSION}}-armhf"
+      CONTAINER_TAG: "{{.GO_VERSION}}-armhf-debian10"
       PACKAGE_PLATFORM: "Linux_ARMv7"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
@@ -180,37 +180,9 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
-      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/armv6"
-      # We are experiencing the following error with ARMv6 build:
-      #
-      #   # github.com/arduino/arduino-cli
-      #   net(.text): unexpected relocation type 296 (R_ARM_V4BX)
-      #   panic: runtime error: invalid memory address or nil pointer dereference
-      #   [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x51ae53]
-      #
-      #   goroutine 1 [running]:
-      #   cmd/link/internal/loader.(*Loader).SymName(0xc000095c00, 0x0, 0xc0000958d8, 0x5a0ac)
-      #           /usr/local/go/src/cmd/link/internal/loader/loader.go:684 +0x53
-      #   cmd/link/internal/ld.dynrelocsym2(0xc000095880, 0x5a0ac)
-      #           /usr/local/go/src/cmd/link/internal/ld/data.go:777 +0x295
-      #   cmd/link/internal/ld.(*dodataState).dynreloc2(0xc007df9800, 0xc000095880)
-      #           /usr/local/go/src/cmd/link/internal/ld/data.go:794 +0x89
-      #   cmd/link/internal/ld.(*Link).dodata2(0xc000095880, 0xc007d00000, 0x60518, 0x60518)
-      #           /usr/local/go/src/cmd/link/internal/ld/data.go:1434 +0x4d4
-      #   cmd/link/internal/ld.Main(0x8729a0, 0x4, 0x8, 0x1, 0xd, 0xe, 0x0, 0x0, 0x6d7737, 0x12, ...)
-      #           /usr/local/go/src/cmd/link/internal/ld/main.go:302 +0x123a
-      #   main.main()
-      #           /usr/local/go/src/cmd/link/main.go:68 +0x1dc
-      #   Error: failed building for linux/armv6: exit status 2
-      #
-      # This seems to be a problem in the go builder 1.16.x that removed support for the R_ARM_V4BX instruction:
-      #    https://github.com/golang/go/pull/44998
-      #    https://groups.google.com/g/golang-codereviews/c/yzN80xxwu2E
-      #
-      # Until there is a fix released we must use a recent gcc for Linux_ARMv6 build, so for this
-      # build we select the debian10 based container.
-      CONTAINER_TAG: "{{.GO_VERSION}}-armel-debian10"
+      CONTAINER_TAG: "{{.GO_VERSION}}-armel-debian12"
       PACKAGE_PLATFORM: "Linux_ARMv6"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
@@ -236,9 +208,9 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
-      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "linux/arm64"
-      CONTAINER_TAG: "{{.GO_VERSION}}-arm"
+      CONTAINER_TAG: "{{.GO_VERSION}}-base-arm-debian10"
       PACKAGE_PLATFORM: "Linux_ARM64"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
@@ -264,7 +236,7 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
-      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "darwin/amd64"
       # We are experiencing the following error with macOS_64bit build:
       #
@@ -305,7 +277,7 @@ tasks:
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"
-      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_COMMAND: "go build -buildvcs=false -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
       BUILD_PLATFORM: "darwin/arm64"
       CONTAINER_TAG: "{{.GO_VERSION}}-darwin-arm64-debian10"
       PACKAGE_PLATFORM: "macOS_ARM64"

--- a/workflow-templates/assets/release-go-task/DistTasks.yml
+++ b/workflow-templates/assets/release-go-task/DistTasks.yml
@@ -19,7 +19,8 @@ version: "3"
 
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
-  GO_VERSION: "1.25.2"
+  GO_VERSION:
+    sh: go list -m -f '{{"{{.GoVersion}}"}}'
   CGO_ENABLED: "1"
 
 tasks:
@@ -195,10 +196,13 @@ tasks:
     desc: Builds Linux ARM64 binaries
     dir: "{{.DIST_DIR}}"
     cmds:
+      # We need to use the --platform linux/arm64 option to build the ARM64 binaries on an AMD64 host.
+      # See https://github.com/elastic/golang-crossbuild/issues/731
       - |
         mkdir -p {{.PLATFORM_DIR}}
         cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
+          --platform linux/arm64 \
           -v `pwd`/..:/home/build \
           -w /home/build \
           -e CGO_ENABLED={{.CGO_ENABLED}} \
@@ -256,10 +260,13 @@ tasks:
     desc: Builds Mac OS X ARM64 binaries
     dir: "{{.DIST_DIR}}"
     cmds:
+      # We need to use the --platform linux/arm64 option to build the ARM64 binaries on an AMD64 host.
+      # See https://github.com/elastic/golang-crossbuild/issues/731
       - |
         mkdir -p {{.PLATFORM_DIR}}
         cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
+          --platform linux/arm64 \
           -v `pwd`/..:/home/build \
           -w /home/build \
           -e CGO_ENABLED={{.CGO_ENABLED}} \

--- a/workflow-templates/publish-go-nightly-task.yml
+++ b/workflow-templates/publish-go-nightly-task.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   create-nightly-artifacts:
     name: Build ${{ matrix.os.artifact-suffix }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
     permissions:
       contents: read
 
@@ -31,22 +31,34 @@ jobs:
         os:
           - task: Windows_32bit
             artifact-suffix: Windows_32bit
+            runner: ubuntu-latest
           - task: Windows_64bit
             artifact-suffix: Windows_64bit
+            runner: ubuntu-latest
+          - task: Windows_ARM64
+            artifact-suffix: Windows_ARM64
+            runner: ubuntu-24.04-arm
           - task: Linux_32bit
             artifact-suffix: Linux_32bit
+            runner: ubuntu-latest
           - task: Linux_64bit
             artifact-suffix: Linux_64bit
+            runner: ubuntu-latest
           - task: Linux_ARMv6
             artifact-suffix: Linux_ARMv6
+            runner: ubuntu-latest
           - task: Linux_ARMv7
             artifact-suffix: Linux_ARMv7
+            runner: ubuntu-latest
           - task: Linux_ARM64
             artifact-suffix: Linux_ARM64
+            runner: ubuntu-24.04-arm
           - task: macOS_64bit
             artifact-suffix: macOS_64bit
+            runner: ubuntu-latest
           - task: macOS_ARM64
             artifact-suffix: macOS_ARM64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -93,6 +93,10 @@ jobs:
             path: "*Windows_64bit.zip"
             artifact-name: Windows_X86-64
             runner: ubuntu-latest
+          - task: Windows_ARM64
+            path: "*Windows_ARM64.zip"
+            artifact-name: Windows_ARM64
+            runner: ubuntu-24.04-arm
           - task: Linux_32bit
             path: "*Linux_32bit.tar.gz"
             artifact-name: Linux_X86-32

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -78,7 +78,7 @@ jobs:
   build:
     needs: package-name-prefix
     name: Build ${{ matrix.os.artifact-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
     permissions:
       contents: read
 
@@ -88,30 +88,39 @@ jobs:
           - task: Windows_32bit
             path: "*Windows_32bit.zip"
             artifact-name: Windows_X86-32
+            runner: ubuntu-latest
           - task: Windows_64bit
             path: "*Windows_64bit.zip"
             artifact-name: Windows_X86-64
+            runner: ubuntu-latest
           - task: Linux_32bit
             path: "*Linux_32bit.tar.gz"
             artifact-name: Linux_X86-32
+            runner: ubuntu-latest
           - task: Linux_64bit
             path: "*Linux_64bit.tar.gz"
             artifact-name: Linux_X86-64
+            runner: ubuntu-latest
           - task: Linux_ARMv6
             path: "*Linux_ARMv6.tar.gz"
             artifact-name: Linux_ARMv6
+            runner: ubuntu-latest
           - task: Linux_ARMv7
             path: "*Linux_ARMv7.tar.gz"
             artifact-name: Linux_ARMv7
+            runner: ubuntu-latest
           - task: Linux_ARM64
             path: "*Linux_ARM64.tar.gz"
             artifact-name: Linux_ARM64
+            runner: ubuntu-24.04-arm
           - task: macOS_64bit
             path: "*macOS_64bit.tar.gz"
             artifact-name: macOS_64
+            runner: ubuntu-latest
           - task: macOS_ARM64
             path: "*macOS_ARM64.tar.gz"
             artifact-name: macOS_ARM64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository

--- a/workflow-templates/publish-go-tester-task.yml
+++ b/workflow-templates/publish-go-tester-task.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Determine if the rest of the workflow should run
         id: determination
         run: |
-          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          RELEASE_BRANCH_REGEX="refs/heads/v?[0-9]+.[0-9]+.x"
           TAG_REGEX="refs/tags/.*"
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   create-release-artifacts:
     name: Build ${{ matrix.os.artifact-suffix }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
     permissions:
       contents: read
 
@@ -28,24 +28,34 @@ jobs:
         os:
           - task: Windows_32bit
             artifact-suffix: Windows_32bit
+            runner: ubuntu-latest
           - task: Windows_64bit
             artifact-suffix: Windows_64bit
+            runner: ubuntu-latest
           - task: Windows_ARM64
             artifact-suffix: Windows_ARM64
+            runner: ubuntu-24.04-arm
           - task: Linux_32bit
             artifact-suffix: Linux_32bit
+            runner: ubuntu-latest
           - task: Linux_64bit
             artifact-suffix: Linux_64bit
+            runner: ubuntu-latest
           - task: Linux_ARMv6
             artifact-suffix: Linux_ARMv6
+            runner: ubuntu-latest
           - task: Linux_ARMv7
             artifact-suffix: Linux_ARMv7
+            runner: ubuntu-latest
           - task: Linux_ARM64
             artifact-suffix: Linux_ARM64
+            runner: ubuntu-24.04-arm
           - task: macOS_64bit
             artifact-suffix: macOS_64bit
+            runner: ubuntu-latest
           - task: macOS_ARM64
             artifact-suffix: macOS_ARM64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository
@@ -67,9 +77,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Build
         run: |

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -68,6 +68,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Build
         run: |
           go tool \

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -14,7 +14,7 @@ env:
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+      - "v?[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   create-release-artifacts:
@@ -68,7 +68,7 @@ jobs:
         if: matrix.os.task == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
-          tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
+          tag-regex: '^v?[0-9]+\.[0-9]+\.[0-9]+.*$'
           filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
           case-insensitive-regex: true
           changelog-file-path: "${{ env.DIST_DIR }}/CHANGELOG.md"

--- a/workflow-templates/release-go-task.yml
+++ b/workflow-templates/release-go-task.yml
@@ -30,6 +30,8 @@ jobs:
             artifact-suffix: Windows_32bit
           - task: Windows_64bit
             artifact-suffix: Windows_64bit
+          - task: Windows_ARM64
+            artifact-suffix: Windows_ARM64
           - task: Linux_32bit
             artifact-suffix: Linux_32bit
           - task: Linux_64bit


### PR DESCRIPTION
The newer Docker-ized cross-compilers require QEMU on the CI runner, so I added the corresponding installation step to the build workflow.

For reference, see: https://github.com/arduino/serial-discovery/pull/93 and https://github.com/arduino/mdns-discovery/pull/81