### PR TITLE
Remove golint installation and replace with go vet for style checking

### DIFF
--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -114,17 +114,9 @@ jobs:
         with:
           go-version-file: ${{ matrix.module.path }}/go.mod
 
-      - name: Install golint
-        run: go install golang.org/x/lint/golint@latest
-
       - name: Check style
-        env:
-          GO_MODULE_PATH: ${{ matrix.module.path }}
         run: |
-          go tool \
-            github.com/go-task/task/v3/cmd/task  \
-              --silent \
-              go:lint
+          go vet ${{ matrix.module.path }}
 
   check-formatting:
     name: check-formatting (${{ matrix.module.path }})


### PR DESCRIPTION
Looking at at https://github.com/golang/lint

NOTE: Golint is https://github.com/golang/go/issues/38968. There's no drop-in replacement for it, but tools such as [Staticcheck](https://staticcheck.io/) and go vet should be used instead.

