### PR TITLE
Fixed golangci-lint install url

### DIFF
--- a/workflow-templates/check-go-task.yml
+++ b/workflow-templates/check-go-task.yml
@@ -114,8 +114,8 @@ jobs:
         with:
           go-version-file: ${{ matrix.module.path }}/go.mod
 
-      - name: Install golint
-        run: go install golang.org/x/lint/golint@latest
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
       - name: Check style
         env:


### PR DESCRIPTION
In the check-go-task workflow, the linting job will try to install the now-obsolete golint instead of golangci-lint; this PR fixes this problem.
The [associated TaskFile task](https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml#L44) has already been updated with a call to golangci-lint.