### PR TITLE
Adjust link check configuration to avoid spurious failures

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -25,6 +25,9 @@
       "pattern": "^development\\.md#development-guide$"
     },
     {
+      "pattern": "^https://www\\.npmjs\\.com/"
+    },
+    {
       "pattern": "^issues\\.md#issue-report-guide$"
     },
     {

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -10,7 +10,7 @@
   "retryOn429": true,
   "timeout": "30s",
   "retryCount": 3,
-  "aliveStatusCodes": [200, 206],
+  "aliveStatusCodes": [200, 206, 429],
   "ignorePatterns": [
     {
       "pattern": "^../development\\.md#development-guide$"

--- a/workflow-templates/assets/check-markdown/.markdown-link-check.json
+++ b/workflow-templates/assets/check-markdown/.markdown-link-check.json
@@ -7,6 +7,11 @@
       }
     }
   ],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://www\\.npmjs\\.com/"
+    }
+  ],
   "retryOn429": true,
   "timeout": "30s",
   "retryCount": 3,


### PR DESCRIPTION
The "Check Markdown" assets provide link validation using the [**markdown-link-check**](https://github.com/tcort/markdown-link-check) tool.

Previously, various valid links were causing spurious failures from the link check. Spurious failures are problematic, both because they will result in a poor experience for contributors, and because they may cause the project maintainers to disregard failed checks, and thus possibly miss true positive detections.

The spurious failures are avoided by [configuring the link check tool](https://github.com/tcort/markdown-link-check#config-file-format) to ignore the problematic links.
