### PR TITLE
Install referenced schemas in "Check npm" workflow

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -954,6 +954,20 @@ tasks:
           go tool \
             github.com/go-task/task/v3/cmd/task utility:mktemp-file \
               TEMPLATE="jscpd-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/madge.json
+      MADGE_SCHEMA_URL: https://json.schemastore.org/madge.json
+      MADGE_SCHEMA_PATH:
+        sh: |
+          go tool \
+            task utility:mktemp-file \
+              TEMPLATE="madge-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/nodemon.json
+      NODEMON_SCHEMA_URL: https://json.schemastore.org/nodemon.json
+      NODEMON_SCHEMA_PATH:
+        sh: |
+          go tool \
+            task utility:mktemp-file \
+              TEMPLATE="nodemon-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/npm-badges.json
       NPM_BADGES_SCHEMA_URL: https://json.schemastore.org/npm-badges.json
       NPM_BADGES_SCHEMA_PATH:
@@ -975,6 +989,13 @@ tasks:
           go tool \
             github.com/go-task/task/v3/cmd/task utility:mktemp-file \
               TEMPLATE="prettierrc-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/quikrun.json
+      QUIKRUN_SCHEMA_URL: https://json.schemastore.org/quikrun.json
+      QUIKRUN_SCHEMA_PATH:
+        sh: |
+          go tool \
+            task utility:mktemp-file \
+              TEMPLATE="quikrun-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_URL: https://json.schemastore.org/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_PATH:
@@ -997,9 +1018,12 @@ tasks:
       - wget --quiet --output-document="{{.BASE_SCHEMA_PATH}}" {{.BASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.ESLINTRC_SCHEMA_PATH}}" {{.ESLINTRC_SCHEMA_URL}}
       - wget --quiet --output-document="{{.JSCPD_SCHEMA_PATH}}" {{.JSCPD_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.MADGE_SCHEMA_PATH}}" {{.MADGE_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.NODEMON_SCHEMA_PATH}}" {{.NODEMON_SCHEMA_URL}}
       - wget --quiet --output-document="{{.NPM_BADGES_SCHEMA_PATH}}" {{.NPM_BADGES_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PARTIAL_ESLINT_PLUGINS_PATH}}" {{.PARTIAL_ESLINT_PLUGINS_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PRETTIERRC_SCHEMA_PATH}}" {{.PRETTIERRC_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.QUIKRUN_SCHEMA_PATH}}" {{.QUIKRUN_SCHEMA_URL}}
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
@@ -1014,9 +1038,12 @@ tasks:
             -r "{{.BASE_SCHEMA_PATH}}" \
             -r "{{.ESLINTRC_SCHEMA_PATH}}" \
             -r "{{.JSCPD_SCHEMA_PATH}}" \
+            -r "{{.MADGE_SCHEMA_PATH}}" \
+            -r "{{.NODEMON_SCHEMA_PATH}}" \
             -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
             -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
             -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
+            -r "{{.QUIKRUN_SCHEMA_PATH}}" \
             -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
             -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
             -d "{{.INSTANCE_PATH}}"

--- a/workflow-templates/assets/check-npm-task/Taskfile.yml
+++ b/workflow-templates/assets/check-npm-task/Taskfile.yml
@@ -59,6 +59,20 @@ tasks:
           go tool \
             github.com/go-task/task/v3/cmd/task utility:mktemp-file \
               TEMPLATE="jscpd-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/madge.json
+      MADGE_SCHEMA_URL: https://json.schemastore.org/madge.json
+      MADGE_SCHEMA_PATH:
+        sh: |
+          go tool \
+            task utility:mktemp-file \
+              TEMPLATE="madge-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/nodemon.json
+      NODEMON_SCHEMA_URL: https://json.schemastore.org/nodemon.json
+      NODEMON_SCHEMA_PATH:
+        sh: |
+          go tool \
+            task utility:mktemp-file \
+              TEMPLATE="nodemon-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/npm-badges.json
       NPM_BADGES_SCHEMA_URL: https://json.schemastore.org/npm-badges.json
       NPM_BADGES_SCHEMA_PATH:
@@ -80,6 +94,13 @@ tasks:
           go tool \
             github.com/go-task/task/v3/cmd/task utility:mktemp-file \
               TEMPLATE="prettierrc-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/quikrun.json
+      QUIKRUN_SCHEMA_URL: https://json.schemastore.org/quikrun.json
+      QUIKRUN_SCHEMA_PATH:
+        sh: |
+          go tool \
+            task utility:mktemp-file \
+              TEMPLATE="quikrun-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_URL: https://json.schemastore.org/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_PATH:
@@ -102,9 +123,12 @@ tasks:
       - wget --quiet --output-document="{{.BASE_SCHEMA_PATH}}" {{.BASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.ESLINTRC_SCHEMA_PATH}}" {{.ESLINTRC_SCHEMA_URL}}
       - wget --quiet --output-document="{{.JSCPD_SCHEMA_PATH}}" {{.JSCPD_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.MADGE_SCHEMA_PATH}}" {{.MADGE_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.NODEMON_SCHEMA_PATH}}" {{.NODEMON_SCHEMA_URL}}
       - wget --quiet --output-document="{{.NPM_BADGES_SCHEMA_PATH}}" {{.NPM_BADGES_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PARTIAL_ESLINT_PLUGINS_PATH}}" {{.PARTIAL_ESLINT_PLUGINS_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PRETTIERRC_SCHEMA_PATH}}" {{.PRETTIERRC_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.QUIKRUN_SCHEMA_PATH}}" {{.QUIKRUN_SCHEMA_URL}}
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
@@ -119,9 +143,12 @@ tasks:
             -r "{{.BASE_SCHEMA_PATH}}" \
             -r "{{.ESLINTRC_SCHEMA_PATH}}" \
             -r "{{.JSCPD_SCHEMA_PATH}}" \
+            -r "{{.MADGE_SCHEMA_PATH}}" \
+            -r "{{.NODEMON_SCHEMA_PATH}}" \
             -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
             -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
             -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
+            -r "{{.QUIKRUN_SCHEMA_PATH}}" \
             -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
             -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
             -d "{{.INSTANCE_PATH}}"


### PR DESCRIPTION
The "Check npm" GitHub Actions workflow validates the repository's `package.json` npm manifest file against its JSON schema to catch any problems with its data format.

In order to avoid duplication of content, JSON schemas may reference other schemas via the `$ref` keyword. The `package.json` schema was recently updated to share resources with additional configuration schemas, which caused the validation to start failing.

The solution is to configure the workflow to download the missing schemas, and to pass their paths to the avj-cli validator via an `-r` flag.