### PR TITLE
Bump `poetry` to 2.4.1 in asset Python project file

### DIFF
--- a/workflow-templates/assets/poetry/pyproject.toml
+++ b/workflow-templates/assets/poetry/pyproject.toml
@@ -9,7 +9,7 @@ package-mode = false
 optional = true
 
 [tool.poetry.group.pipx.dependencies]
-poetry = "2.2.1"
+poetry = "2.4.1"
 
 [tool.poetry.dependencies]
 python = "~3.14"


### PR DESCRIPTION
This is now the standard version of Poetry for use with the assets.